### PR TITLE
Slice 004: Configuration system

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,6 +10,9 @@ dependencies = [
     "uvicorn[standard]>=0.32.0",
     "pydantic>=2.9.0",
     "structlog>=24.4.0",
+    "pydantic-settings>=2.15.0",
+    "pyyaml>=6.0.3",
+    "tzdata>=2026.3",
 ]
 
 [project.scripts]
@@ -30,6 +33,7 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
     "httpx>=0.27.0",
+    "types-pyyaml>=6.0.12.20260815",
 ]
 
 [tool.ruff]

--- a/backend/src/flightsite/api/internal.py
+++ b/backend/src/flightsite/api/internal.py
@@ -1,0 +1,95 @@
+"""Unsupported internal API: ``/api/internal``.
+
+Mutations the FlightSite frontend needs. Unversioned, undocumented, and
+excluded from the OpenAPI schema published for ``/api/v1`` — the router is
+mounted with ``include_in_schema=False`` in
+:func:`flightsite.app.create_app`, which keeps the exclusion a single
+app-level decision rather than a per-endpoint flag (ADR-0007, docs/API.md §5).
+
+This slice owns configuration mutation. The setup wizard (slice 018) and the
+Settings UI (slice 019) consume these endpoints rather than touching
+``config.yaml`` themselves, so validation and atomic write-back have exactly
+one implementation.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+import structlog
+from fastapi import APIRouter, Body, HTTPException, Request, status
+from pydantic import ValidationError
+
+from flightsite.config import ConfigError, ConfigStore, Settings
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+
+def _config_response(store: ConfigStore, settings: Settings) -> dict[str, Any]:
+    """Build the config payload.
+
+    ``config`` is the full effective configuration with secrets masked;
+    ``secrets_set`` reports, per secret, whether a value is stored, so the
+    Settings UI can render "configured / not configured" without ever
+    receiving the value (SPEC §29).
+    """
+    return {
+        "first_run": store.first_run,
+        "config": settings.dump_public(),
+        "secrets_set": settings.secrets_state(),
+    }
+
+
+def _safe_errors(exc: ValidationError) -> list[dict[str, Any]]:
+    """Render validation errors without echoing the rejected input.
+
+    Pydantic includes the offending value in ``input``; for a secret field
+    that would hand the value straight back to the client (and into any
+    request log). Only the location, message and error type are returned —
+    which is what makes the message helpful anyway.
+    """
+    return [
+        {"loc": list(error["loc"]), "msg": error["msg"], "type": error["type"]}
+        for error in exc.errors(include_url=False)
+    ]
+
+
+@router.get("/config")
+async def get_config(request: Request) -> dict[str, Any]:
+    """Return the effective configuration with secrets masked, plus first-run state."""
+    store: ConfigStore = request.app.state.config_store
+    settings: Settings = request.app.state.settings
+    return _config_response(store, settings)
+
+
+@router.put("/config")
+async def put_config(
+    request: Request,
+    patch: Annotated[dict[str, Any], Body()],
+) -> dict[str, Any]:
+    """Apply a partial or full configuration update.
+
+    The payload is the same document shape ``GET`` returns. It is validated
+    against the settings model, written atomically (non-secret fields to
+    ``config.yaml``, secret fields to ``secrets.yaml``), and applied to the
+    running app. A secret sent back as its mask is left unchanged; an explicit
+    ``null`` clears it.
+
+    Nothing is written when validation fails, so a rejected update leaves both
+    files and the running settings untouched.
+    """
+    store: ConfigStore = request.app.state.config_store
+    try:
+        settings = store.apply_update(patch)
+    except ConfigError as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    except ValidationError as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=_safe_errors(exc)) from exc
+
+    request.app.state.settings = settings
+    # Log the changed key paths only — never the values, which may include a
+    # secret the caller just set (SPEC §29).
+    logger.info("config_updated", fields=sorted(patch))
+    return _config_response(store, settings)

--- a/backend/src/flightsite/app.py
+++ b/backend/src/flightsite/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -10,7 +11,9 @@ import structlog
 from fastapi import FastAPI
 
 from flightsite import __version__
+from flightsite.api.internal import router as internal_router
 from flightsite.api.v1 import router as v1_router
+from flightsite.config import ConfigStore
 from flightsite.logging import configure_logging
 from flightsite.readiness import ReadinessRegistry
 
@@ -28,20 +31,41 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         logger.info("app_shutdown")
 
 
-def create_app() -> FastAPI:
+def create_app(data_dir: str | os.PathLike[str] | None = None) -> FastAPI:
     """Build and configure the FlightSite FastAPI application.
 
-    Configures structured logging, initializes the readiness registry and
-    uptime clock, and mounts the versioned ``/api/v1`` router. With no
-    subsystems registered against the readiness registry, the app becomes
-    ready as soon as the lifespan startup hook runs.
+    Loads configuration once (``config.yaml`` / ``secrets.yaml`` /
+    ``FLIGHTSITE_*``) and stores the resulting :class:`~flightsite.config.Settings`
+    plus its :class:`~flightsite.config.ConfigStore` on ``app.state``;
+    ``PUT /api/internal/config`` replaces ``app.state.settings`` in place, so
+    request handlers must read it from state rather than caching it at import
+    time. Then configures structured logging, initializes the readiness
+    registry and uptime clock, and mounts the routers. With no subsystems
+    registered against the readiness registry, the app becomes ready as soon
+    as the lifespan startup hook runs.
+
+    Args:
+        data_dir: overrides data-directory resolution (``FLIGHTSITE_DATA_DIR``,
+            then ``/opt/flightsite/data``). Used by tests.
     """
-    configure_logging()
+    store = ConfigStore(data_dir)
+    settings = store.load()
+
+    # settings.log_level already reflects FLIGHTSITE_LOG_LEVEL when set — the
+    # environment outranks config.yaml inside the settings model — so passing
+    # it here keeps the env override winning (SPEC §30).
+    configure_logging(level=settings.log_level)
 
     app = FastAPI(title="FlightSite", version=__version__, lifespan=_lifespan)
+    app.state.config_store = store
+    app.state.settings = settings
     app.state.readiness = ReadinessRegistry()
     app.state.start_time = time.monotonic()
 
     app.include_router(v1_router, prefix="/api/v1")
+    # /api/internal is an unsupported, unversioned surface (ADR-0007) and is
+    # kept out of the OpenAPI schema published for /api/v1. One flag here
+    # covers every internal endpoint, now and in later slices.
+    app.include_router(internal_router, prefix="/api/internal", include_in_schema=False)
 
     return app

--- a/backend/src/flightsite/config/__init__.py
+++ b/backend/src/flightsite/config/__init__.py
@@ -1,0 +1,71 @@
+"""FlightSite configuration: settings model, file layering, and write-back.
+
+Public entry points:
+
+* :class:`Settings` — the validated configuration model.
+* :class:`ConfigStore` — reads/writes ``config.yaml`` and ``secrets.yaml`` in
+  the resolved data directory, and reports first-run state.
+* :func:`load_settings` — one-shot load used by the app factory.
+"""
+
+from __future__ import annotations
+
+from flightsite.config.loader import (
+    ConfigError,
+    ConfigStore,
+    atomic_write_text,
+    check_unknown_keys,
+    deep_merge,
+    load_settings,
+    strip_masked_secrets,
+)
+from flightsite.config.models import (
+    SECRET_MASK,
+    AlertSettings,
+    EnrichmentSettings,
+    LocationSettings,
+    MapSettings,
+    NotificationSettings,
+    ReceiverSettings,
+    RetentionSettings,
+    Settings,
+    SightingTimingSettings,
+    secret_field_paths,
+)
+from flightsite.config.paths import (
+    CONFIG_FILENAME,
+    DATA_DIR_ENV_VAR,
+    DEFAULT_DATA_DIR,
+    SECRETS_FILENAME,
+    config_path,
+    resolve_data_dir,
+    secrets_path,
+)
+
+__all__ = [
+    "CONFIG_FILENAME",
+    "DATA_DIR_ENV_VAR",
+    "DEFAULT_DATA_DIR",
+    "SECRETS_FILENAME",
+    "SECRET_MASK",
+    "AlertSettings",
+    "ConfigError",
+    "ConfigStore",
+    "EnrichmentSettings",
+    "LocationSettings",
+    "MapSettings",
+    "NotificationSettings",
+    "ReceiverSettings",
+    "RetentionSettings",
+    "Settings",
+    "SightingTimingSettings",
+    "atomic_write_text",
+    "check_unknown_keys",
+    "config_path",
+    "deep_merge",
+    "load_settings",
+    "resolve_data_dir",
+    "secret_field_paths",
+    "secrets_path",
+    "strip_masked_secrets",
+]

--- a/backend/src/flightsite/config/loader.py
+++ b/backend/src/flightsite/config/loader.py
@@ -1,0 +1,289 @@
+"""YAML layering, atomic write-back, and first-run detection.
+
+This module owns every filesystem interaction for configuration:
+
+* reading ``config.yaml`` and ``secrets.yaml`` out of the data directory,
+* merging them under the environment (see
+  :meth:`flightsite.config.models.Settings.settings_customise_sources`),
+* writing them back atomically (temp file in the same directory, ``fsync``,
+  then :func:`os.replace`), and
+* reporting first-run state (no ``config.yaml`` on disk).
+
+``config.yaml`` is written from the model, not patched in place: comment
+preservation is explicitly not required (roadmap slice 004), and a full,
+field-ordered dump keeps the output clean and stable across writes.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ValidationError
+
+from flightsite.config.models import SECRET_MASK, Settings, secret_field_paths
+from flightsite.config.paths import config_path, resolve_data_dir, secrets_path
+
+CONFIG_HEADER = (
+    "# FlightSite configuration (non-secret).\n"
+    "# Secrets live in secrets.yaml; FLIGHTSITE_* environment variables override\n"
+    "# both files. Written by FlightSite — comments are not preserved on save.\n"
+)
+SECRETS_HEADER = (
+    "# FlightSite secrets. Never commit this file; never include it in a backup\n"
+    "# unless the backup manifest says so. Written by FlightSite.\n"
+)
+
+_SECRET_FILE_MODE = 0o600
+
+
+class ConfigError(Exception):
+    """Raised when configuration on disk cannot be read or is malformed."""
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    """Read a YAML file into a mapping; missing files yield ``{}``."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    except OSError as exc:
+        raise ConfigError(f"could not read {path}: {exc}") from exc
+
+    try:
+        parsed = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"{path} is not valid YAML: {exc}") from exc
+
+    if parsed is None:
+        return {}
+    if not isinstance(parsed, dict):
+        raise ConfigError(f"{path} must contain a YAML mapping at the top level")
+    return parsed
+
+
+def deep_merge(base: Mapping[str, Any], overlay: Mapping[str, Any]) -> dict[str, Any]:
+    """Recursively merge ``overlay`` onto ``base``, returning a new dict."""
+    merged: dict[str, Any] = dict(base)
+    for key, value in overlay.items():
+        existing = merged.get(key)
+        if isinstance(existing, Mapping) and isinstance(value, Mapping):
+            merged[key] = deep_merge(existing, value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def check_unknown_keys(data: Mapping[str, Any], model: type[BaseModel], source: str) -> None:
+    """Reject keys the settings model does not define.
+
+    The settings model itself ignores extra input so that unrelated
+    ``FLIGHTSITE_*`` environment variables stay harmless. Files and API
+    payloads are hand-authored, though, so a typo there should be a loud,
+    helpful error rather than a silently dropped setting.
+    """
+
+    def walk(node: Mapping[str, Any], current: type[BaseModel], prefix: str) -> None:
+        fields = current.model_fields
+        for key, value in node.items():
+            dotted = f"{prefix}{key}"
+            field = fields.get(key)
+            if field is None:
+                known = ", ".join(sorted(f"{prefix}{name}" for name in fields))
+                raise ConfigError(
+                    f"unknown configuration key {dotted!r} in {source}; known keys: {known}"
+                )
+            annotation = field.annotation
+            if (
+                isinstance(value, Mapping)
+                and isinstance(annotation, type)
+                and issubclass(annotation, BaseModel)
+            ):
+                walk(value, annotation, f"{dotted}.")
+
+    walk(data, model, "")
+
+
+def _deep_copy_mapping(source: Mapping[str, Any]) -> dict[str, Any]:
+    """Copy nested mappings so the caller's payload is never mutated."""
+    return {
+        key: _deep_copy_mapping(value) if isinstance(value, Mapping) else value
+        for key, value in source.items()
+    }
+
+
+def strip_masked_secrets(patch: Mapping[str, Any]) -> dict[str, Any]:
+    """Drop secret entries whose value is the mask placeholder.
+
+    ``GET /api/internal/config`` returns stored secrets as
+    :data:`~flightsite.config.models.SECRET_MASK`. A client that edits one
+    field and sends the whole document back must not overwrite the real
+    secret with the mask, so masked secret values mean "leave unchanged".
+    """
+    result = _deep_copy_mapping(patch)
+    for path in secret_field_paths(Settings):
+        node: Any = result
+        for part in path[:-1]:
+            node = node.get(part) if isinstance(node, dict) else None
+            if not isinstance(node, dict):
+                break
+        if isinstance(node, dict) and node.get(path[-1]) == SECRET_MASK:
+            del node[path[-1]]
+    return result
+
+
+def _dump_yaml(data: Mapping[str, Any], header: str) -> str:
+    """Render a stable, human-readable YAML document."""
+    body = yaml.safe_dump(
+        dict(data),
+        sort_keys=False,
+        default_flow_style=False,
+        allow_unicode=True,
+        width=100,
+    )
+    return header + body
+
+
+def atomic_write_text(path: Path, text: str, *, file_mode: int | None = None) -> None:
+    """Write ``text`` to ``path`` atomically.
+
+    The content goes to a temporary file in the destination directory, is
+    flushed and ``fsync``-ed, then moved into place with :func:`os.replace`.
+    If anything fails before the replace, the temporary file is removed and
+    any existing file at ``path`` is left byte-for-byte intact.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if file_mode is not None:
+            os.chmod(tmp_path, file_mode)
+        os.replace(tmp_path, path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+class ConfigStore:
+    """Reads, validates, and writes FlightSite configuration for one data directory."""
+
+    def __init__(self, data_dir: str | os.PathLike[str] | None = None) -> None:
+        self.data_dir = resolve_data_dir(data_dir)
+
+    @property
+    def config_path(self) -> Path:
+        """Path of ``config.yaml`` inside the data directory."""
+        return config_path(self.data_dir)
+
+    @property
+    def secrets_path(self) -> Path:
+        """Path of ``secrets.yaml`` inside the data directory."""
+        return secrets_path(self.data_dir)
+
+    @property
+    def first_run(self) -> bool:
+        """True while no ``config.yaml`` exists — FlightSite has never been set up."""
+        return not self.config_path.exists()
+
+    def load(self, overrides: Mapping[str, Any] | None = None) -> Settings:
+        """Build the effective settings.
+
+        Layers, lowest first: model defaults, ``config.yaml``,
+        ``secrets.yaml``, ``FLIGHTSITE_*`` environment variables. ``overrides``
+        sits with the file layers and exists so a candidate update can be
+        validated before it is written.
+        """
+        file_data = _load_yaml_mapping(self.config_path)
+        check_unknown_keys(file_data, Settings, str(self.config_path))
+        secret_data = _load_yaml_mapping(self.secrets_path)
+        check_unknown_keys(secret_data, Settings, str(self.secrets_path))
+
+        merged = deep_merge(file_data, secret_data)
+        if overrides:
+            merged = deep_merge(merged, overrides)
+        merged.pop("data_dir", None)
+
+        return Settings(data_dir=self.data_dir, **merged)
+
+    def save(self, settings: Settings) -> None:
+        """Write the non-secret configuration to ``config.yaml`` atomically."""
+        atomic_write_text(self.config_path, _dump_yaml(settings.dump_for_file(), CONFIG_HEADER))
+
+    def save_secrets(self, settings: Settings) -> None:
+        """Write stored secrets to ``secrets.yaml`` atomically, or remove the file.
+
+        Only secret fields are written, and only those with a value. When no
+        secret is set, an existing ``secrets.yaml`` is deleted rather than
+        left holding a stale key.
+        """
+        document: dict[str, Any] = {}
+        for path in secret_field_paths(Settings):
+            value: Any = settings
+            for part in path:
+                value = getattr(value, part)
+            if value is None:
+                continue
+            node = document
+            for part in path[:-1]:
+                node = node.setdefault(part, {})
+            node[path[-1]] = value.get_secret_value()
+
+        if not document:
+            self.secrets_path.unlink(missing_ok=True)
+            return
+
+        atomic_write_text(
+            self.secrets_path,
+            _dump_yaml(document, SECRETS_HEADER),
+            file_mode=stat.S_IRUSR | stat.S_IWUSR,
+        )
+
+    def apply_update(self, patch: Mapping[str, Any]) -> Settings:
+        """Validate a partial or full configuration update, then persist it.
+
+        The patch is merged over the current effective configuration, secret
+        fields are routed to ``secrets.yaml`` and non-secret fields to
+        ``config.yaml``, and both files are written atomically. Raises
+        :class:`ConfigError` for unknown keys and
+        :class:`pydantic.ValidationError` for invalid values; in both cases
+        nothing is written.
+
+        A secret whose patch value is :data:`SECRET_MASK` is left unchanged,
+        so a client can send back the masked document it was given. An
+        explicit ``None`` clears the stored secret.
+
+        Values pinned by a ``FLIGHTSITE_*`` environment variable keep winning
+        after the write: the update reaches ``config.yaml``, but the
+        environment still outranks the file (SPEC §30).
+        """
+        check_unknown_keys(patch, Settings, "configuration update")
+        candidate = self.load(overrides=strip_masked_secrets(patch))
+        self.save(candidate)
+        self.save_secrets(candidate)
+        return candidate
+
+
+def load_settings(data_dir: str | os.PathLike[str] | None = None) -> Settings:
+    """Convenience loader used by the app factory and by scripts."""
+    return ConfigStore(data_dir).load()
+
+
+__all__ = [
+    "ConfigError",
+    "ConfigStore",
+    "ValidationError",
+    "atomic_write_text",
+    "check_unknown_keys",
+    "deep_merge",
+    "load_settings",
+    "strip_masked_secrets",
+]

--- a/backend/src/flightsite/config/models.py
+++ b/backend/src/flightsite/config/models.py
@@ -1,0 +1,365 @@
+"""The FlightSite settings model.
+
+One Pydantic model is the single description of FlightSite's configuration
+(SPEC §30): the ``config.yaml`` file, the ``FLIGHTSITE_*`` environment
+overrides, the internal config API, and the Settings UI all validate against
+it.
+
+Layering is performed by :mod:`flightsite.config.loader`; this module owns the
+*shape*, the defaults, the validation rules, and the secret-safe
+serialization.
+
+Secrets (SPEC §29) are typed :class:`pydantic.SecretStr`. That gives leak
+resistance by construction — ``repr``/``str`` of the model renders them as
+``**********`` and ``model_dump(mode="json")`` renders a fixed-width mask —
+and it lets :func:`secret_field_paths` discover the secret fields by type
+instead of by a hand-maintained list.
+"""
+
+from __future__ import annotations
+
+import types
+import typing
+import zoneinfo
+from pathlib import Path
+from typing import Annotated, Any, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator, model_validator
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
+
+from flightsite.config.paths import DEFAULT_DATA_DIR
+
+#: Placeholder returned instead of a stored secret value. The internal config
+#: API accepts this value back on ``PUT`` and treats it as "leave unchanged",
+#: so a client can round-trip the document it was given.
+SECRET_MASK = "•••"
+
+UnitSystem = Literal["aviation", "metric"]
+
+Latitude = Annotated[float, Field(ge=-90.0, le=90.0)]
+Longitude = Annotated[float, Field(ge=-180.0, le=180.0)]
+
+
+class _ConfigModel(BaseModel):
+    """Base for the nested configuration sections."""
+
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
+
+class ReceiverSettings(_ConfigModel):
+    """Decoder (readsb / dump1090-fa) HTTP JSON endpoint — SPEC §11."""
+
+    host: str = Field(default="127.0.0.1", min_length=1)
+    port: int = Field(default=8080, ge=1, le=65535)
+    path: str = Field(default="/data/aircraft.json", min_length=1)
+    poll_interval_s: float = Field(default=1.0, gt=0.0, le=60.0)
+
+    @field_validator("host")
+    @classmethod
+    def _strip_host(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("receiver host must not be blank")
+        return stripped
+
+    @field_validator("path")
+    @classmethod
+    def _leading_slash(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped.startswith("/"):
+            raise ValueError("receiver path must start with '/' (e.g. '/data/aircraft.json')")
+        return stripped
+
+
+class LocationSettings(_ConfigModel):
+    """Receiver location — SPEC §13.
+
+    Latitude and longitude are required before FlightSite can compute
+    bearings, distances or range rings, but they are unset until the setup
+    wizard (slice 018) collects them, so both default to ``None``.
+    """
+
+    latitude: Latitude | None = None
+    longitude: Longitude | None = None
+    site_name: str | None = Field(default=None, max_length=120)
+    antenna_height_ft: float | None = Field(default=None, ge=-1400.0, le=30000.0)
+
+    @model_validator(mode="after")
+    def _both_or_neither(self) -> Self:
+        if (self.latitude is None) != (self.longitude is None):
+            raise ValueError(
+                "receiver location requires both latitude and longitude, or neither "
+                "(set both to configure the receiver position)"
+            )
+        return self
+
+    @property
+    def is_configured(self) -> bool:
+        """True once a usable receiver position is present."""
+        return self.latitude is not None and self.longitude is not None
+
+
+class SightingTimingSettings(_ConfigModel):
+    """Sighting lifecycle timing — Phase 0 defaults 15 s / 60 s / 600 s."""
+
+    stale_s: float = Field(default=15.0, gt=0.0, le=3600.0)
+    remove_s: float = Field(default=60.0, gt=0.0, le=7200.0)
+    close_s: float = Field(default=600.0, gt=0.0, le=86400.0)
+
+    @model_validator(mode="after")
+    def _ordered(self) -> Self:
+        if not self.stale_s < self.remove_s < self.close_s:
+            raise ValueError(
+                "sighting timings must increase: stale_s < remove_s < close_s "
+                f"(got stale_s={self.stale_s}, remove_s={self.remove_s}, close_s={self.close_s})"
+            )
+        return self
+
+
+class RetentionSettings(_ConfigModel):
+    """Retention policy — SPEC §64 / ADR-0009.
+
+    Only the high-resolution receiver-metric window is user-tunable; sighting
+    history is retained indefinitely (SPEC §65).
+    """
+
+    high_res_metric_days: int = Field(default=14, ge=7, le=30)
+
+
+class MapSettings(_ConfigModel):
+    """Map configuration — SPEC §32 / §33.
+
+    ``basemap`` is an opaque id resolved against the basemap registry that
+    arrives with the map foundation (slice 013); the config layer only stores
+    and validates the shape.
+    """
+
+    basemap: str = Field(default="dark-aviation", min_length=1, max_length=64)
+    range_rings_enabled: bool = True
+    range_ring_radii_nm: list[float] = Field(default_factory=lambda: [50.0, 100.0, 150.0, 200.0])
+
+    @field_validator("range_ring_radii_nm")
+    @classmethod
+    def _sorted_positive(cls, value: list[float]) -> list[float]:
+        if len(value) > 10:
+            raise ValueError("at most 10 range rings may be configured")
+        if any(radius <= 0 for radius in value):
+            raise ValueError("range ring radii must be greater than 0 nm")
+        if len(set(value)) != len(value):
+            raise ValueError("range ring radii must be unique")
+        return sorted(value)
+
+
+class EnrichmentSettings(_ConfigModel):
+    """Online route enrichment — SPEC §28.
+
+    ``aerodatabox_api_key`` is the only v1 secret (SPEC §29). It is never
+    written to ``config.yaml`` and never serialized by
+    :meth:`Settings.dump_public`.
+    """
+
+    aerodatabox_enabled: bool = False
+    aerodatabox_api_key: SecretStr | None = None
+
+    @model_validator(mode="after")
+    def _key_required_when_enabled(self) -> Self:
+        if self.aerodatabox_enabled and self.aerodatabox_api_key is None:
+            raise ValueError(
+                "enrichment.aerodatabox_enabled requires an AeroDataBox API key "
+                "(set it in secrets.yaml or FLIGHTSITE_ENRICHMENT__AERODATABOX_API_KEY)"
+            )
+        return self
+
+
+class NotificationSettings(_ConfigModel):
+    """Browser notification enables per alert severity — SPEC §46 / §48.
+
+    Defaults follow "do not silently enable every possible notification"
+    (SPEC §45): the low-signal ``info`` severity is off by default.
+    """
+
+    enabled: bool = True
+    info: bool = False
+    interesting: bool = True
+    high: bool = True
+    critical: bool = True
+
+
+class AlertSettings(_ConfigModel):
+    """Alert configuration — SPEC §45.
+
+    ``enabled_templates`` is written by the setup wizard (slice 018) and read
+    by slice 038 when instantiating the shipped alert templates. The config
+    layer does not know the template catalogue, so ids are validated for shape
+    only.
+    """
+
+    enabled_templates: list[str] = Field(default_factory=list)
+
+    @field_validator("enabled_templates")
+    @classmethod
+    def _clean_ids(cls, value: list[str]) -> list[str]:
+        cleaned: list[str] = []
+        for template_id in value:
+            stripped = template_id.strip()
+            if not stripped:
+                raise ValueError("alert template ids must not be blank")
+            if stripped not in cleaned:
+                cleaned.append(stripped)
+        return cleaned
+
+
+class Settings(BaseSettings):
+    """Root FlightSite configuration.
+
+    Source precedence is defined by :meth:`settings_customise_sources`:
+    environment variables outrank everything, then the values supplied at
+    construction (which :mod:`flightsite.config.loader` fills from
+    ``config.yaml`` then ``secrets.yaml``), then these defaults.
+
+    ``extra="ignore"`` is deliberate: the ``FLIGHTSITE_`` environment
+    namespace is shared with non-settings variables (``FLIGHTSITE_HOST`` and
+    ``FLIGHTSITE_PORT`` bind uvicorn, ``FLIGHTSITE_LOG_DIR`` steers the log
+    handler), so an unknown ``FLIGHTSITE_*`` variable must not be fatal.
+    Unknown keys in ``config.yaml`` — the file a human edits — are rejected
+    separately by :func:`flightsite.config.loader.check_unknown_keys`.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="FLIGHTSITE_",
+        env_nested_delimiter="__",
+        extra="ignore",
+        validate_assignment=True,
+        nested_model_default_partial_update=True,
+    )
+
+    #: Resolved data directory. Deployment-level and environment-driven, so it
+    #: is excluded from serialization and never written to ``config.yaml``.
+    data_dir: Annotated[Path, Field(exclude=True)] = DEFAULT_DATA_DIR
+
+    log_level: Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"] = "INFO"
+
+    units: UnitSystem = "aviation"
+    timezone: str = "UTC"
+    display_radius_nm: float = Field(default=250.0, gt=0.0, le=10000.0)
+    #: ``None`` means unlimited: alerts fire regardless of distance (SPEC §66).
+    alert_radius_nm: float | None = Field(default=None, gt=0.0, le=10000.0)
+
+    receiver: ReceiverSettings = Field(default_factory=ReceiverSettings)
+    location: LocationSettings = Field(default_factory=LocationSettings)
+    sighting: SightingTimingSettings = Field(default_factory=SightingTimingSettings)
+    retention: RetentionSettings = Field(default_factory=RetentionSettings)
+    map: MapSettings = Field(default_factory=MapSettings)
+    enrichment: EnrichmentSettings = Field(default_factory=EnrichmentSettings)
+    notifications: NotificationSettings = Field(default_factory=NotificationSettings)
+    alerts: AlertSettings = Field(default_factory=AlertSettings)
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Put environment variables above the file layers.
+
+        Highest priority first. ``init_settings`` carries the merged
+        ``config.yaml`` + ``secrets.yaml`` data assembled by the loader, so
+        returning ``(env, init)`` yields the documented order:
+        defaults < config.yaml < secrets.yaml < ``FLIGHTSITE_*``.
+        """
+        return (env_settings, init_settings)
+
+    @field_validator("timezone")
+    @classmethod
+    def _known_timezone(cls, value: str) -> str:
+        try:
+            zoneinfo.ZoneInfo(value)
+        except (zoneinfo.ZoneInfoNotFoundError, ValueError) as exc:
+            raise ValueError(
+                f"unknown IANA timezone {value!r} "
+                "(expected a tz database name such as 'Europe/London' or 'UTC')"
+            ) from exc
+        return value
+
+    def dump_public(self) -> dict[str, Any]:
+        """Serialize every non-secret field, with secrets masked.
+
+        Secret fields are replaced with :data:`SECRET_MASK` when set and
+        ``None`` when unset, so the result is safe for the internal config
+        API, for diagnostics, and for logging. Use :meth:`dump_for_file` for
+        ``config.yaml`` write-back, which omits secret keys entirely.
+        """
+        data = self.model_dump(mode="json")
+        for path in secret_field_paths(type(self)):
+            _set_masked(data, path, mask=SECRET_MASK)
+        return data
+
+    def dump_for_file(self) -> dict[str, Any]:
+        """Serialize the non-secret configuration for ``config.yaml``.
+
+        Secret keys are removed rather than masked: a mask written to disk
+        would be indistinguishable from a real value on the next load.
+        """
+        data = self.model_dump(mode="json")
+        for path in secret_field_paths(type(self)):
+            _set_masked(data, path, mask=None)
+        return data
+
+    def secrets_state(self) -> dict[str, bool]:
+        """Map each secret's dotted path to whether a value is stored."""
+        state: dict[str, bool] = {}
+        for path in secret_field_paths(type(self)):
+            value: Any = self
+            for part in path:
+                value = getattr(value, part)
+            state[".".join(path)] = value is not None
+        return state
+
+
+def _set_masked(data: dict[str, Any], path: tuple[str, ...], *, mask: str | None) -> None:
+    """Replace ``path`` in ``data`` with ``mask`` (or drop it when masking to None)."""
+    node: Any = data
+    for part in path[:-1]:
+        node = node.get(part)
+        if not isinstance(node, dict):
+            return
+    leaf = path[-1]
+    if leaf not in node:
+        return
+    if mask is None:
+        del node[leaf]
+    else:
+        node[leaf] = mask if node[leaf] is not None else None
+
+
+def _contains_secret_str(annotation: Any) -> bool:
+    if annotation is SecretStr:
+        return True
+    origin = typing.get_origin(annotation)
+    if origin in (typing.Union, types.UnionType):
+        return any(_contains_secret_str(arg) for arg in typing.get_args(annotation))
+    return False
+
+
+def secret_field_paths(model: type[BaseModel]) -> tuple[tuple[str, ...], ...]:
+    """Discover every ``SecretStr`` field, as dotted paths from the root model.
+
+    Walking the model by type means a secret added in a later slice is
+    automatically masked everywhere secrets are masked — nothing has to be
+    added to a parallel list.
+    """
+    paths: list[tuple[str, ...]] = []
+
+    def walk(current: type[BaseModel], prefix: tuple[str, ...]) -> None:
+        for name, field in current.model_fields.items():
+            annotation = field.annotation
+            if _contains_secret_str(annotation):
+                paths.append((*prefix, name))
+            elif isinstance(annotation, type) and issubclass(annotation, BaseModel):
+                walk(annotation, (*prefix, name))
+
+    walk(model, ())
+    return tuple(paths)

--- a/backend/src/flightsite/config/paths.py
+++ b/backend/src/flightsite/config/paths.py
@@ -1,0 +1,47 @@
+"""Data-directory resolution.
+
+All persistent FlightSite state lives under a single directory
+(``docs/ARCHITECTURE.md`` §2.1). In containers this is the bind mount
+``/opt/flightsite/data``; tests and non-container runs override it with the
+``FLIGHTSITE_DATA_DIR`` environment variable.
+
+The data directory has to be resolved *before* the settings model is loaded —
+``config.yaml`` and ``secrets.yaml`` live inside it — so this resolution is
+deliberately a plain function over the environment rather than a settings
+field lookup.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+DATA_DIR_ENV_VAR = "FLIGHTSITE_DATA_DIR"
+DEFAULT_DATA_DIR = Path("/opt/flightsite/data")
+
+CONFIG_FILENAME = "config.yaml"
+SECRETS_FILENAME = "secrets.yaml"
+
+
+def resolve_data_dir(data_dir: str | os.PathLike[str] | None = None) -> Path:
+    """Resolve the FlightSite data directory.
+
+    Precedence: explicit argument, then ``FLIGHTSITE_DATA_DIR``, then
+    ``/opt/flightsite/data``. The path is not created or required to exist.
+    """
+    if data_dir is not None:
+        return Path(data_dir)
+    from_env = os.environ.get(DATA_DIR_ENV_VAR)
+    if from_env:
+        return Path(from_env)
+    return DEFAULT_DATA_DIR
+
+
+def config_path(data_dir: Path) -> Path:
+    """Path of the canonical non-secret configuration file."""
+    return data_dir / CONFIG_FILENAME
+
+
+def secrets_path(data_dir: Path) -> Path:
+    """Path of the optional secrets file."""
+    return data_dir / SECRETS_FILENAME

--- a/backend/src/flightsite/logging.py
+++ b/backend/src/flightsite/logging.py
@@ -6,10 +6,13 @@ uvicorn or third-party libraries) — is rendered as a single JSON line with an
 ISO-8601 UTC timestamp. The log level is configurable via the
 ``FLIGHTSITE_LOG_LEVEL`` environment variable (default ``INFO``).
 
-A rotating-file handler scaffold is included but disabled by default; the
-full configuration system (config.yaml / secrets.yaml / env layering) arrives
-in slice 004, so for now this module only reads plain environment variables
-and accepts direct arguments.
+A rotating-file handler scaffold is included but disabled by default.
+
+:func:`flightsite.app.create_app` passes ``settings.log_level``, which the
+settings model has already resolved through the config.yaml / secrets.yaml /
+environment layering — so ``FLIGHTSITE_LOG_LEVEL`` still outranks
+``config.yaml``. The environment fallback below keeps this module usable on
+its own, before any settings object exists.
 """
 
 from __future__ import annotations

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,9 +3,17 @@
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
+
+from flightsite.config import ConfigStore
+
+SECRET_SENTINEL = "sentinel-aerodatabox-key-9c1f4a"
+"""A recognisable fake secret. Secret-leak tests search serialized output,
+files and log records for this exact string."""
 
 
 @pytest.fixture(autouse=True)
@@ -25,3 +33,28 @@ def _reset_logging_state() -> Iterator[None]:
     root_logger.handlers.clear()
     root_logger.handlers.extend(original_handlers)
     root_logger.setLevel(original_level)
+
+
+@pytest.fixture(autouse=True)
+def isolated_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Give every test a private, empty data directory and a clean environment.
+
+    Configuration reads ``FLIGHTSITE_*`` environment variables, so a stray
+    variable in the developer's shell (or one set by an earlier test) would
+    otherwise change results. Every ``FLIGHTSITE_*`` variable is removed and
+    ``FLIGHTSITE_DATA_DIR`` is pointed at a fresh temporary directory.
+    """
+    for name in list(os.environ):
+        if name.startswith("FLIGHTSITE_"):
+            monkeypatch.delenv(name, raising=False)
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("FLIGHTSITE_DATA_DIR", str(data_dir))
+    return data_dir
+
+
+@pytest.fixture
+def store(isolated_data_dir: Path) -> ConfigStore:
+    """A ``ConfigStore`` bound to the test's isolated data directory."""
+    return ConfigStore(isolated_data_dir)

--- a/backend/tests/test_config_api.py
+++ b/backend/tests/test_config_api.py
@@ -1,0 +1,222 @@
+"""Internal config API tests: ``GET`` / ``PUT /api/internal/config``."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from flightsite.app import create_app
+from flightsite.config import SECRET_MASK, ConfigStore
+
+from .conftest import SECRET_SENTINEL
+
+
+@pytest.fixture
+def client(isolated_data_dir: Path) -> Iterator[TestClient]:
+    with TestClient(create_app(isolated_data_dir)) as test_client:
+        yield test_client
+
+
+def test_get_config_reports_first_run_and_defaults(client: TestClient) -> None:
+    response = client.get("/api/internal/config")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["first_run"] is True
+    assert body["config"]["units"] == "aviation"
+    assert body["config"]["display_radius_nm"] == 250.0
+    assert body["config"]["alert_radius_nm"] is None
+    assert body["config"]["receiver"]["port"] == 8080
+    assert body["secrets_set"] == {"enrichment.aerodatabox_api_key": False}
+
+
+def test_put_config_persists_and_clears_first_run(
+    client: TestClient, isolated_data_dir: Path
+) -> None:
+    response = client.put(
+        "/api/internal/config",
+        json={
+            "units": "metric",
+            "timezone": "Europe/London",
+            "location": {"latitude": 51.5, "longitude": -0.12, "site_name": "London"},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["first_run"] is False
+    assert body["config"]["units"] == "metric"
+    assert body["config"]["location"]["site_name"] == "London"
+
+    on_disk = yaml.safe_load((isolated_data_dir / "config.yaml").read_text(encoding="utf-8"))
+    assert on_disk["units"] == "metric"
+    assert on_disk["location"]["latitude"] == 51.5
+
+    assert client.get("/api/internal/config").json()["first_run"] is False
+
+
+def test_put_config_applies_to_the_running_app(client: TestClient) -> None:
+    assert client.app.state.settings.display_radius_nm == 250.0  # type: ignore[attr-defined]
+
+    client.put("/api/internal/config", json={"display_radius_nm": 90.0})
+
+    assert client.app.state.settings.display_radius_nm == 90.0  # type: ignore[attr-defined]
+
+
+def test_put_config_round_trips_the_document_it_returned(client: TestClient) -> None:
+    document = client.get("/api/internal/config").json()["config"]
+    document["retention"]["high_res_metric_days"] = 21
+
+    response = client.put("/api/internal/config", json=document)
+
+    assert response.status_code == 200
+    assert response.json()["config"] == document
+
+
+def test_partial_put_preserves_unrelated_values(client: TestClient) -> None:
+    client.put("/api/internal/config", json={"units": "metric", "display_radius_nm": 120.0})
+
+    body = client.put("/api/internal/config", json={"display_radius_nm": 130.0}).json()
+
+    assert body["config"]["units"] == "metric"
+    assert body["config"]["display_radius_nm"] == 130.0
+
+
+def test_empty_put_is_a_no_op_that_still_writes_the_file(client: TestClient) -> None:
+    response = client.put("/api/internal/config", json={})
+
+    assert response.status_code == 200
+    assert response.json()["first_run"] is False
+
+
+def test_secret_is_write_only_and_masked_on_read(
+    client: TestClient, isolated_data_dir: Path
+) -> None:
+    put_body = client.put(
+        "/api/internal/config",
+        json={"enrichment": {"aerodatabox_enabled": True, "aerodatabox_api_key": SECRET_SENTINEL}},
+    ).json()
+
+    # The response that just accepted the secret must not echo it back.
+    assert put_body["config"]["enrichment"]["aerodatabox_api_key"] == SECRET_MASK
+    assert put_body["secrets_set"] == {"enrichment.aerodatabox_api_key": True}
+    assert SECRET_SENTINEL not in json.dumps(put_body)
+
+    get_response = client.get("/api/internal/config")
+    assert SECRET_SENTINEL not in get_response.text
+    assert get_response.json()["config"]["enrichment"]["aerodatabox_api_key"] == SECRET_MASK
+
+    # The secret reached secrets.yaml and only secrets.yaml.
+    assert SECRET_SENTINEL not in (isolated_data_dir / "config.yaml").read_text(encoding="utf-8")
+    secrets = yaml.safe_load((isolated_data_dir / "secrets.yaml").read_text(encoding="utf-8"))
+    assert secrets["enrichment"]["aerodatabox_api_key"] == SECRET_SENTINEL
+
+
+def test_resending_the_masked_secret_does_not_overwrite_it(
+    client: TestClient, isolated_data_dir: Path
+) -> None:
+    client.put(
+        "/api/internal/config",
+        json={"enrichment": {"aerodatabox_enabled": True, "aerodatabox_api_key": SECRET_SENTINEL}},
+    )
+
+    document = client.get("/api/internal/config").json()["config"]
+    document["units"] = "metric"
+    response = client.put("/api/internal/config", json=document)
+
+    assert response.status_code == 200
+    assert response.json()["secrets_set"]["enrichment.aerodatabox_api_key"] is True
+    secrets = yaml.safe_load((isolated_data_dir / "secrets.yaml").read_text(encoding="utf-8"))
+    assert secrets["enrichment"]["aerodatabox_api_key"] == SECRET_SENTINEL
+
+
+def test_null_secret_clears_it(client: TestClient, isolated_data_dir: Path) -> None:
+    client.put(
+        "/api/internal/config",
+        json={"enrichment": {"aerodatabox_enabled": True, "aerodatabox_api_key": SECRET_SENTINEL}},
+    )
+
+    body = client.put(
+        "/api/internal/config",
+        json={"enrichment": {"aerodatabox_enabled": False, "aerodatabox_api_key": None}},
+    ).json()
+
+    assert body["secrets_set"]["enrichment.aerodatabox_api_key"] is False
+    assert not (isolated_data_dir / "secrets.yaml").exists()
+
+
+def test_invalid_value_is_rejected_with_a_helpful_error(client: TestClient) -> None:
+    response = client.put("/api/internal/config", json={"location": {"latitude": 120.0}})
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any("latitude" in str(error["loc"]) for error in detail)
+
+
+def test_invalid_timezone_message_is_helpful(client: TestClient) -> None:
+    response = client.put("/api/internal/config", json={"timezone": "Mars/Olympus_Mons"})
+
+    assert response.status_code == 422
+    assert "unknown IANA timezone" in json.dumps(response.json()["detail"])
+
+
+def test_unknown_key_is_rejected(client: TestClient) -> None:
+    response = client.put("/api/internal/config", json={"displayradius": 100})
+
+    assert response.status_code == 422
+    assert "unknown configuration key" in response.json()["detail"]
+
+
+def test_rejected_update_does_not_change_stored_config(client: TestClient) -> None:
+    client.put("/api/internal/config", json={"display_radius_nm": 120.0})
+
+    client.put("/api/internal/config", json={"display_radius_nm": -5.0})
+
+    assert client.get("/api/internal/config").json()["config"]["display_radius_nm"] == 120.0
+
+
+def test_validation_errors_do_not_echo_the_rejected_secret(client: TestClient) -> None:
+    """A bad payload must not hand the submitted secret back to the caller."""
+    response = client.put(
+        "/api/internal/config",
+        json={
+            "timezone": "Mars/Olympus_Mons",
+            "enrichment": {"aerodatabox_api_key": SECRET_SENTINEL},
+        },
+    )
+
+    assert response.status_code == 422
+    assert SECRET_SENTINEL not in response.text
+
+
+def test_internal_api_is_excluded_from_the_openapi_schema(client: TestClient) -> None:
+    schema = client.get("/openapi.json").json()
+
+    assert "/api/v1/health" in schema["paths"]
+    assert not any(path.startswith("/api/internal") for path in schema["paths"])
+
+
+def test_app_state_carries_the_settings_and_store(isolated_data_dir: Path) -> None:
+    app = create_app(isolated_data_dir)
+
+    assert isinstance(app.state.config_store, ConfigStore)
+    assert app.state.config_store.data_dir == isolated_data_dir
+    assert app.state.settings.data_dir == isolated_data_dir
+
+
+def test_log_level_comes_from_config_with_env_override_winning(
+    isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (isolated_data_dir / "config.yaml").write_text("log_level: WARNING\n", encoding="utf-8")
+
+    app = create_app(isolated_data_dir)
+    assert app.state.settings.log_level == "WARNING"
+
+    monkeypatch.setenv("FLIGHTSITE_LOG_LEVEL", "DEBUG")
+    app = create_app(isolated_data_dir)
+    assert app.state.settings.log_level == "DEBUG"

--- a/backend/tests/test_config_loading.py
+++ b/backend/tests/test_config_loading.py
@@ -1,0 +1,252 @@
+"""Load-order, data-directory resolution, and first-run tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from flightsite.config import (
+    DEFAULT_DATA_DIR,
+    ConfigError,
+    ConfigStore,
+    Settings,
+    load_settings,
+    resolve_data_dir,
+)
+
+
+def write_yaml(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+def test_resolve_data_dir_prefers_argument_then_env_then_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FLIGHTSITE_DATA_DIR", "/from/env")
+    assert resolve_data_dir("/explicit") == Path("/explicit")
+    assert resolve_data_dir() == Path("/from/env")
+
+    monkeypatch.delenv("FLIGHTSITE_DATA_DIR")
+    assert resolve_data_dir() == DEFAULT_DATA_DIR
+
+
+def test_missing_config_yields_defaults_and_first_run(store: ConfigStore) -> None:
+    assert store.first_run is True
+
+    settings = store.load()
+
+    assert settings.units == "aviation"
+    assert settings.timezone == "UTC"
+    assert settings.display_radius_nm == 250.0
+    assert settings.alert_radius_nm is None
+    assert settings.receiver.port == 8080
+    assert settings.receiver.poll_interval_s == 1.0
+    assert (settings.sighting.stale_s, settings.sighting.remove_s, settings.sighting.close_s) == (
+        15.0,
+        60.0,
+        600.0,
+    )
+    assert settings.retention.high_res_metric_days == 14
+    assert settings.alerts.enabled_templates == []
+    assert settings.location.is_configured is False
+    assert settings.enrichment.aerodatabox_api_key is None
+
+
+def test_first_run_clears_once_config_is_written(store: ConfigStore) -> None:
+    assert store.first_run is True
+
+    store.save(store.load())
+
+    assert store.first_run is False
+    assert store.config_path.exists()
+
+
+def test_config_file_overrides_defaults(store: ConfigStore) -> None:
+    write_yaml(
+        store.config_path,
+        "units: metric\ndisplay_radius_nm: 120\nreceiver:\n  host: readsb.lan\n  port: 8081\n",
+    )
+
+    settings = store.load()
+
+    assert settings.units == "metric"
+    assert settings.display_radius_nm == 120.0
+    assert settings.receiver.host == "readsb.lan"
+    assert settings.receiver.port == 8081
+    # Unspecified keys keep their defaults rather than being reset.
+    assert settings.receiver.path == "/data/aircraft.json"
+
+
+def test_secrets_file_overrides_config_file(store: ConfigStore) -> None:
+    write_yaml(store.config_path, "receiver:\n  port: 8081\n")
+    write_yaml(
+        store.secrets_path,
+        "enrichment:\n  aerodatabox_api_key: from-secrets\n",
+    )
+
+    settings = store.load()
+
+    assert settings.receiver.port == 8081
+    assert settings.enrichment.aerodatabox_api_key is not None
+    assert settings.enrichment.aerodatabox_api_key.get_secret_value() == "from-secrets"
+
+
+def test_full_precedence_chain_defaults_config_secrets_env(
+    store: ConfigStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Defaults < config.yaml < secrets.yaml < FLIGHTSITE_* — all four layers."""
+    write_yaml(
+        store.config_path,
+        "units: metric\ntimezone: Europe/London\nreceiver:\n  host: config-host\n  port: 8081\n",
+    )
+    write_yaml(
+        store.secrets_path,
+        "receiver:\n  port: 8082\nenrichment:\n  aerodatabox_api_key: from-secrets\n",
+    )
+    monkeypatch.setenv("FLIGHTSITE_RECEIVER__PORT", "8083")
+
+    settings = store.load()
+
+    # default layer: untouched by any file or variable
+    assert settings.map.basemap == "dark-aviation"
+    # config.yaml layer: beats the defaults
+    assert settings.units == "metric"
+    assert settings.timezone == "Europe/London"
+    assert settings.receiver.host == "config-host"
+    # secrets.yaml layer: beats config.yaml
+    assert settings.enrichment.aerodatabox_api_key is not None
+    # env layer: beats both files
+    assert settings.receiver.port == 8083
+
+
+def test_env_overrides_scalar_and_nested_file_values(
+    store: ConfigStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    write_yaml(store.config_path, "display_radius_nm: 300\nreceiver:\n  host: config-host\n")
+    monkeypatch.setenv("FLIGHTSITE_DISPLAY_RADIUS_NM", "175.5")
+    monkeypatch.setenv("FLIGHTSITE_RECEIVER__HOST", "env-host")
+
+    settings = store.load()
+
+    assert settings.display_radius_nm == 175.5
+    assert settings.receiver.host == "env-host"
+
+
+def test_secret_loads_from_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FLIGHTSITE_ENRICHMENT__AERODATABOX_API_KEY", "from-env")
+
+    settings = load_settings()
+
+    assert settings.enrichment.aerodatabox_api_key is not None
+    assert settings.enrichment.aerodatabox_api_key.get_secret_value() == "from-env"
+
+
+def test_env_secret_beats_secrets_file(store: ConfigStore, monkeypatch: pytest.MonkeyPatch) -> None:
+    write_yaml(store.secrets_path, "enrichment:\n  aerodatabox_api_key: from-secrets\n")
+    monkeypatch.setenv("FLIGHTSITE_ENRICHMENT__AERODATABOX_API_KEY", "from-env")
+
+    settings = store.load()
+
+    assert settings.enrichment.aerodatabox_api_key is not None
+    assert settings.enrichment.aerodatabox_api_key.get_secret_value() == "from-env"
+
+
+def test_unrelated_flightsite_env_vars_are_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    """FLIGHTSITE_HOST/PORT bind uvicorn; they must not break settings loading."""
+    monkeypatch.setenv("FLIGHTSITE_HOST", "0.0.0.0")
+    monkeypatch.setenv("FLIGHTSITE_PORT", "9000")
+    monkeypatch.setenv("FLIGHTSITE_LOG_DIR", "/var/log/flightsite")
+
+    settings = load_settings()
+
+    assert settings.receiver.port == 8080
+
+
+def test_data_dir_is_recorded_but_never_serialized(store: ConfigStore) -> None:
+    settings = store.load()
+
+    assert settings.data_dir == store.data_dir
+    assert "data_dir" not in settings.dump_public()
+    assert "data_dir" not in settings.dump_for_file()
+
+
+def test_data_dir_key_in_config_file_is_not_applied(store: ConfigStore) -> None:
+    """The data directory is resolved from the environment, not from the file it contains."""
+    write_yaml(store.config_path, "data_dir: /somewhere/else\n")
+
+    settings = store.load()
+
+    assert settings.data_dir == store.data_dir
+
+
+def test_empty_config_file_is_treated_as_no_configuration(store: ConfigStore) -> None:
+    write_yaml(store.config_path, "\n")
+
+    settings = store.load()
+
+    assert settings.units == "aviation"
+    assert store.first_run is False
+
+
+def test_unreadable_config_path_raises_config_error(store: ConfigStore) -> None:
+    """A directory where config.yaml should be is a clear error, not a silent default."""
+    store.config_path.mkdir(parents=True)
+
+    with pytest.raises(ConfigError, match="could not read"):
+        store.load()
+
+
+def test_malformed_yaml_raises_config_error(store: ConfigStore) -> None:
+    write_yaml(store.config_path, "receiver: [unclosed\n")
+
+    with pytest.raises(ConfigError, match="not valid YAML"):
+        store.load()
+
+
+def test_non_mapping_config_raises_config_error(store: ConfigStore) -> None:
+    write_yaml(store.config_path, "- just\n- a\n- list\n")
+
+    with pytest.raises(ConfigError, match="mapping at the top level"):
+        store.load()
+
+
+def test_unknown_config_key_is_rejected_with_known_keys_listed(store: ConfigStore) -> None:
+    write_yaml(store.config_path, "displayradius: 100\n")
+
+    with pytest.raises(ConfigError) as excinfo:
+        store.load()
+
+    message = str(excinfo.value)
+    assert "unknown configuration key 'displayradius'" in message
+    assert "display_radius_nm" in message
+
+
+def test_unknown_nested_config_key_is_rejected(store: ConfigStore) -> None:
+    write_yaml(store.config_path, "receiver:\n  prt: 8080\n")
+
+    with pytest.raises(ConfigError, match=r"receiver\.prt"):
+        store.load()
+
+
+EXAMPLE_CONFIG = Path(__file__).resolve().parents[2] / "config.example.yaml"
+
+
+def test_repo_example_config_is_valid_and_matches_the_defaults(store: ConfigStore) -> None:
+    """config.example.yaml documents the real defaults — it must load and agree."""
+    write_yaml(store.config_path, EXAMPLE_CONFIG.read_text(encoding="utf-8"))
+
+    from_example = store.load()
+
+    store.config_path.unlink()
+    defaults = store.load()
+
+    assert from_example.dump_for_file() == defaults.dump_for_file()
+
+
+def test_settings_can_be_constructed_without_any_files() -> None:
+    """The model alone is usable — no filesystem access required."""
+    settings = Settings()
+
+    assert settings.units == "aviation"
+    assert settings.notifications.critical is True

--- a/backend/tests/test_config_secrets.py
+++ b/backend/tests/test_config_secrets.py
@@ -1,0 +1,166 @@
+"""Secret-leak tests (SPEC §29).
+
+Each test puts the sentinel secret into the configuration and then searches an
+output channel — repr, serialization, the config file, log records — for it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+import structlog
+
+from flightsite.config import SECRET_MASK, ConfigStore, Settings, secret_field_paths
+from flightsite.config.models import _set_masked
+from flightsite.logging import configure_logging
+
+from .conftest import SECRET_SENTINEL
+
+
+@pytest.fixture
+def configured(store: ConfigStore) -> Settings:
+    """Settings with the sentinel secret stored in ``secrets.yaml``."""
+    store.secrets_path.write_text(
+        f"enrichment:\n  aerodatabox_api_key: {SECRET_SENTINEL}\n", encoding="utf-8"
+    )
+    return store.load()
+
+
+def test_the_sentinel_secret_is_actually_loaded(configured: Settings) -> None:
+    """Guard: every other test here is vacuous if the secret never arrives."""
+    assert configured.enrichment.aerodatabox_api_key is not None
+    assert configured.enrichment.aerodatabox_api_key.get_secret_value() == SECRET_SENTINEL
+
+
+def test_secret_fields_are_discovered_by_type(configured: Settings) -> None:
+    assert secret_field_paths(Settings) == (("enrichment", "aerodatabox_api_key"),)
+
+
+def test_repr_and_str_do_not_reveal_the_secret(configured: Settings) -> None:
+    assert SECRET_SENTINEL not in repr(configured)
+    assert SECRET_SENTINEL not in str(configured)
+    assert SECRET_SENTINEL not in repr(configured.enrichment)
+    assert SECRET_SENTINEL not in str(configured.enrichment.aerodatabox_api_key)
+    assert SECRET_SENTINEL not in f"{configured!r} {configured!s}"
+
+
+def test_model_dump_does_not_reveal_the_secret(configured: Settings) -> None:
+    assert SECRET_SENTINEL not in str(configured.model_dump())
+    assert SECRET_SENTINEL not in str(configured.model_dump(mode="json"))
+    assert SECRET_SENTINEL not in configured.model_dump_json()
+
+
+def test_dump_public_masks_the_secret(configured: Settings) -> None:
+    public = configured.dump_public()
+
+    assert public["enrichment"]["aerodatabox_api_key"] == SECRET_MASK
+    assert SECRET_SENTINEL not in json.dumps(public)
+
+
+def test_dump_public_reports_an_unset_secret_as_null(store: ConfigStore) -> None:
+    public = store.load().dump_public()
+
+    assert public["enrichment"]["aerodatabox_api_key"] is None
+
+
+def test_dump_for_file_omits_the_secret_key_entirely(configured: Settings) -> None:
+    """A mask written to config.yaml would be reloaded as if it were the key."""
+    for_file = configured.dump_for_file()
+
+    assert "aerodatabox_api_key" not in for_file["enrichment"]
+    assert SECRET_SENTINEL not in json.dumps(for_file)
+    assert SECRET_MASK not in json.dumps(for_file)
+
+
+def test_secrets_state_reports_set_and_unset_without_the_value(
+    store: ConfigStore, configured: Settings
+) -> None:
+    assert configured.secrets_state() == {"enrichment.aerodatabox_api_key": True}
+
+    store.secrets_path.unlink()
+    assert store.load().secrets_state() == {"enrichment.aerodatabox_api_key": False}
+
+
+def test_written_config_yaml_never_contains_the_secret(
+    store: ConfigStore, configured: Settings
+) -> None:
+    store.save(configured)
+
+    assert SECRET_SENTINEL not in store.config_path.read_text(encoding="utf-8")
+
+
+def test_secret_does_not_reach_the_logs(
+    store: ConfigStore, configured: Settings, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Structured logs render the whole settings object at DEBUG without leaking."""
+    configure_logging(level="DEBUG")
+    logger = structlog.get_logger("test")
+
+    logger.debug("settings_loaded", settings=configured, public=configured.dump_public())
+    logger.info("enrichment", enrichment=configured.enrichment)
+    logging.getLogger("stdlib").warning("settings=%s", configured)
+
+    captured = capsys.readouterr()
+    assert SECRET_SENTINEL not in captured.out
+    assert SECRET_SENTINEL not in captured.err
+    # ...and the log really did contain the settings, so the search was meaningful.
+    assert "settings_loaded" in captured.out + captured.err
+
+
+def test_secret_survives_a_config_save_that_does_not_touch_it(
+    store: ConfigStore, configured: Settings
+) -> None:
+    store.apply_update({"units": "metric"})
+
+    reloaded = ConfigStore(store.data_dir).load()
+    assert reloaded.enrichment.aerodatabox_api_key is not None
+    assert reloaded.enrichment.aerodatabox_api_key.get_secret_value() == SECRET_SENTINEL
+
+
+def test_masked_value_in_an_update_leaves_the_stored_secret_alone(
+    store: ConfigStore, configured: Settings
+) -> None:
+    """A client can send back the masked document it was given."""
+    document = configured.dump_public()
+    document["units"] = "metric"
+
+    updated = store.apply_update(document)
+
+    assert updated.units == "metric"
+    assert updated.enrichment.aerodatabox_api_key is not None
+    assert updated.enrichment.aerodatabox_api_key.get_secret_value() == SECRET_SENTINEL
+
+
+def test_secret_is_not_in_any_file_in_the_data_directory_after_a_public_save(
+    store: ConfigStore, configured: Settings
+) -> None:
+    store.secrets_path.unlink()
+    store.save(store.load(overrides={"enrichment": {"aerodatabox_api_key": SECRET_SENTINEL}}))
+
+    for path in store.data_dir.rglob("*"):
+        if path.is_file():
+            assert SECRET_SENTINEL not in _read(path)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+@pytest.mark.parametrize(
+    "document",
+    [{}, {"enrichment": {}}, {"enrichment": None}],
+    ids=["no-section", "empty-section", "section-not-a-mapping"],
+)
+def test_masking_tolerates_a_document_missing_the_secret_path(
+    document: dict[str, object],
+) -> None:
+    """Masking is a no-op on a partial dump rather than raising or inventing keys."""
+    before = json.dumps(document, sort_keys=True)
+
+    _set_masked(document, ("enrichment", "aerodatabox_api_key"), mask=SECRET_MASK)
+    _set_masked(document, ("enrichment", "aerodatabox_api_key"), mask=None)
+
+    assert json.dumps(document, sort_keys=True) == before

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -1,0 +1,157 @@
+"""Validation-error tests: bad values must be rejected with a helpful message."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from flightsite.config import (
+    AlertSettings,
+    EnrichmentSettings,
+    LocationSettings,
+    MapSettings,
+    ReceiverSettings,
+    RetentionSettings,
+    Settings,
+    SightingTimingSettings,
+)
+
+
+@pytest.mark.parametrize(
+    ("latitude", "longitude"),
+    [(91.0, 0.0), (-90.5, 0.0), (0.0, 181.0), (0.0, -180.5)],
+)
+def test_out_of_range_coordinates_are_rejected(latitude: float, longitude: float) -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        LocationSettings(latitude=latitude, longitude=longitude)
+
+    assert excinfo.value.error_count() == 1
+
+
+def test_valid_coordinates_are_accepted() -> None:
+    location = LocationSettings(latitude=51.4775, longitude=-0.4614, site_name="Heathrow")
+
+    assert location.is_configured is True
+
+
+def test_half_configured_location_is_rejected() -> None:
+    with pytest.raises(ValidationError, match="both latitude and longitude"):
+        LocationSettings(latitude=51.5)
+
+
+@pytest.mark.parametrize("timezone", ["Mars/Olympus_Mons", "Not A Zone", "", "UTC+1"])
+def test_unknown_timezone_is_rejected_with_a_helpful_message(timezone: str) -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        Settings(timezone=timezone)
+
+    message = str(excinfo.value)
+    assert "unknown IANA timezone" in message
+    assert "Europe/London" in message
+
+
+@pytest.mark.parametrize("timezone", ["UTC", "Europe/London", "America/New_York"])
+def test_known_timezones_are_accepted(timezone: str) -> None:
+    assert Settings(timezone=timezone).timezone == timezone
+
+
+@pytest.mark.parametrize("radius", [0.0, -5.0, 20000.0])
+def test_invalid_display_radius_is_rejected(radius: float) -> None:
+    with pytest.raises(ValidationError):
+        Settings(display_radius_nm=radius)
+
+
+def test_alert_radius_none_means_unlimited() -> None:
+    assert Settings(alert_radius_nm=None).alert_radius_nm is None
+
+
+def test_zero_alert_radius_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Settings(alert_radius_nm=0.0)
+
+
+@pytest.mark.parametrize("days", [0, 6, 31, 365])
+def test_retention_window_outside_7_to_30_days_is_rejected(days: int) -> None:
+    with pytest.raises(ValidationError):
+        RetentionSettings(high_res_metric_days=days)
+
+
+@pytest.mark.parametrize("days", [7, 14, 30])
+def test_retention_window_within_range_is_accepted(days: int) -> None:
+    assert RetentionSettings(high_res_metric_days=days).high_res_metric_days == days
+
+
+def test_unknown_unit_system_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Settings(units="furlongs")  # type: ignore[arg-type]
+
+
+def test_unknown_log_level_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Settings(log_level="CHATTY")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("port", [0, -1, 70000])
+def test_invalid_receiver_port_is_rejected(port: int) -> None:
+    with pytest.raises(ValidationError):
+        ReceiverSettings(port=port)
+
+
+def test_blank_receiver_host_is_rejected() -> None:
+    with pytest.raises(ValidationError, match="blank"):
+        ReceiverSettings(host="   ")
+
+
+def test_receiver_path_must_be_absolute() -> None:
+    with pytest.raises(ValidationError, match="must start with"):
+        ReceiverSettings(path="data/aircraft.json")
+
+
+@pytest.mark.parametrize("interval", [0.0, -1.0, 61.0])
+def test_invalid_poll_interval_is_rejected(interval: float) -> None:
+    with pytest.raises(ValidationError):
+        ReceiverSettings(poll_interval_s=interval)
+
+
+def test_sighting_timings_must_increase() -> None:
+    with pytest.raises(ValidationError, match="stale_s < remove_s < close_s"):
+        SightingTimingSettings(stale_s=90.0, remove_s=60.0, close_s=600.0)
+
+
+def test_sighting_timings_in_order_are_accepted() -> None:
+    timing = SightingTimingSettings(stale_s=10.0, remove_s=45.0, close_s=300.0)
+
+    assert timing.remove_s == 45.0
+
+
+def test_range_rings_are_sorted_and_deduplicated_or_rejected() -> None:
+    assert MapSettings(range_ring_radii_nm=[200.0, 50.0]).range_ring_radii_nm == [50.0, 200.0]
+
+    with pytest.raises(ValidationError, match="unique"):
+        MapSettings(range_ring_radii_nm=[50.0, 50.0])
+
+    with pytest.raises(ValidationError, match="greater than 0"):
+        MapSettings(range_ring_radii_nm=[0.0])
+
+    with pytest.raises(ValidationError, match="at most 10"):
+        MapSettings(range_ring_radii_nm=[float(n) for n in range(1, 13)])
+
+
+def test_blank_alert_template_id_is_rejected() -> None:
+    with pytest.raises(ValidationError, match="must not be blank"):
+        AlertSettings(enabled_templates=["military", " "])
+
+
+def test_alert_template_ids_are_deduplicated() -> None:
+    alerts = AlertSettings(enabled_templates=["military", "military", " police "])
+
+    assert alerts.enabled_templates == ["military", "police"]
+
+
+def test_enrichment_requires_a_key_when_enabled() -> None:
+    with pytest.raises(ValidationError, match="requires an AeroDataBox API key"):
+        EnrichmentSettings(aerodatabox_enabled=True)
+
+
+def test_unknown_nested_key_is_rejected_by_the_model() -> None:
+    with pytest.raises(ValidationError):
+        ReceiverSettings(hostname="readsb.lan")  # type: ignore[call-arg]

--- a/backend/tests/test_config_writeback.py
+++ b/backend/tests/test_config_writeback.py
@@ -1,0 +1,204 @@
+"""Write-back tests: atomicity, stability, and secret separation on disk."""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from flightsite.config import ConfigError, ConfigStore, atomic_write_text
+
+from .conftest import SECRET_SENTINEL
+
+
+def test_saved_config_is_valid_yaml_with_a_comment_header(store: ConfigStore) -> None:
+    store.save(store.load())
+
+    text = store.config_path.read_text(encoding="utf-8")
+    assert text.startswith("# FlightSite configuration")
+
+    parsed = yaml.safe_load(text)
+    assert parsed["units"] == "aviation"
+    assert parsed["receiver"]["port"] == 8080
+
+
+def test_saved_config_round_trips_through_load(store: ConfigStore) -> None:
+    settings = store.apply_update(
+        {
+            "units": "metric",
+            "timezone": "Europe/London",
+            "location": {"latitude": 51.5, "longitude": -0.12, "site_name": "London"},
+            "alerts": {"enabled_templates": ["military", "emergency-squawk"]},
+        }
+    )
+
+    reloaded = ConfigStore(store.data_dir).load()
+
+    assert reloaded.model_dump() == settings.model_dump()
+    assert reloaded.location.site_name == "London"
+    assert reloaded.alerts.enabled_templates == ["military", "emergency-squawk"]
+
+
+def test_write_back_output_is_stable_across_repeated_saves(store: ConfigStore) -> None:
+    store.save(store.load())
+    first = store.config_path.read_text(encoding="utf-8")
+
+    for _ in range(3):
+        store.save(ConfigStore(store.data_dir).load())
+
+    assert store.config_path.read_text(encoding="utf-8") == first
+
+
+def test_write_back_uses_lf_line_endings(store: ConfigStore) -> None:
+    store.save(store.load())
+
+    assert b"\r\n" not in store.config_path.read_bytes()
+
+
+def test_write_back_creates_no_leftover_temp_files(store: ConfigStore) -> None:
+    store.save(store.load())
+    store.save(store.load())
+
+    assert sorted(p.name for p in store.data_dir.iterdir()) == ["config.yaml"]
+
+
+@pytest.mark.parametrize("failing_call", ["os.fsync", "os.replace"])
+def test_atomic_write_leaves_the_original_intact_when_writing_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failing_call: str
+) -> None:
+    """Injected failure before and after the content is on disk: the original survives."""
+    directory = tmp_path / "atomic"
+    directory.mkdir()
+    target = directory / "config.yaml"
+    original = "# original\nunits: aviation\n"
+    target.write_text(original, encoding="utf-8")
+
+    def explode(*_args: object, **_kwargs: object) -> None:
+        raise OSError("injected write failure")
+
+    monkeypatch.setattr(f"flightsite.config.loader.{failing_call}", explode)
+
+    with pytest.raises(OSError, match="injected write failure"):
+        atomic_write_text(target, "units: metric\n")
+
+    assert target.read_text(encoding="utf-8") == original
+    assert sorted(p.name for p in directory.iterdir()) == ["config.yaml"]
+
+
+def test_apply_update_leaves_files_intact_when_the_write_fails(
+    store: ConfigStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store.apply_update({"units": "metric"})
+    before = store.config_path.read_text(encoding="utf-8")
+
+    def explode(*_args: object, **_kwargs: object) -> None:
+        raise OSError("injected write failure")
+
+    monkeypatch.setattr("flightsite.config.loader.os.replace", explode)
+
+    with pytest.raises(OSError, match="injected write failure"):
+        store.apply_update({"units": "aviation"})
+
+    assert store.config_path.read_text(encoding="utf-8") == before
+    assert ConfigStore(store.data_dir).load().units == "metric"
+
+
+def test_failed_update_leaves_config_and_running_settings_untouched(store: ConfigStore) -> None:
+    store.apply_update({"display_radius_nm": 300.0})
+    before = store.config_path.read_text(encoding="utf-8")
+
+    with pytest.raises(ValidationError):
+        store.apply_update({"display_radius_nm": -1.0})
+
+    assert store.config_path.read_text(encoding="utf-8") == before
+    assert store.load().display_radius_nm == 300.0
+
+
+def test_unknown_key_in_update_is_rejected_before_writing(store: ConfigStore) -> None:
+    store.save(store.load())
+    before = store.config_path.read_text(encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="unknown configuration key"):
+        store.apply_update({"displayradius": 100})
+
+    assert store.config_path.read_text(encoding="utf-8") == before
+
+
+def test_partial_update_preserves_unrelated_settings(store: ConfigStore) -> None:
+    store.apply_update({"units": "metric", "receiver": {"host": "readsb.lan"}})
+
+    settings = store.apply_update({"receiver": {"port": 8081}})
+
+    assert settings.units == "metric"
+    assert settings.receiver.host == "readsb.lan"
+    assert settings.receiver.port == 8081
+
+
+def test_secrets_are_never_written_to_config_yaml(store: ConfigStore) -> None:
+    store.apply_update({"enrichment": {"aerodatabox_api_key": SECRET_SENTINEL}})
+
+    config_text = store.config_path.read_text(encoding="utf-8")
+    assert SECRET_SENTINEL not in config_text
+    assert "aerodatabox_api_key" not in config_text
+    assert yaml.safe_load(config_text)["enrichment"] == {"aerodatabox_enabled": False}
+
+
+def test_secrets_are_written_only_to_secrets_yaml(store: ConfigStore) -> None:
+    store.apply_update({"enrichment": {"aerodatabox_api_key": SECRET_SENTINEL}})
+
+    stored = yaml.safe_load(store.secrets_path.read_text(encoding="utf-8"))
+    assert stored == {"enrichment": {"aerodatabox_api_key": SECRET_SENTINEL}}
+
+    reloaded = ConfigStore(store.data_dir).load().enrichment.aerodatabox_api_key
+    assert reloaded is not None
+    assert reloaded.get_secret_value() == SECRET_SENTINEL
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX file modes are not meaningful on Windows"
+)
+def test_secrets_file_is_owner_only(store: ConfigStore) -> None:
+    store.apply_update({"enrichment": {"aerodatabox_api_key": SECRET_SENTINEL}})
+
+    mode = stat.S_IMODE(os.stat(store.secrets_path).st_mode)
+    assert mode == 0o600
+
+
+def test_clearing_the_last_secret_removes_the_secrets_file(store: ConfigStore) -> None:
+    store.apply_update({"enrichment": {"aerodatabox_api_key": SECRET_SENTINEL}})
+    assert store.secrets_path.exists()
+
+    store.apply_update({"enrichment": {"aerodatabox_api_key": None}})
+
+    assert not store.secrets_path.exists()
+    assert ConfigStore(store.data_dir).load().enrichment.aerodatabox_api_key is None
+
+
+def test_saving_without_any_secret_writes_no_secrets_file(store: ConfigStore) -> None:
+    store.apply_update({"units": "metric"})
+
+    assert not store.secrets_path.exists()
+
+
+def test_environment_still_outranks_a_written_value(
+    store: ConfigStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FLIGHTSITE_RECEIVER__PORT", "9999")
+
+    settings = store.apply_update({"receiver": {"port": 8081}})
+
+    assert settings.receiver.port == 9999
+    assert ConfigStore(store.data_dir).load().receiver.port == 9999
+
+
+def test_save_creates_a_missing_data_directory(tmp_path: Path) -> None:
+    store = ConfigStore(tmp_path / "nested" / "data")
+
+    store.save(store.load())
+
+    assert store.config_path.exists()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -151,7 +151,10 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyyaml" },
     { name = "structlog" },
+    { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -163,13 +166,17 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "pydantic", specifier = ">=2.9.0" },
+    { name = "pydantic-settings", specifier = ">=2.15.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "structlog", specifier = ">=24.4.0" },
+    { name = "tzdata", specifier = ">=2026.3" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
 
@@ -181,6 +188,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.7.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20260815" },
 ]
 
 [[package]]
@@ -380,6 +388,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
@@ -506,6 +528,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260815"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/72/b56089aeee6c496d969bac42376bedb6e3eeab4682e1018fa3137122f94b/types_pyyaml-6.0.12.20260815.tar.gz", hash = "sha256:28764110c9cf35846e733da32d8d734df7473c5dde9ef67c3b7332ec0e819858", size = 18545, upload-time = "2026-08-15T02:41:51.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/52/eefeba09be4ef2a1eb989eb92934561e8e502a6ee3c32654996e4be7e399/types_pyyaml-6.0.12.20260815-py3-none-any.whl", hash = "sha256:6f332212b7e191f3afd5016a713c510b6340593b7ebec573c7d5d20aa5386d3b", size = 21148, upload-time = "2026-08-15T02:41:50.555Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -524,6 +555,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,104 @@
+# FlightSite configuration — example with the built-in defaults.
+#
+# Copy to your data directory (default /opt/flightsite/data/config.yaml,
+# override with FLIGHTSITE_DATA_DIR) and edit. Every key is optional: anything
+# omitted falls back to the default shown here, so a missing config.yaml is a
+# valid first-run state rather than an error.
+#
+# Load order (later wins):
+#   1. these built-in defaults
+#   2. config.yaml            (this file — non-secret configuration)
+#   3. secrets.yaml           (secrets only; never written to config.yaml)
+#   4. FLIGHTSITE_* env vars  (nested keys use "__", e.g. FLIGHTSITE_RECEIVER__PORT=8081)
+#
+# FlightSite rewrites this file when configuration is saved from the Settings
+# UI. The output is clean and stable, but comments are not preserved.
+#
+# Units are nautical miles / feet / knots unless `units: metric` is set; that
+# setting affects display only — storage and the API stay canonical (nm/ft/kt,
+# UTC timestamps).
+
+# Backend log level: CRITICAL, ERROR, WARNING, INFO or DEBUG.
+log_level: INFO
+
+# Display unit system: "aviation" (nm/ft/kt) or "metric" (km/m/km-h).
+units: aviation
+
+# IANA timezone used to render receiver-local times in the UI.
+# Examples: Europe/London, America/New_York, Australia/Sydney.
+timezone: UTC
+
+# Live-map display radius in nautical miles. Detections beyond it are still
+# stored and still count toward range records and analytics.
+display_radius_nm: 250.0
+
+# Alert radius in nautical miles. null means unlimited: alerts fire regardless
+# of distance from the receiver.
+alert_radius_nm: null
+
+# ADS-B decoder (readsb / dump1090-fa) HTTP JSON endpoint.
+receiver:
+  host: 127.0.0.1
+  port: 8080
+  # Path to the aircraft JSON document. tar1090 installs commonly use
+  # /data/aircraft.json; some setups use /tar1090/data/aircraft.json.
+  path: /data/aircraft.json
+  # Poll period in seconds. The decoder publishes at roughly 1 Hz.
+  poll_interval_s: 1.0
+
+# Receiver location: the reference point for bearing, distance, range rings,
+# closest approach, farthest detection, coverage analytics and alert radius.
+# Set latitude and longitude together, or leave both null (the setup wizard
+# collects them on first run).
+location:
+  latitude: null
+  longitude: null
+  site_name: null
+  antenna_height_ft: null
+
+# Sighting lifecycle timing, in seconds. Must increase:
+# stale_s < remove_s < close_s.
+sighting:
+  # No update for this long: the aircraft is shown as stale.
+  stale_s: 15.0
+  # No update for this long: the aircraft is dropped from the live map.
+  remove_s: 60.0
+  # No update for this long: the current sighting is closed and persisted.
+  close_s: 600.0
+
+# Retention policy. Sightings, tracks and lifetime statistics are kept
+# indefinitely; only high-resolution receiver telemetry is pruned.
+retention:
+  # Days of high-resolution receiver metrics to keep before downsampling.
+  # Valid range: 7-30.
+  high_res_metric_days: 14
+
+map:
+  # Basemap style id from the basemap registry.
+  basemap: dark-aviation
+  range_rings_enabled: true
+  # Range ring radii in nautical miles (up to 10, unique, sorted on save).
+  range_ring_radii_nm:
+    - 50.0
+    - 100.0
+    - 150.0
+    - 200.0
+
+# Optional online route enrichment (AeroDataBox). FlightSite works fully
+# without it. The API key is a SECRET: put it in secrets.yaml or set
+# FLIGHTSITE_ENRICHMENT__AERODATABOX_API_KEY — never in this file.
+enrichment:
+  aerodatabox_enabled: false
+
+# Browser notifications, enabled per alert severity.
+notifications:
+  enabled: true
+  info: false
+  interesting: true
+  high: true
+  critical: true
+
+alerts:
+  # Ids of the shipped alert templates to instantiate. Chosen during first-run
+  # setup; empty means no alert templates are enabled.
+  enabled_templates: []

--- a/docs/API.md
+++ b/docs/API.md
@@ -469,7 +469,7 @@ config/domain models the backend uses.
 | Group | Endpoints (sketch) | Slice |
 |---|---|---|
 | Setup / first-run | `GET /setup/state`, `POST /setup/complete` | 018 |
-| Config | `GET /config` (secrets masked as `"•••" + last4`), `PUT /config` (masked values ignored unless replaced; secrets never echoed back) | 004/019 |
+| Config | `GET /config` (secrets fully masked as `"•••"`; per-secret set/unset reported via `secrets_set`), `PUT /config` (masked values ignored unless replaced; secrets never echoed back) | 004/019 |
 | Connection test | `POST /decoder/test` → reachability, parse result, sample aircraft count | 007/018 |
 | Watchlists | `GET/POST /watchlists`, `PUT/DELETE /watchlists/{id}`, entries CRUD | 037 |
 | Alert rules | `GET/POST /alert-rules`, `PUT/DELETE /alert-rules/{id}`, `GET /alert-templates` | 038/041 |

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -187,7 +187,7 @@ slices:
     title: "Configuration system"
     phase: 1
     branch: "004-config-system"
-    status: planned
+    status: merged
     depends_on: ["001"]
     objective: "Implement the canonical config.yaml / secrets.yaml / environment-override configuration model."
     scope:


### PR DESCRIPTION
## Slice
- **Slice ID:** 004 — Configuration system
- **Roadmap:** `planning/roadmap.yaml` slice 004 (phase 1)
- **Issue:** Closes #4

## Objective
Canonical config.yaml / secrets.yaml / environment-override configuration model.

## Implementation summary
- `flightsite.config`: pydantic-settings model covering all SPEC §30 areas with Phase 0 defaults (nm/ft/kt, 15/60/600 lifecycle, 250 NM display radius, unlimited alert radius, 14-day metric window, alerts.enabled_templates)
- Precedence defaults < config.yaml < secrets.yaml < FLIGHTSITE_* env (`__` nesting); FLIGHTSITE_DATA_DIR resolution (default /opt/flightsite/data)
- Secrets: SecretStr, discovered by type; `dump_public()` masks fully ("•••", no last-4 — safer than the API.md sketch, doc reconciled); secrets.yaml written 0600, removed when empty; masked value in PUT means unchanged
- Atomic write-back (mkstemp → fsync → os.replace; failure injection leaves original intact); unknown-key rejection with helpful listing
- `/api/internal/config` GET/PUT (excluded from OpenAPI; validation errors never echo rejected input); create_app loads settings onto app.state
- config.example.yaml with drift-guard test

## Acceptance criteria
- [x] missing config.yaml → valid defaults + first_run
- [x] env overrides file values; secrets from secrets.yaml and env
- [x] clean stable YAML write-back
- [x] secret masking verified (sentinel sweeps of repr/dumps/config.yaml/API/logs, with a loaded-sentinel guard test)

## Tests added/run
144 passed, 1 skipped (POSIX file-mode on Windows). Coverage **97.89%**; config package 100%. Reviewer re-ran all gates independently.

## Performance considerations
Config loads once at startup; API writes are rare and atomic.

## Security considerations
Core SPEC §29 slice: masking, 0600 secrets file, no echo in validation errors, log fields limited to key paths.

## Data/migration considerations
None (no DB yet).

## Documentation updates
API.md §5 mask description reconciled to full masking + secrets_set.

## Known limitations
Env-pinned values are materialized into config.yaml on write-back (env still wins on load; tested + documented).

## Follow-up work
Slice 019 consumes secrets_set for configured/not-configured UI.

## Fable self-review (SPEC §104)
- [x] Full diff inspected; scope exact; tests meaningful incl. failure injection; no TODO/FIXME; secrets provably absent from outputs
- [x] Branch reconciled with dev (merge from origin/dev, no conflicts)
- [ ] CI green on this PR (gate before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)