### PR TITLE
Slice 011: Demo mode

### DIFF
--- a/backend/src/flightsite/api/v1.py
+++ b/backend/src/flightsite/api/v1.py
@@ -29,6 +29,11 @@ async def health(request: Request) -> dict[str, Any]:
         "version": __version__,
         "uptime_s": round(uptime_s, 3),
         "counters": counters.snapshot(),
+        # True when ingestion is simulated traffic (FLIGHTSITE_DEMO=1, slice
+        # 011) rather than a real decoder — surfaced so the UI and support
+        # requests can tell "no real hardware attached" apart from "decoder
+        # is down" at a glance.
+        "demo": request.app.state.demo_enabled,
     }
 
 

--- a/backend/src/flightsite/app.py
+++ b/backend/src/flightsite/app.py
@@ -16,6 +16,7 @@ from flightsite.api.v1 import router as v1_router
 from flightsite.config import ConfigStore, Settings
 from flightsite.db import Database, database_path, initialize_database
 from flightsite.db.startup import DATABASE_SUBSYSTEM
+from flightsite.demo import DEFAULT_CENTER, DemoAdapter, demo_enabled
 from flightsite.ingest import DecoderEndpoint, IngestionService, Position, build_ingestion_service
 from flightsite.live import LiveStore
 from flightsite.logging import configure_logging
@@ -64,6 +65,12 @@ async def _start_ingestion(app: FastAPI) -> IngestionService | None:
     setup wizard has even been opened, so ingestion is skipped and starts on
     the next boot after a configuration is saved.
 
+    Demo mode (``FLIGHTSITE_DEMO=1``, slice 011) is the one exception: it
+    starts :class:`~flightsite.demo.DemoAdapter` regardless of first-run
+    state, because demo mode's whole purpose is a full stack with zero
+    configuration (SPEC §76). A receiver location is injected into the live
+    store when none is configured, so distance and bearing still compute.
+
     The live store is the sole consumer: every normalized batch goes straight
     into the in-memory registry, and nothing on this path touches the database
     (``docs/ARCHITECTURE.md`` §3.1).
@@ -71,12 +78,24 @@ async def _start_ingestion(app: FastAPI) -> IngestionService | None:
     Decoder health deliberately never affects ``/ready``; the reasoning is in
     :mod:`flightsite.ingest.service`.
     """
+    live: LiveStore = app.state.live
+
+    if demo_enabled():
+        if live.receiver_location is None:
+            live.set_receiver_location(DEFAULT_CENTER)
+        service = IngestionService(
+            DemoAdapter(center=live.receiver_location),
+            readiness=app.state.readiness,
+            consumers=(live.apply,),
+        )
+        await service.start()
+        return service
+
     store: ConfigStore = app.state.config_store
     if store.first_run:
         logger.info("ingestion_skipped", reason="first_run")
         return None
 
-    live: LiveStore = app.state.live
     service = build_ingestion_service(
         _decoder_endpoint(app.state.settings),
         readiness=app.state.readiness,
@@ -165,6 +184,10 @@ def create_app(data_dir: str | os.PathLike[str] | None = None) -> FastAPI:
     # instead of guarding every access. Constructing it starts nothing.
     app.state.live = _build_live_store(settings)
     app.state.start_time = time.monotonic()
+    # Read once at app-construction time, not per-request: demo mode is a
+    # process-level run mode (FLIGHTSITE_DEMO), not something that changes
+    # while the app is up.
+    app.state.demo_enabled = demo_enabled()
 
     app.include_router(v1_router, prefix="/api/v1")
     # /api/internal is an unsupported, unversioned surface (ADR-0007) and is

--- a/backend/src/flightsite/demo/__init__.py
+++ b/backend/src/flightsite/demo/__init__.py
@@ -1,0 +1,53 @@
+"""Deterministic demo/mock decoder traffic (SPEC §76, ``docs/ARCHITECTURE.md`` §3.5).
+
+Module map:
+
+=================================== ==========================================
+Module                              Responsibility
+=================================== ==========================================
+:mod:`~flightsite.demo.motion`      closed-form position/altitude integration
+:mod:`~flightsite.demo.roster`      the seeded, deterministic aircraft roster
+:mod:`~flightsite.demo.scenario`    tick index -> decoder batch (pure)
+:mod:`~flightsite.demo.adapter`     :class:`DemoAdapter`, the ``DecoderAdapter``
+:mod:`~flightsite.demo.env`         the ``FLIGHTSITE_DEMO`` activation flag
+=================================== ==========================================
+
+:class:`DemoAdapter` implements :class:`~flightsite.ingest.protocol.DecoderAdapter`
+(ADR-0003): it is a drop-in replacement for
+:class:`~flightsite.ingest.readsb.ReadsbJsonAdapter` that needs no decoder, no
+network and no configuration, generating a rotating population of commercial,
+military, government, police, non-positioned Mode S, MLAT, rare, first-ever
+and ground traffic — including an emergency-squawk event — deterministically
+from a seed.
+"""
+
+from __future__ import annotations
+
+from flightsite.demo.adapter import (
+    DEFAULT_CENTER,
+    DEFAULT_POPULATION,
+    DEFAULT_SEED,
+    TICK_INTERVAL_S,
+    DemoAdapter,
+)
+from flightsite.demo.env import DEMO_ENV_VAR, demo_enabled
+from flightsite.demo.roster import PERIOD_S, AircraftProfile, Category, EmergencyEvent, build_roster
+from flightsite.demo.scenario import SCENARIO_EPOCH, batch_at, update_at
+
+__all__ = [
+    "DEFAULT_CENTER",
+    "DEFAULT_POPULATION",
+    "DEFAULT_SEED",
+    "DEMO_ENV_VAR",
+    "PERIOD_S",
+    "SCENARIO_EPOCH",
+    "TICK_INTERVAL_S",
+    "AircraftProfile",
+    "Category",
+    "DemoAdapter",
+    "EmergencyEvent",
+    "batch_at",
+    "build_roster",
+    "demo_enabled",
+    "update_at",
+]

--- a/backend/src/flightsite/demo/adapter.py
+++ b/backend/src/flightsite/demo/adapter.py
@@ -1,0 +1,192 @@
+"""``DemoAdapter`` — a deterministic, in-process ``DecoderAdapter`` (SPEC §76).
+
+Implements the seam :mod:`flightsite.ingest.protocol` draws (ADR-0003): the
+live store, sightings, alerts and analytics consume this exactly like a
+polled readsb decoder, and never know the difference. There is no decoder to
+lose, so :meth:`DemoAdapter.health` reports ``connected`` from the first
+batch onward — that is the truthful state for a simulation, and it is what
+lets the health endpoint show a healthy decoder with no hardware attached
+(SPEC §76: "demo mode runs the full stack with no decoder and no internet").
+
+All the scenario content lives in :mod:`flightsite.demo.roster` (who flies)
+and :mod:`flightsite.demo.scenario` (what they are doing at any tick); this
+module is only the ``DecoderAdapter`` plumbing around
+:func:`~flightsite.demo.scenario.batch_at` — turning elapsed clock time into
+a tick index and yielding the batch that tick produces.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import replace
+from datetime import UTC, datetime
+from typing import Final
+
+import structlog
+
+from flightsite.demo.roster import AircraftProfile, build_roster
+from flightsite.demo.scenario import batch_at
+from flightsite.ingest.health import AdapterHealth, HealthState
+from flightsite.ingest.types import AircraftStateBatch, Position
+
+logger = structlog.get_logger(__name__)
+
+#: A busy central-US airspace crossroads, chosen only because it puts a
+#: realistic amount of overflying traffic within a few hundred nm of some
+#: point — not tied to any real receiver. Used when demo mode is active and
+#: no receiver location has been configured (SPEC §76: demo mode works with
+#: zero configuration).
+DEFAULT_CENTER: Final = Position(latitude=39.8283, longitude=-98.5795)
+
+#: Arbitrary but fixed: what matters for determinism is that it never
+#: changes, not what it is.
+DEFAULT_SEED: Final = 20260831
+
+#: Target concurrent aircraft count — roadmap slice 011: "~40-80 concurrent".
+DEFAULT_POPULATION: Final = 60
+
+#: The product's 1 Hz decoder cadence.
+TICK_INTERVAL_S: Final = 1.0
+
+
+class DemoAdapter:
+    """Deterministic simulated decoder traffic (SPEC §76, ADR-0003).
+
+    Every batch is computed by :func:`flightsite.demo.scenario.batch_at` from
+    the roster built at construction time and the *elapsed* tick index alone
+    — nothing about a previous tick is remembered. Two adapters built with
+    the same ``seed`` therefore produce identical batches for the same tick
+    index, and the same adapter re-asked for an old tick gets the same answer
+    back (roadmap acceptance criterion: "two runs with the same seed produce
+    identical update sequences").
+
+    Args:
+        seed: seeds every random decision in the roster (aircraft identity,
+            callsigns, flight parameters). The same seed always builds the
+            same roster.
+        population: target concurrent aircraft count; see
+            :mod:`flightsite.demo.roster` for how the roster is sized from
+            it. Scales from a handful up to several hundred for perf work.
+        center: the point cruise and local traffic is generated around —
+            normally the configured receiver location. Defaults to
+            :data:`DEFAULT_CENTER` so demo mode works with no configuration
+            at all.
+        clock: monotonic seconds source the tick index is derived from;
+            injectable so tests can drive many simulated ticks without real
+            delay. Defaults to :func:`time.monotonic`.
+        sleep: awaited between polls; injectable for the same reason.
+        tick_interval_s: simulated seconds per tick — the 1 Hz product
+            cadence by default.
+    """
+
+    def __init__(
+        self,
+        *,
+        seed: int = DEFAULT_SEED,
+        population: int = DEFAULT_POPULATION,
+        center: Position | None = None,
+        clock: Callable[[], float] | None = None,
+        sleep: Callable[[float], Awaitable[None]] | None = None,
+        tick_interval_s: float = TICK_INTERVAL_S,
+    ) -> None:
+        if tick_interval_s <= 0.0:
+            raise ValueError("tick_interval_s must be greater than zero")
+        self._seed = seed
+        self._center = center if center is not None else DEFAULT_CENTER
+        self._roster: tuple[AircraftProfile, ...] = build_roster(
+            seed=seed, population=population, center=self._center
+        )
+        self._clock = clock if clock is not None else time.monotonic
+        self._sleep = sleep if sleep is not None else asyncio.sleep
+        self._tick_interval_s = tick_interval_s
+        self._stopped = True
+        self._start_clock = 0.0
+        self._health = AdapterHealth()
+
+    @property
+    def seed(self) -> int:
+        """The seed the roster was built from."""
+        return self._seed
+
+    @property
+    def center(self) -> Position:
+        """The point traffic is generated around."""
+        return self._center
+
+    @property
+    def roster(self) -> tuple[AircraftProfile, ...]:
+        """The deterministic aircraft roster this session is driving."""
+        return self._roster
+
+    def batch_for_tick(self, tick_index: int) -> AircraftStateBatch:
+        """The batch at ``tick_index`` — a pure function of ``(seed, tick_index)``.
+
+        Exposed directly (not only through :meth:`updates`) so determinism
+        and scenario-coverage tests can drive many ticks instantly, without
+        running the async loop or a clock at all.
+        """
+        return batch_at(self._roster, tick_index)
+
+    async def start(self) -> None:
+        """Mark the scenario clock started. Does not yield anything by itself."""
+        self._stopped = False
+        self._start_clock = self._clock()
+        logger.info(
+            "demo_adapter_started",
+            seed=self._seed,
+            population=len(self._roster),
+            center_lat=self._center.latitude,
+            center_lon=self._center.longitude,
+        )
+
+    async def stop(self) -> None:
+        """Stop the scenario. Idempotent."""
+        self._stopped = True
+        self._health = replace(self._health, state=HealthState.DOWN)
+        logger.info("demo_adapter_stopped")
+
+    def health(self) -> AdapterHealth:
+        """Return the current (always-connected-once-started) health snapshot."""
+        return self._health
+
+    async def updates(self) -> AsyncIterator[AircraftStateBatch]:
+        """Yield one batch per elapsed tick until stopped.
+
+        The tick index is derived from ``clock() - start_clock``, not from a
+        loop counter: a slow consumer that misses a tick's real-time window
+        simply sees the scenario jump forward to the tick that elapsed time
+        now maps to — the same way a real decoder poll would, and still an
+        exact function of ``(seed, tick_index)`` for whatever tick is served.
+        """
+        last_tick_index = -1
+        while not self._stopped:
+            elapsed = max(0.0, self._clock() - self._start_clock)
+            tick_index = int(elapsed / self._tick_interval_s)
+            if tick_index != last_tick_index:
+                last_tick_index = tick_index
+                self._mark_connected()
+                yield self.batch_for_tick(tick_index)
+            await self._sleep(self._tick_interval_s)
+
+    def _mark_connected(self) -> None:
+        self._health = replace(
+            self._health,
+            state=HealthState.CONNECTED,
+            consecutive_failures=0,
+            failures_since_success=0,
+            total_successes=self._health.total_successes + 1,
+            last_success=datetime.now(UTC),
+            last_error=None,
+            next_retry_delay_s=None,
+        )
+
+
+__all__ = [
+    "DEFAULT_CENTER",
+    "DEFAULT_POPULATION",
+    "DEFAULT_SEED",
+    "TICK_INTERVAL_S",
+    "DemoAdapter",
+]

--- a/backend/src/flightsite/demo/env.py
+++ b/backend/src/flightsite/demo/env.py
@@ -1,0 +1,39 @@
+"""Demo mode activation: the ``FLIGHTSITE_DEMO`` environment flag.
+
+Kept env-only, deliberately not a field on
+:class:`flightsite.config.models.Settings`: demo mode is a run-mode switch an
+operator flips for a container or a development shell, not a persisted
+preference a user sets through the config API, and it must work before any
+``config.yaml`` exists (SPEC §76: "demo mode runs the full stack with no
+decoder and no internet" — including on a first run). Reading it directly
+here, rather than threading it through the settings model, keeps the config
+schema untouched by this slice.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+#: Values that turn demo mode on, compared case-insensitively.
+_TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
+
+#: The environment variable itself, named once so app wiring and tests never
+#: hand-spell it differently.
+DEMO_ENV_VAR = "FLIGHTSITE_DEMO"
+
+
+def demo_enabled(environ: Mapping[str, str] | None = None) -> bool:
+    """True when ``FLIGHTSITE_DEMO`` is set to a truthy value.
+
+    Args:
+        environ: overrides the source of environment variables; defaults to
+            ``os.environ``. Tests pass an explicit mapping rather than
+            monkeypatching the process environment when they want isolation
+            without touching global state.
+    """
+    source = environ if environ is not None else os.environ
+    return source.get(DEMO_ENV_VAR, "").strip().lower() in _TRUTHY_VALUES
+
+
+__all__ = ["DEMO_ENV_VAR", "demo_enabled"]

--- a/backend/src/flightsite/demo/motion.py
+++ b/backend/src/flightsite/demo/motion.py
@@ -1,0 +1,150 @@
+"""Closed-form, deterministic motion for demo-mode aircraft.
+
+Every position the demo scenario ever reports is computed directly from
+*elapsed seconds since spawn* — never by iterating a simulation step by step
+and accumulating state. That is what keeps
+:func:`~flightsite.demo.scenario.state_at` a pure function of
+``(seed, tick_index)``: two adapters built from the same seed produce bit-
+identical output for tick 400 without ever having computed ticks 0-399.
+
+Constant-turn-rate flight model
+--------------------------------
+
+An aircraft flies at constant true airspeed ``speed_kt`` on a heading that
+turns at a constant rate ``turn_rate_deg_s`` (``0`` for a straight leg, a
+small value for a gentle en-route drift, a larger value for a loitering
+orbit). That is a textbook constant-radius turn, which has an exact closed
+form in local East/North coordinates:
+
+.. math::
+
+    E(t) - E_0 = \\frac{v}{\\omega} \\left( \\cos\\theta_0 - \\cos\\theta(t) \\right)
+
+    N(t) - N_0 = \\frac{v}{\\omega} \\left( \\sin\\theta(t) - \\sin\\theta_0 \\right)
+
+with :math:`\\theta(t) = \\theta_0 + \\omega t`, :math:`v` the speed and
+:math:`\\omega` the turn rate in radians/second. As :math:`\\omega \\to 0`
+this reduces to the straight-line case, which is computed directly to avoid
+a division by (near) zero.
+
+Local coordinates are converted to latitude/longitude with a flat-earth
+approximation (nautical miles / 60 = degrees latitude; longitude scaled by
+``cos(latitude)``). Demo positions are for visualization, not measurement —
+``flightsite.live.geo`` remains the only geodesy the rest of the system
+relies on — so the small distortion this introduces at long range is an
+acceptable trade for a simple, exact, continuous function of time.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Final
+
+from flightsite.ingest.types import Position
+
+#: Nautical miles per degree of latitude (and, at the equator, of longitude).
+NM_PER_DEGREE_LATITUDE: Final = 60.0
+
+#: Below this angular rate a turn is treated as a straight line: the exact
+#: formula's ``v/omega`` term would otherwise blow up for no visible benefit
+#: (a radius that many thousands of nautical miles is indistinguishable from
+#: straight over any demo aircraft's active window).
+STRAIGHT_LINE_THRESHOLD_DEG_S: Final = 1e-6
+
+
+def _clamp_latitude(latitude: float) -> float:
+    return max(-90.0, min(90.0, latitude))
+
+
+def _wrap_longitude(longitude: float) -> float:
+    return ((longitude + 180.0) % 360.0) - 180.0
+
+
+def offset_position(origin: Position, *, distance_nm: float, bearing_deg: float) -> Position:
+    """Return the point ``distance_nm`` from ``origin`` on ``bearing_deg``.
+
+    A flat-earth approximation, deliberately: this builds scenario geometry
+    (start points, orbit centers), not a distance a user will read off the
+    UI. It is the exact inverse of the East/North displacement
+    :func:`position_at` integrates, which keeps the whole module internally
+    consistent.
+    """
+    bearing_rad = math.radians(bearing_deg)
+    north_nm = distance_nm * math.cos(bearing_rad)
+    east_nm = distance_nm * math.sin(bearing_rad)
+    return _displace(origin, east_nm=east_nm, north_nm=north_nm)
+
+
+def _displace(origin: Position, *, east_nm: float, north_nm: float) -> Position:
+    latitude = origin.latitude + north_nm / NM_PER_DEGREE_LATITUDE
+    cos_lat = math.cos(math.radians(origin.latitude))
+    # A demo center within a few hundred nm of a pole is not a scenario this
+    # module needs to support; guard only against literal division by zero.
+    divisor = cos_lat if abs(cos_lat) > 1e-9 else 1e-9
+    longitude = origin.longitude + east_nm / (NM_PER_DEGREE_LATITUDE * divisor)
+    return Position(latitude=_clamp_latitude(latitude), longitude=_wrap_longitude(longitude))
+
+
+def position_at(
+    start: Position,
+    *,
+    heading_deg: float,
+    speed_kt: float,
+    turn_rate_deg_s: float,
+    age_s: float,
+) -> tuple[Position, float]:
+    """Return ``(position, heading_deg)`` after ``age_s`` seconds of flight.
+
+    ``age_s`` is seconds since the aircraft started this leg (its spawn tick)
+    — the sole time-varying input, which is what makes the result a pure
+    function of elapsed time for a fixed profile.
+    """
+    speed_nm_s = speed_kt / 3600.0
+    heading0_rad = math.radians(heading_deg)
+    omega = math.radians(turn_rate_deg_s)
+
+    if abs(turn_rate_deg_s) < STRAIGHT_LINE_THRESHOLD_DEG_S:
+        east_nm = speed_nm_s * age_s * math.sin(heading0_rad)
+        north_nm = speed_nm_s * age_s * math.cos(heading0_rad)
+        heading_now = heading_deg % 360.0
+    else:
+        heading_now_rad = heading0_rad + omega * age_s
+        radius = speed_nm_s / omega
+        east_nm = radius * (math.cos(heading0_rad) - math.cos(heading_now_rad))
+        north_nm = radius * (math.sin(heading_now_rad) - math.sin(heading0_rad))
+        heading_now = math.degrees(heading_now_rad) % 360.0
+
+    return _displace(start, east_nm=east_nm, north_nm=north_nm), heading_now
+
+
+def altitude_at(
+    *,
+    base_altitude_ft: float,
+    climb_fpm: float,
+    age_s: float,
+    min_altitude_ft: float,
+    max_altitude_ft: float,
+) -> tuple[float, float]:
+    """Return ``(altitude_ft, vertical_rate_fpm)`` after ``age_s`` seconds.
+
+    A linear climb/descent from ``base_altitude_ft`` at ``climb_fpm``,
+    clamped to ``[min_altitude_ft, max_altitude_ft]``. Once clamped the
+    reported vertical rate drops to ``0.0`` — the aircraft has leveled off,
+    which is the truthful reading at that instant, not a discontinuity in the
+    underlying model.
+    """
+    altitude = base_altitude_ft + (climb_fpm / 60.0) * age_s
+    if altitude >= max_altitude_ft:
+        return max_altitude_ft, 0.0
+    if altitude <= min_altitude_ft:
+        return min_altitude_ft, 0.0
+    return altitude, climb_fpm
+
+
+__all__ = [
+    "NM_PER_DEGREE_LATITUDE",
+    "STRAIGHT_LINE_THRESHOLD_DEG_S",
+    "altitude_at",
+    "offset_position",
+    "position_at",
+]

--- a/backend/src/flightsite/demo/roster.py
+++ b/backend/src/flightsite/demo/roster.py
@@ -1,0 +1,665 @@
+"""The demo scenario's aircraft roster: who flies, and how.
+
+:func:`build_roster` is the *only* place randomness enters demo mode. It
+consumes a single seeded :class:`random.Random` in a fixed, deterministic
+order and produces a tuple of immutable :class:`AircraftProfile` values —
+identity, callsign, category and flight-model parameters. Everything after
+that (:mod:`flightsite.demo.scenario`) is arithmetic on ``age_s``, so the same
+seed always builds the same roster and the same roster always produces the
+same batches.
+
+Population and rotation
+------------------------
+
+``population`` is the *target concurrent count* the caller asks for, not the
+roster size. Aircraft do not stay live forever — a rotating population is
+part of the product requirement (SPEC §76) — so the roster is built larger
+than ``population`` by :data:`ROSTER_MULTIPLIER`, and each profile is only
+"on the air" for a fraction of :data:`~flightsite.demo.scenario.PERIOD_S`.
+With the category duty cycles below, the *expected* number of simultaneously
+transmitting aircraft lands close to ``population``; it is a deliberately
+approximate target (the roadmap calls for "~40-80"), not a hard bound.
+
+Category coverage
+------------------
+
+Every :class:`Category` gets at least one profile scheduled to spawn within
+the scenario's first :data:`EARLY_SPAWN_WINDOW_S` seconds, so the "all
+scenario types observable within the first simulated 10 minutes" acceptance
+criterion holds regardless of population size or random chance. The bulk of
+the roster (mostly :attr:`Category.COMMERCIAL`) spawns throughout the whole
+period, which is what gives the population its ongoing rotation.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Final
+
+from flightsite.demo.motion import offset_position
+from flightsite.ingest.types import Position, PositionSource
+
+#: How much larger the roster is than the requested concurrent population, to
+#: account for aircraft that are only transmitting part of the time. See the
+#: module docstring.
+ROSTER_MULTIPLIER: Final = 1.7
+
+#: Aircraft guaranteed to cover every required category spawn within this
+#: many simulated seconds, satisfying "all types within the first 10
+#: simulated minutes" (SPEC §76) independent of population size.
+EARLY_SPAWN_WINDOW_S: Final = 420
+
+#: The rotation period: profiles repeat with this cadence forever. 30 minutes
+#: is long enough that a profile's active window (a few minutes to half an
+#: hour) and its off-air gap both read as a real aircraft's visit rather than
+#: a loop, while ``EARLY_SPAWN_WINDOW_S`` keeps category coverage in the
+#: first 10 minutes of *every* period, not just the first.
+PERIOD_S: Final = 1800
+
+#: Receiver-relative distance band cruise traffic starts within (nm) — far
+#: enough out to look like it is genuinely crossing the display area.
+CRUISE_START_RANGE_NM: Final = (60.0, 230.0)
+
+#: Distance band low-altitude local traffic (police, ground) starts within.
+LOCAL_START_RANGE_NM: Final = (1.0, 12.0)
+
+
+class Category(StrEnum):
+    """The scenario's aircraft categories — SPEC §76's coverage list."""
+
+    COMMERCIAL = "commercial"
+    MILITARY = "military"
+    GOVERNMENT = "government"
+    POLICE = "police"
+    # The value below deliberately avoids readsb's own `type` vocabulary
+    # (ADR-0003, tests/ingest/test_no_field_leakage.py), which is reserved to
+    # ingest/readsb.py even for an unrelated domain value spelled the same.
+    MODE_S = "mode_s_only"
+    MLAT = "mlat"
+    GROUND = "ground"
+    RARE = "rare"
+    FIRST_EVER = "first_ever"
+
+
+@dataclass(frozen=True, slots=True)
+class EmergencyEvent:
+    """A temporary squawk override applied within an aircraft's active window."""
+
+    squawk: str
+    start_offset_s: float
+    duration_s: float
+
+
+@dataclass(frozen=True, slots=True)
+class AircraftProfile:
+    """Everything :mod:`flightsite.demo.scenario` needs to compute one
+    aircraft's state at any tick — built once, read many times.
+    """
+
+    icao: str
+    callsign: str | None
+    category: Category
+    position_source: PositionSource
+
+    #: Tick within :data:`PERIOD_S` at which this aircraft starts transmitting.
+    spawn_tick: int
+    #: How many ticks it stays on the air before falling silent.
+    active_ticks: int
+    #: Only active on periods where ``loop % rare_loop_modulus == 0``; ``1``
+    #: means every period.
+    rare_loop_modulus: int
+    #: Only active during the scenario's first period (``loop == 0``) —
+    #: the "appears once, ever" first-contact aircraft.
+    once: bool
+
+    #: ``None`` for aircraft that never report a position (Mode S only).
+    start: Position | None
+    heading_deg: float
+    speed_kt: float
+    turn_rate_deg_s: float
+    reports_speed_and_track: bool
+
+    #: ``None`` for on-ground aircraft, which report no barometric altitude.
+    base_altitude_ft: float | None
+    climb_fpm: float
+    min_altitude_ft: float
+    max_altitude_ft: float
+
+    on_ground: bool
+    squawk: str
+    rssi_db: float
+    emergency: EmergencyEvent | None = None
+
+
+AIRLINE_CALLSIGN_PREFIXES: Final[tuple[str, ...]] = (
+    "DAL",
+    "UAL",
+    "AAL",
+    "SWA",
+    "JBU",
+    "ASA",
+    "FFT",
+    "NKS",
+    "BAW",
+    "DLH",
+    "AFR",
+    "KLM",
+    "UAE",
+    "ACA",
+    "QFA",
+    "VIR",
+)
+
+MILITARY_CALLSIGN_PREFIXES: Final[tuple[str, ...]] = (
+    "RCH",
+    "CNV",
+    "HAWG",
+    "VIPER",
+    "REDEYE",
+    "TOGA",
+    "GRZLY",
+    "SENTRY",
+)
+
+#: Realistic Air Force / heavy-lift altitude blocks (SPEC §76: "blocks at
+#: varied altitudes").
+MILITARY_ALTITUDE_BLOCKS_FT: Final[tuple[float, ...]] = (
+    3_000.0,
+    5_000.0,
+    8_000.0,
+    12_000.0,
+    18_000.0,
+    25_000.0,
+    33_000.0,
+    41_000.0,
+)
+
+GOVERNMENT_CALLSIGN_PREFIXES: Final[tuple[str, ...]] = ("CBP", "NASA", "USFS", "EXEC", "GLEX")
+
+POLICE_CALLSIGN_PREFIXES: Final[tuple[str, ...]] = ("METRO", "AIR", "SHERIFF", "STAR", "EAGLE")
+
+GENERAL_AVIATION_SUFFIXES: Final[tuple[str, ...]] = ("", "A", "B", "CJ", "QS", "XP", "TV", "MD")
+
+
+def _airline_callsign(rng: random.Random) -> str:
+    prefix = rng.choice(AIRLINE_CALLSIGN_PREFIXES)
+    return f"{prefix}{rng.randint(1, 3999)}"
+
+
+def _military_callsign(rng: random.Random) -> str:
+    prefix = rng.choice(MILITARY_CALLSIGN_PREFIXES)
+    return f"{prefix}{rng.randint(1, 999)}"
+
+
+def _government_callsign(rng: random.Random) -> str:
+    prefix = rng.choice(GOVERNMENT_CALLSIGN_PREFIXES)
+    return f"{prefix}{rng.randint(1, 99)}"
+
+
+def _police_callsign(rng: random.Random) -> str:
+    prefix = rng.choice(POLICE_CALLSIGN_PREFIXES)
+    return f"{prefix}{rng.randint(1, 20)}"
+
+
+def _general_aviation_callsign(rng: random.Random) -> str:
+    suffix = rng.choice(GENERAL_AVIATION_SUFFIXES)
+    return f"N{rng.randint(1, 999)}{suffix}"
+
+
+def _octal_squawk(rng: random.Random) -> str:
+    if rng.random() < 0.4:
+        return "1200"
+    return f"{rng.randint(0, 7)}{rng.randint(0, 7)}{rng.randint(0, 7)}{rng.randint(0, 7)}"
+
+
+def _unique_icao(rng: random.Random, used: set[str]) -> str:
+    while True:
+        candidate = f"{rng.getrandbits(24):06x}"
+        if candidate not in used:
+            used.add(candidate)
+            return candidate
+
+
+def _cruise_start(rng: random.Random, center: Position) -> tuple[Position, float]:
+    """Pick a start point on the fringe of the area, heading roughly inward.
+
+    Returns ``(start, heading_deg)``. The heading points toward the center
+    plus jitter, so tracks read as crossing traffic rather than every leg
+    converging on one exact point (SPEC §76: "great-circle-ish tracks
+    crossing the area").
+    """
+    distance = rng.uniform(*CRUISE_START_RANGE_NM)
+    bearing_from_center = rng.uniform(0.0, 360.0)
+    start = offset_position(center, distance_nm=distance, bearing_deg=bearing_from_center)
+    heading_to_center = (bearing_from_center + 180.0) % 360.0
+    heading = (heading_to_center + rng.uniform(-40.0, 40.0)) % 360.0
+    return start, heading
+
+
+def _local_start(rng: random.Random, center: Position) -> Position:
+    distance = rng.uniform(*LOCAL_START_RANGE_NM)
+    bearing = rng.uniform(0.0, 360.0)
+    return offset_position(center, distance_nm=distance, bearing_deg=bearing)
+
+
+def _spawn_schedule(
+    rng: random.Random, *, early: bool, active_range_s: tuple[int, int]
+) -> tuple[int, int]:
+    """Return ``(spawn_tick, active_ticks)`` within :data:`PERIOD_S`.
+
+    ``early`` guarantees ``spawn_tick`` leaves the whole active window inside
+    :data:`EARLY_SPAWN_WINDOW_S` — used for the one profile per category that
+    must be observable in the first simulated 10 minutes.
+    """
+    active_ticks = rng.randint(*active_range_s)
+    if early:
+        latest_spawn = max(0, EARLY_SPAWN_WINDOW_S - active_ticks)
+        spawn_tick = rng.randint(0, latest_spawn)
+    else:
+        spawn_tick = rng.randint(0, PERIOD_S - active_ticks)
+    return spawn_tick, active_ticks
+
+
+def _build_commercial(
+    rng: random.Random, used_icao: set[str], center: Position, *, early: bool
+) -> AircraftProfile:
+    start, heading = _cruise_start(rng, center)
+    spawn_tick, active_ticks = _spawn_schedule(rng, early=early, active_range_s=(480, 1400))
+    return AircraftProfile(
+        icao=_unique_icao(rng, used_icao),
+        callsign=_airline_callsign(rng),
+        category=Category.COMMERCIAL,
+        position_source="adsb",
+        spawn_tick=spawn_tick,
+        active_ticks=active_ticks,
+        rare_loop_modulus=1,
+        once=False,
+        start=start,
+        heading_deg=heading,
+        speed_kt=rng.uniform(380.0, 490.0),
+        turn_rate_deg_s=rng.uniform(-0.05, 0.05),
+        reports_speed_and_track=True,
+        base_altitude_ft=rng.uniform(28_000.0, 41_000.0),
+        climb_fpm=rng.uniform(-150.0, 150.0),
+        min_altitude_ft=27_000.0,
+        max_altitude_ft=42_000.0,
+        on_ground=False,
+        squawk=_octal_squawk(rng),
+        rssi_db=rng.uniform(-24.0, -6.0),
+    )
+
+
+def _build_military(
+    rng: random.Random, used_icao: set[str], center: Position, *, early: bool
+) -> AircraftProfile:
+    start, heading = _cruise_start(rng, center)
+    spawn_tick, active_ticks = _spawn_schedule(rng, early=early, active_range_s=(300, 900))
+    altitude = rng.choice(MILITARY_ALTITUDE_BLOCKS_FT)
+    return AircraftProfile(
+        icao=_unique_icao(rng, used_icao),
+        callsign=_military_callsign(rng),
+        category=Category.MILITARY,
+        position_source="adsb",
+        spawn_tick=spawn_tick,
+        active_ticks=active_ticks,
+        rare_loop_modulus=1,
+        once=False,
+        start=start,
+        heading_deg=heading,
+        speed_kt=rng.uniform(250.0, 500.0),
+        turn_rate_deg_s=rng.uniform(-0.15, 0.15),
+        reports_speed_and_track=True,
+        base_altitude_ft=altitude,
+        climb_fpm=rng.uniform(-100.0, 100.0),
+        min_altitude_ft=max(1_000.0, altitude - 2_000.0),
+        max_altitude_ft=altitude + 2_000.0,
+        on_ground=False,
+        squawk=_octal_squawk(rng),
+        rssi_db=rng.uniform(-22.0, -4.0),
+    )
+
+
+def _build_government(
+    rng: random.Random, used_icao: set[str], center: Position, *, early: bool
+) -> AircraftProfile:
+    start, heading = _cruise_start(rng, center)
+    spawn_tick, active_ticks = _spawn_schedule(rng, early=early, active_range_s=(400, 1000))
+    return AircraftProfile(
+        icao=_unique_icao(rng, used_icao),
+        callsign=_government_callsign(rng),
+        category=Category.GOVERNMENT,
+        position_source="adsb",
+        spawn_tick=spawn_tick,
+        active_ticks=active_ticks,
+        rare_loop_modulus=1,
+        once=False,
+        start=start,
+        heading_deg=heading,
+        speed_kt=rng.uniform(300.0, 470.0),
+        turn_rate_deg_s=rng.uniform(-0.08, 0.08),
+        reports_speed_and_track=True,
+        base_altitude_ft=rng.uniform(20_000.0, 41_000.0),
+        climb_fpm=rng.uniform(-100.0, 100.0),
+        min_altitude_ft=18_000.0,
+        max_altitude_ft=42_000.0,
+        on_ground=False,
+        squawk=_octal_squawk(rng),
+        rssi_db=rng.uniform(-22.0, -5.0),
+    )
+
+
+def _build_police(
+    rng: random.Random, used_icao: set[str], center: Position, *, early: bool
+) -> AircraftProfile:
+    start = _local_start(rng, center)
+    spawn_tick, active_ticks = _spawn_schedule(rng, early=early, active_range_s=(600, 1500))
+    turn_rate = rng.uniform(2.0, 4.0) * rng.choice((-1.0, 1.0))
+    return AircraftProfile(
+        icao=_unique_icao(rng, used_icao),
+        callsign=_police_callsign(rng),
+        category=Category.POLICE,
+        position_source="adsb",
+        spawn_tick=spawn_tick,
+        active_ticks=active_ticks,
+        rare_loop_modulus=1,
+        once=False,
+        start=start,
+        heading_deg=rng.uniform(0.0, 360.0),
+        speed_kt=rng.uniform(60.0, 120.0),
+        turn_rate_deg_s=turn_rate,
+        reports_speed_and_track=True,
+        base_altitude_ft=rng.uniform(500.0, 2_500.0),
+        climb_fpm=0.0,
+        min_altitude_ft=400.0,
+        max_altitude_ft=3_000.0,
+        on_ground=False,
+        squawk=_octal_squawk(rng),
+        rssi_db=rng.uniform(-18.0, -3.0),
+    )
+
+
+def _build_mode_s(rng: random.Random, used_icao: set[str], *, early: bool) -> AircraftProfile:
+    spawn_tick, active_ticks = _spawn_schedule(rng, early=early, active_range_s=(300, 900))
+    return AircraftProfile(
+        icao=_unique_icao(rng, used_icao),
+        callsign=None,
+        category=Category.MODE_S,
+        position_source="none",
+        spawn_tick=spawn_tick,
+        active_ticks=active_ticks,
+        rare_loop_modulus=1,
+        once=False,
+        start=None,
+        heading_deg=0.0,
+        speed_kt=0.0,
+        turn_rate_deg_s=0.0,
+        reports_speed_and_track=False,
+        base_altitude_ft=rng.uniform(2_000.0, 25_000.0),
+        climb_fpm=rng.uniform(-100.0, 100.0),
+        min_altitude_ft=1_500.0,
+        max_altitude_ft=26_000.0,
+        on_ground=False,
+        squawk=_octal_squawk(rng),
+        rssi_db=rng.uniform(-26.0, -8.0),
+    )
+
+
+def _build_mlat(
+    rng: random.Random, used_icao: set[str], center: Position, *, early: bool
+) -> AircraftProfile:
+    start, heading = _cruise_start(rng, center)
+    spawn_tick, active_ticks = _spawn_schedule(rng, early=early, active_range_s=(300, 800))
+    return AircraftProfile(
+        icao=_unique_icao(rng, used_icao),
+        callsign=_general_aviation_callsign(rng),
+        category=Category.MLAT,
+        position_source="mlat",
+        spawn_tick=spawn_tick,
+        active_ticks=active_ticks,
+        rare_loop_modulus=1,
+        once=False,
+        start=start,
+        heading_deg=heading,
+        speed_kt=rng.uniform(100.0, 250.0),
+        turn_rate_deg_s=rng.uniform(-0.1, 0.1),
+        reports_speed_and_track=True,
+        base_altitude_ft=rng.uniform(2_000.0, 15_000.0),
+        climb_fpm=rng.uniform(-150.0, 150.0),
+        min_altitude_ft=1_000.0,
+        max_altitude_ft=16_000.0,
+        on_ground=False,
+        squawk=_octal_squawk(rng),
+        rssi_db=rng.uniform(-26.0, -8.0),
+    )
+
+
+def _build_ground(
+    rng: random.Random, used_icao: set[str], center: Position, *, early: bool
+) -> AircraftProfile:
+    start = _local_start(rng, center)
+    spawn_tick, active_ticks = _spawn_schedule(rng, early=early, active_range_s=(200, 700))
+    return AircraftProfile(
+        icao=_unique_icao(rng, used_icao),
+        callsign=rng.choice((_airline_callsign, _general_aviation_callsign))(rng),
+        category=Category.GROUND,
+        position_source="adsb",
+        spawn_tick=spawn_tick,
+        active_ticks=active_ticks,
+        rare_loop_modulus=1,
+        once=False,
+        start=start,
+        heading_deg=rng.uniform(0.0, 360.0),
+        speed_kt=rng.uniform(0.0, 20.0),
+        turn_rate_deg_s=rng.uniform(-1.0, 1.0),
+        reports_speed_and_track=True,
+        base_altitude_ft=None,
+        climb_fpm=0.0,
+        min_altitude_ft=0.0,
+        max_altitude_ft=0.0,
+        on_ground=True,
+        squawk=_octal_squawk(rng),
+        rssi_db=rng.uniform(-20.0, -4.0),
+    )
+
+
+def _build_rare(
+    rng: random.Random, used_icao: set[str], center: Position, *, early: bool
+) -> AircraftProfile:
+    start, heading = _cruise_start(rng, center)
+    spawn_tick, active_ticks = _spawn_schedule(rng, early=early, active_range_s=(200, 500))
+    return AircraftProfile(
+        icao=_unique_icao(rng, used_icao),
+        callsign=_general_aviation_callsign(rng),
+        category=Category.RARE,
+        position_source="adsb",
+        spawn_tick=spawn_tick,
+        active_ticks=active_ticks,
+        rare_loop_modulus=3,
+        once=False,
+        start=start,
+        heading_deg=heading,
+        speed_kt=rng.uniform(420.0, 500.0),
+        turn_rate_deg_s=rng.uniform(-0.05, 0.05),
+        reports_speed_and_track=True,
+        base_altitude_ft=rng.uniform(35_000.0, 45_000.0),
+        climb_fpm=rng.uniform(-100.0, 100.0),
+        min_altitude_ft=34_000.0,
+        max_altitude_ft=46_000.0,
+        on_ground=False,
+        squawk=_octal_squawk(rng),
+        rssi_db=rng.uniform(-24.0, -6.0),
+    )
+
+
+def _build_first_ever(rng: random.Random, used_icao: set[str], center: Position) -> AircraftProfile:
+    start, heading = _cruise_start(rng, center)
+    active_ticks = rng.randint(240, 420)
+    spawn_tick = rng.randint(0, max(0, EARLY_SPAWN_WINDOW_S - active_ticks))
+    return AircraftProfile(
+        icao=_unique_icao(rng, used_icao),
+        callsign=_general_aviation_callsign(rng),
+        category=Category.FIRST_EVER,
+        position_source="adsb",
+        spawn_tick=spawn_tick,
+        active_ticks=active_ticks,
+        rare_loop_modulus=1,
+        once=True,
+        start=start,
+        heading_deg=heading,
+        speed_kt=rng.uniform(150.0, 300.0),
+        turn_rate_deg_s=rng.uniform(-0.1, 0.1),
+        reports_speed_and_track=True,
+        base_altitude_ft=rng.uniform(8_000.0, 22_000.0),
+        climb_fpm=rng.uniform(-100.0, 100.0),
+        min_altitude_ft=6_000.0,
+        max_altitude_ft=23_000.0,
+        on_ground=False,
+        squawk=_octal_squawk(rng),
+        rssi_db=rng.uniform(-24.0, -6.0),
+    )
+
+
+def _build_emergency(
+    rng: random.Random,
+    used_icao: set[str],
+    center: Position,
+    *,
+    squawk: str,
+    event_offset_s: float,
+) -> AircraftProfile:
+    """A commercial-style aircraft that squawks an emergency code once.
+
+    ``event_offset_s`` is measured from spawn, so the two emergency profiles
+    (7700, then 7600) can be scheduled to occur one after the other within
+    the first 10 simulated minutes.
+    """
+    start, heading = _cruise_start(rng, center)
+    active_ticks = rng.randint(600, 900)
+    spawn_tick = rng.randint(0, 120)
+    normal_squawk = _octal_squawk(rng)
+    return AircraftProfile(
+        icao=_unique_icao(rng, used_icao),
+        callsign=_airline_callsign(rng),
+        category=Category.COMMERCIAL,
+        position_source="adsb",
+        spawn_tick=spawn_tick,
+        active_ticks=active_ticks,
+        rare_loop_modulus=1,
+        once=False,
+        start=start,
+        heading_deg=heading,
+        speed_kt=rng.uniform(380.0, 470.0),
+        turn_rate_deg_s=rng.uniform(-0.05, 0.05),
+        reports_speed_and_track=True,
+        base_altitude_ft=rng.uniform(30_000.0, 39_000.0),
+        climb_fpm=rng.uniform(-100.0, 100.0),
+        min_altitude_ft=27_000.0,
+        max_altitude_ft=42_000.0,
+        on_ground=False,
+        squawk=normal_squawk,
+        rssi_db=rng.uniform(-22.0, -6.0),
+        emergency=EmergencyEvent(squawk=squawk, start_offset_s=event_offset_s, duration_s=120.0),
+    )
+
+
+#: ``(builder, weight)`` pairs used to size the bulk of the roster. Weights
+#: are relative, not percentages — see ``_category_counts``.
+_WEIGHTED_CATEGORIES: Final[tuple[tuple[Category, float], ...]] = (
+    (Category.COMMERCIAL, 0.58),
+    (Category.MILITARY, 0.07),
+    (Category.GOVERNMENT, 0.04),
+    (Category.POLICE, 0.04),
+    (Category.MODE_S, 0.08),
+    (Category.MLAT, 0.08),
+    (Category.GROUND, 0.07),
+    (Category.RARE, 0.04),
+)
+
+
+def _category_counts(roster_size: int) -> dict[Category, int]:
+    """Split ``roster_size`` across the weighted categories, each getting
+    at least one slot (on top of the guaranteed early one built separately).
+    """
+    counts: dict[Category, int] = {}
+    for category, weight in _WEIGHTED_CATEGORIES:
+        counts[category] = max(1, round(roster_size * weight))
+    return counts
+
+
+def build_roster(*, seed: int, population: int, center: Position) -> tuple[AircraftProfile, ...]:
+    """Build the full, deterministic aircraft roster for one demo session.
+
+    Args:
+        seed: drives every random decision below, in a fixed call order —
+            the same seed always builds the same roster.
+        population: the target *concurrent* aircraft count (see module
+            docstring); the roster itself is larger.
+        center: the point cruise and local traffic is generated around —
+            normally the configured receiver location.
+
+    Returns:
+        An immutable tuple, one :class:`AircraftProfile` per category
+        representative (each guaranteed to spawn within
+        :data:`EARLY_SPAWN_WINDOW_S`) plus the weighted bulk population, plus
+        exactly one first-ever aircraft and two dedicated emergency-squawk
+        aircraft (7700 then 7600).
+    """
+    if population < 1:
+        raise ValueError("population must be at least 1")
+
+    rng = random.Random(seed)
+    used_icao: set[str] = set()
+    roster_size = max(len(_WEIGHTED_CATEGORIES), round(population * ROSTER_MULTIPLIER))
+
+    profiles: list[AircraftProfile] = []
+
+    # One guaranteed-early representative per required category, built first
+    # so the acceptance criterion holds regardless of what the weighted bulk
+    # below happens to roll.
+    profiles.append(_build_commercial(rng, used_icao, center, early=True))
+    profiles.append(_build_military(rng, used_icao, center, early=True))
+    profiles.append(_build_government(rng, used_icao, center, early=True))
+    profiles.append(_build_police(rng, used_icao, center, early=True))
+    profiles.append(_build_mode_s(rng, used_icao, early=True))
+    profiles.append(_build_mlat(rng, used_icao, center, early=True))
+    profiles.append(_build_ground(rng, used_icao, center, early=True))
+    profiles.append(_build_rare(rng, used_icao, center, early=True))
+    profiles.append(_build_first_ever(rng, used_icao, center))
+    profiles.append(_build_emergency(rng, used_icao, center, squawk="7700", event_offset_s=90.0))
+    profiles.append(_build_emergency(rng, used_icao, center, squawk="7600", event_offset_s=240.0))
+
+    builders: dict[Category, Callable[[], AircraftProfile]] = {
+        Category.COMMERCIAL: lambda: _build_commercial(rng, used_icao, center, early=False),
+        Category.MILITARY: lambda: _build_military(rng, used_icao, center, early=False),
+        Category.GOVERNMENT: lambda: _build_government(rng, used_icao, center, early=False),
+        Category.POLICE: lambda: _build_police(rng, used_icao, center, early=False),
+        Category.MODE_S: lambda: _build_mode_s(rng, used_icao, early=False),
+        Category.MLAT: lambda: _build_mlat(rng, used_icao, center, early=False),
+        Category.GROUND: lambda: _build_ground(rng, used_icao, center, early=False),
+        Category.RARE: lambda: _build_rare(rng, used_icao, center, early=False),
+    }
+    for category, count in _category_counts(roster_size).items():
+        builder = builders[category]
+        for _ in range(count):
+            profiles.append(builder())
+
+    return tuple(profiles)
+
+
+__all__ = [
+    "AIRLINE_CALLSIGN_PREFIXES",
+    "EARLY_SPAWN_WINDOW_S",
+    "GOVERNMENT_CALLSIGN_PREFIXES",
+    "MILITARY_ALTITUDE_BLOCKS_FT",
+    "MILITARY_CALLSIGN_PREFIXES",
+    "PERIOD_S",
+    "POLICE_CALLSIGN_PREFIXES",
+    "ROSTER_MULTIPLIER",
+    "AircraftProfile",
+    "Category",
+    "EmergencyEvent",
+    "build_roster",
+]

--- a/backend/src/flightsite/demo/scenario.py
+++ b/backend/src/flightsite/demo/scenario.py
@@ -1,0 +1,135 @@
+"""Turns a tick index into one decoder batch — the scenario's pure core.
+
+:func:`batch_at` is the whole demo scenario: given a roster (built once from
+a seed by :mod:`flightsite.demo.roster`) and a tick index, it computes every
+active aircraft's state directly from elapsed time and returns a batch. No
+mutable simulation state is threaded through — tick 4000 is computed exactly
+the same way whether or not tick 3999 was ever asked for — which is what
+makes :class:`~flightsite.demo.adapter.DemoAdapter` deterministic (roadmap
+slice 011: "same seed + elapsed time => identical state").
+
+One tick is one simulated second (the product's 1 Hz cadence). A profile is
+"on the air" for ``[spawn_tick, spawn_tick + active_ticks)`` within each
+:data:`~flightsite.demo.roster.PERIOD_S`-second period; outside that window it
+simply produces no update for the tick, which is what lets the live store's
+ordinary stale/remove lifecycle turn "stopped transmitting" into "goes stale,
+then disappears" without this module knowing anything about that lifecycle.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Final
+
+from flightsite.demo.motion import altitude_at, position_at
+from flightsite.demo.roster import PERIOD_S, AircraftProfile
+from flightsite.ingest.types import AircraftStateBatch, AircraftStateUpdate
+
+#: Fixed reference instant every batch's timestamp is computed from
+#: (``SCENARIO_EPOCH + tick_index`` seconds). A demo scenario is defined
+#: purely in terms of elapsed ticks, so timestamps are pinned to a constant
+#: rather than derived from wall-clock "now" — that is precisely what makes
+#: two runs with the same seed produce byte-identical update sequences
+#: (roadmap slice 011 acceptance criterion), independent of when either run
+#: happened to start.
+SCENARIO_EPOCH: Final = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _active_age_s(profile: AircraftProfile, tick_index: int) -> float | None:
+    """Seconds since spawn if ``profile`` is transmitting at ``tick_index``, else ``None``."""
+    loop, phase = divmod(tick_index, PERIOD_S)
+    if profile.once and loop > 0:
+        return None
+    if profile.rare_loop_modulus > 1 and loop % profile.rare_loop_modulus != 0:
+        return None
+    if not (profile.spawn_tick <= phase < profile.spawn_tick + profile.active_ticks):
+        return None
+    return float(phase - profile.spawn_tick)
+
+
+def _squawk_at(profile: AircraftProfile, age_s: float) -> str:
+    event = profile.emergency
+    if event is None:
+        return profile.squawk
+    event_end = event.start_offset_s + event.duration_s
+    if event.start_offset_s <= age_s < event_end:
+        return event.squawk
+    return profile.squawk
+
+
+def update_at(profile: AircraftProfile, tick_index: int) -> AircraftStateUpdate | None:
+    """The one observation ``profile`` produces at ``tick_index``, or ``None``.
+
+    ``None`` means the aircraft is not transmitting this tick — either it has
+    not spawned yet, has fallen silent, or (for ``rare``/``first_ever``
+    profiles) this period is one it sits out entirely.
+    """
+    age_s = _active_age_s(profile, tick_index)
+    if age_s is None:
+        return None
+
+    timestamp = SCENARIO_EPOCH + timedelta(seconds=tick_index)
+
+    position = None
+    track_deg = None
+    ground_speed_kt = None
+    if profile.start is not None:
+        position, heading_now = position_at(
+            profile.start,
+            heading_deg=profile.heading_deg,
+            speed_kt=profile.speed_kt,
+            turn_rate_deg_s=profile.turn_rate_deg_s,
+            age_s=age_s,
+        )
+        if profile.reports_speed_and_track:
+            track_deg = heading_now
+            ground_speed_kt = profile.speed_kt
+
+    altitude_ft = None
+    vertical_rate_fpm = None
+    if profile.base_altitude_ft is not None:
+        altitude_ft, vertical_rate_fpm = altitude_at(
+            base_altitude_ft=profile.base_altitude_ft,
+            climb_fpm=profile.climb_fpm,
+            age_s=age_s,
+            min_altitude_ft=profile.min_altitude_ft,
+            max_altitude_ft=profile.max_altitude_ft,
+        )
+
+    return AircraftStateUpdate(
+        icao=profile.icao,
+        timestamp=timestamp,
+        position_source=profile.position_source if position is not None else "none",
+        callsign=profile.callsign,
+        squawk=_squawk_at(profile, age_s),
+        position=position,
+        altitude_ft=altitude_ft,
+        ground_speed_kt=ground_speed_kt,
+        track_deg=track_deg,
+        vertical_rate_fpm=vertical_rate_fpm,
+        on_ground=profile.on_ground,
+        rssi_db=profile.rssi_db,
+        messages=int(age_s) + 1,
+        seen_s=0.0,
+        seen_pos_s=0.0 if position is not None else None,
+    )
+
+
+def batch_at(roster: tuple[AircraftProfile, ...], tick_index: int) -> AircraftStateBatch:
+    """The full decoder batch at ``tick_index`` — one update per active aircraft.
+
+    A pure function of ``(roster, tick_index)``; since ``roster`` is itself a
+    pure function of the seed (:func:`flightsite.demo.roster.build_roster`),
+    this is the ``(seed, tick_index) -> batch`` determinism the roadmap
+    requires.
+    """
+    if tick_index < 0:
+        raise ValueError("tick_index must be non-negative")
+    updates = tuple(
+        update for profile in roster if (update := update_at(profile, tick_index)) is not None
+    )
+    timestamp = SCENARIO_EPOCH + timedelta(seconds=tick_index)
+    return AircraftStateBatch(timestamp=timestamp, updates=updates)
+
+
+__all__ = ["SCENARIO_EPOCH", "batch_at", "update_at"]

--- a/backend/tests/demo/test_app_wiring.py
+++ b/backend/tests/demo/test_app_wiring.py
@@ -1,0 +1,122 @@
+"""Demo mode as the app wires it up: activation, health, and receiver defaults.
+
+Complements ``tests/ingest/test_app_wiring.py`` (which pins the non-demo
+first-run and unreachable-decoder behavior) with the slice 011 exception to
+those rules: ``FLIGHTSITE_DEMO=1`` starts ingestion on a first run, and the
+health payload says so.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
+
+from flightsite.app import create_app
+from flightsite.config import ConfigStore, LocationSettings
+from flightsite.demo.adapter import DEFAULT_CENTER
+from flightsite.ingest.service import READINESS_SUBSYSTEM, IngestionService
+
+
+@pytest.fixture
+def configured(isolated_data_dir: Path) -> ConfigStore:
+    """Write a config.yaml, so the install is no longer on its first run."""
+    store = ConfigStore(isolated_data_dir)
+    store.save(store.load())
+    assert store.first_run is False
+    return store
+
+
+def test_demo_disabled_by_default(isolated_data_dir: Path) -> None:
+    app = create_app()
+
+    with TestClient(app) as client:
+        assert app.state.ingestion is None
+        health = client.get("/api/v1/health")
+
+    assert health.json()["demo"] is False
+
+
+def test_demo_flag_starts_ingestion_on_a_first_run(
+    isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FLIGHTSITE_DEMO", "1")
+    store = ConfigStore(isolated_data_dir)
+    assert store.first_run is True
+
+    app = create_app()
+
+    with TestClient(app) as client:
+        service: IngestionService | None = app.state.ingestion
+        ready = client.get("/api/v1/ready")
+        health = client.get("/api/v1/health")
+
+        assert service is not None
+        assert service.running is True
+        assert ready.status_code == 200
+        assert ready.json()["subsystems"] == {"database": True, READINESS_SUBSYSTEM: True}
+        assert health.json()["demo"] is True
+
+
+def test_demo_flag_starts_ingestion_even_when_configured(
+    configured: ConfigStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FLIGHTSITE_DEMO", "1")
+    app = create_app()
+
+    with TestClient(app):
+        service: IngestionService | None = app.state.ingestion
+
+    assert service is not None
+
+
+async def test_demo_injects_the_default_center_when_no_receiver_is_configured(
+    isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FLIGHTSITE_DEMO", "1")
+    app = create_app()
+
+    async with app.router.lifespan_context(app):
+        assert app.state.live.receiver_location == DEFAULT_CENTER
+
+
+async def test_demo_uses_the_configured_receiver_location_when_present(
+    isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = ConfigStore(isolated_data_dir)
+    settings = store.load()
+    settings.location = LocationSettings(latitude=47.4502, longitude=-122.3088)
+    store.save(settings)
+
+    monkeypatch.setenv("FLIGHTSITE_DEMO", "1")
+    app = create_app()
+
+    async with app.router.lifespan_context(app):
+        location = app.state.live.receiver_location
+        assert location is not None
+        assert location.latitude == pytest.approx(47.4502)
+        assert location.longitude == pytest.approx(-122.3088)
+
+
+async def test_demo_mode_grows_the_live_set_over_real_time(
+    isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FLIGHTSITE_DEMO", "1")
+    app = create_app()
+    transport = ASGITransport(app=app)
+
+    async with (
+        app.router.lifespan_context(app),
+        AsyncClient(transport=transport, base_url="http://testserver") as client,
+    ):
+        health = await client.get("/api/v1/health")
+        assert health.json()["demo"] is True
+
+        # The demo adapter's poll loop runs on the wall clock in production
+        # wiring (no injected clock here) — a short real wait is the only way
+        # to observe it actually producing traffic end to end.
+        await asyncio.sleep(1.5)
+        assert len(app.state.live) > 0

--- a/backend/tests/demo/test_determinism.py
+++ b/backend/tests/demo/test_determinism.py
@@ -1,0 +1,116 @@
+"""Determinism: the roadmap slice 011 acceptance criterion.
+
+"Two runs with the same seed produce identical update sequences." Every
+assertion here compares independently constructed objects — never state
+carried over within one object — so a passing suite is proof the scenario is
+a pure function of ``(seed, tick_index)``, not an accident of shared state.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from flightsite.demo import build_roster
+from flightsite.demo.adapter import DEFAULT_CENTER, DemoAdapter
+from flightsite.ingest.types import Position
+
+SEATTLE = Position(latitude=47.4502, longitude=-122.3088)
+
+
+def test_same_seed_produces_identical_rosters() -> None:
+    first = build_roster(seed=42, population=50, center=DEFAULT_CENTER)
+    second = build_roster(seed=42, population=50, center=DEFAULT_CENTER)
+
+    assert first == second
+
+
+def test_different_seeds_produce_different_rosters() -> None:
+    first = build_roster(seed=1, population=50, center=DEFAULT_CENTER)
+    second = build_roster(seed=2, population=50, center=DEFAULT_CENTER)
+
+    assert first != second
+    assert {profile.icao for profile in first} != {profile.icao for profile in second}
+
+
+def test_roster_icaos_are_unique() -> None:
+    roster = build_roster(seed=7, population=80, center=DEFAULT_CENTER)
+
+    icaos = [profile.icao for profile in roster]
+    assert len(icaos) == len(set(icaos))
+
+
+@pytest.mark.parametrize("tick", [0, 1, 59, 300, 419, 900, 1799, 1800, 5000])
+def test_two_adapters_same_seed_produce_identical_batches(tick: int) -> None:
+    first = DemoAdapter(seed=42, population=60)
+    second = DemoAdapter(seed=42, population=60)
+
+    assert first.batch_for_tick(tick) == second.batch_for_tick(tick)
+
+
+def test_two_adapters_different_seed_diverge_somewhere_in_the_first_period() -> None:
+    first = DemoAdapter(seed=1, population=60)
+    second = DemoAdapter(seed=2, population=60)
+
+    batches = [
+        (first.batch_for_tick(tick), second.batch_for_tick(tick)) for tick in range(0, 900, 30)
+    ]
+    assert any(a != b for a, b in batches)
+
+
+def test_batch_for_tick_is_stateless_and_order_independent() -> None:
+    """Re-asking for an earlier tick after a later one gives the same answer.
+
+    Nothing may be cached or threaded from one call to the next: this is what
+    lets a consumer resync (WebSocket reconnect, a replayed capture) to any
+    tick without replaying the ticks before it.
+    """
+    adapter = DemoAdapter(seed=42, population=60)
+
+    forward = [adapter.batch_for_tick(tick) for tick in range(60)]
+    out_of_order = [adapter.batch_for_tick(tick) for tick in reversed(range(60))]
+
+    assert forward == list(reversed(out_of_order))
+
+
+def test_a_receiver_relocated_center_changes_the_roster_deterministically() -> None:
+    """The center is scenario geometry, not randomness — but it still must be
+    reproducible: the same ``(seed, center)`` pair always builds the same
+    roster.
+    """
+    first = build_roster(seed=99, population=40, center=SEATTLE)
+    second = build_roster(seed=99, population=40, center=SEATTLE)
+    different_center = build_roster(seed=99, population=40, center=DEFAULT_CENTER)
+
+    assert first == second
+    assert first != different_center
+
+
+async def test_updates_stream_yields_ticks_in_order_from_the_injected_clock() -> None:
+    """The async loop is just plumbing around ``batch_for_tick``: it must
+    yield exactly the ticks the injected clock says have elapsed, in order.
+    """
+
+    class FakeClock:
+        def __init__(self) -> None:
+            self.value = 0.0
+
+        def __call__(self) -> float:
+            return self.value
+
+    clock = FakeClock()
+
+    async def fake_sleep(seconds: float) -> None:
+        clock.value += seconds
+
+    adapter = DemoAdapter(seed=1, population=10, clock=clock, sleep=fake_sleep)
+    await adapter.start()
+
+    collected = []
+    async for batch in adapter.updates():
+        collected.append(batch)
+        if len(collected) == 4:
+            break
+    await adapter.stop()
+
+    expected = [adapter.batch_for_tick(tick) for tick in (0, 1, 2, 3)]
+    assert collected == expected

--- a/backend/tests/demo/test_realism.py
+++ b/backend/tests/demo/test_realism.py
@@ -1,0 +1,101 @@
+"""Realism sanity: plausible numbers, and tracks that move rather than jump.
+
+Iterates :func:`~flightsite.demo.scenario.update_at` directly (a pure
+function), rather than driving a live store — these are properties of the
+motion model and the roster's generated ranges, independent of ingestion or
+lifecycle behavior, which the other test modules in this package cover.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from flightsite.demo import build_roster
+from flightsite.demo.adapter import DEFAULT_CENTER, DEFAULT_SEED
+from flightsite.demo.roster import AircraftProfile
+from flightsite.demo.scenario import update_at
+from flightsite.live.geo import distance_nm
+
+POPULATION: Final = 60
+
+#: Generous "did not teleport" bound: even a 500 kt airliner moves under
+#: 0.14 nm in one second, and the fastest demo category (commercial, up to
+#: 490 kt) stays comfortably under this per-tick step.
+MAX_STEP_NM_PER_TICK: Final = 0.5
+
+#: Plausible barometric altitude band across every category the roster
+#: generates (SPEC §76's "realistic ... altitudes").
+MIN_PLAUSIBLE_ALTITUDE_FT: Final = -1_000.0
+MAX_PLAUSIBLE_ALTITUDE_FT: Final = 46_000.0
+
+MAX_PLAUSIBLE_GROUND_SPEED_KT: Final = 600.0
+MAX_PLAUSIBLE_VERTICAL_RATE_FPM: Final = 2_000.0
+
+
+def _roster() -> tuple[AircraftProfile, ...]:
+    return build_roster(seed=DEFAULT_SEED, population=POPULATION, center=DEFAULT_CENTER)
+
+
+def test_altitudes_speeds_and_vertical_rates_stay_within_plausible_bounds() -> None:
+    checked = 0
+    for profile in _roster():
+        window = range(profile.spawn_tick, profile.spawn_tick + profile.active_ticks, 5)
+        for tick in window:
+            update = update_at(profile, tick)
+            assert update is not None
+            if update.altitude_ft is not None:
+                assert MIN_PLAUSIBLE_ALTITUDE_FT <= update.altitude_ft <= MAX_PLAUSIBLE_ALTITUDE_FT
+                checked += 1
+            if update.ground_speed_kt is not None:
+                assert 0.0 <= update.ground_speed_kt <= MAX_PLAUSIBLE_GROUND_SPEED_KT
+            if update.vertical_rate_fpm is not None:
+                assert abs(update.vertical_rate_fpm) <= MAX_PLAUSIBLE_VERTICAL_RATE_FPM
+
+    assert checked > 0
+
+
+def test_positions_move_smoothly_with_no_teleporting() -> None:
+    checked_steps = 0
+    for profile in _roster():
+        if profile.start is None:
+            continue  # Mode S: never positioned, nothing to check.
+
+        previous_position = None
+        for tick in range(profile.spawn_tick, profile.spawn_tick + profile.active_ticks):
+            update = update_at(profile, tick)
+            assert update is not None
+            if update.position is None:
+                continue
+            if previous_position is not None:
+                step_nm = distance_nm(previous_position, update.position)
+                assert step_nm <= MAX_STEP_NM_PER_TICK, (
+                    f"{profile.icao} jumped {step_nm:.3f} nm in one tick at {tick=}"
+                )
+                checked_steps += 1
+            previous_position = update.position
+
+    assert checked_steps > 0
+
+
+def test_squawks_are_well_formed_four_digit_octal() -> None:
+    for profile in _roster():
+        for tick in (profile.spawn_tick, profile.spawn_tick + profile.active_ticks - 1):
+            update = update_at(profile, tick)
+            assert update is not None
+            squawk = update.squawk
+            assert squawk is not None
+            assert len(squawk) == 4
+            assert all(digit in "01234567" for digit in squawk)
+
+
+def test_callsigns_are_stable_for_the_life_of_an_aircraft() -> None:
+    """A single aircraft's callsign never changes mid-session — SPEC §76's
+    "callsigns consistent per aircraft per session".
+    """
+    for profile in _roster():
+        callsigns: set[str | None] = set()
+        for tick in range(profile.spawn_tick, profile.spawn_tick + profile.active_ticks, 11):
+            update = update_at(profile, tick)
+            assert update is not None
+            callsigns.add(update.callsign)
+        assert len(callsigns) == 1

--- a/backend/tests/demo/test_scenario_coverage.py
+++ b/backend/tests/demo/test_scenario_coverage.py
@@ -1,0 +1,222 @@
+"""Scenario coverage: every SPEC §76 traffic type, observed through a live store.
+
+These tests drive a real :class:`~flightsite.live.LiveStore` with demo
+batches on a hand-driven clock (``docs/TEST_STRATEGY.md`` §3 — simulated
+time, never real sleeps) and assert on what the live picture actually shows,
+the same way a consumer of :class:`~flightsite.demo.DemoAdapter` would see
+it.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from flightsite.demo import Category, build_roster
+from flightsite.demo.adapter import DEFAULT_CENTER, DEFAULT_SEED
+from flightsite.demo.roster import (
+    MILITARY_CALLSIGN_PREFIXES,
+    PERIOD_S,
+    AircraftProfile,
+)
+from flightsite.demo.scenario import batch_at, update_at
+from flightsite.ingest.types import AircraftStateUpdate
+from flightsite.live import LiveStore
+from flightsite.live.aircraft import LiveState
+
+#: 15 simulated minutes: comfortably past the "first 10 minutes" acceptance
+#: window, with margin for every guaranteed-early representative to have
+#: actually appeared (not just spawned).
+DRIVE_TICKS: Final = 900
+
+POPULATION: Final = 60
+
+
+class ManualClock:
+    """A monotonic clock this test drives by hand — see module docstring."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self._now = start
+
+    def __call__(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> float:
+        self._now += seconds
+        return self._now
+
+
+def _roster() -> tuple[AircraftProfile, ...]:
+    return build_roster(seed=DEFAULT_SEED, population=POPULATION, center=DEFAULT_CENTER)
+
+
+def _drive(
+    roster: tuple[AircraftProfile, ...], live: LiveStore, clock: ManualClock, ticks: int
+) -> list[tuple[int, AircraftStateUpdate]]:
+    """Apply ``ticks`` batches to ``live``; return every ``(tick, update)`` seen.
+
+    Returning the raw updates (not just the final live-store snapshot) is
+    what lets momentary conditions — an emergency squawk active for only a
+    couple of minutes — be asserted on, even though the live store only ever
+    holds *current* state.
+    """
+    seen: list[tuple[int, AircraftStateUpdate]] = []
+    for tick in range(ticks):
+        batch = batch_at(roster, tick)
+        live.apply(batch)
+        seen.extend((tick, update) for update in batch.updates)
+        clock.advance(1.0)
+    return seen
+
+
+def test_every_required_category_is_observed_within_ten_simulated_minutes() -> None:
+    roster = _roster()
+    icao_category = {profile.icao: profile.category for profile in roster}
+    clock = ManualClock()
+    live = LiveStore(clock=clock, receiver_location=DEFAULT_CENTER)
+
+    seen = _drive(roster, live, clock, DRIVE_TICKS)
+    categories_seen = {icao_category[update.icao] for _, update in seen}
+
+    assert categories_seen == set(Category)
+
+
+def test_mlat_and_non_positioned_mode_s_aircraft_appear() -> None:
+    roster = _roster()
+    clock = ManualClock()
+    live = LiveStore(clock=clock, receiver_location=DEFAULT_CENTER)
+
+    seen = _drive(roster, live, clock, DRIVE_TICKS)
+    position_sources = {update.position_source for _, update in seen}
+
+    assert "mlat" in position_sources
+    assert "none" in position_sources
+
+    # A non-positioned Mode S aircraft reports altitude/squawk only.
+    mode_s_updates = [
+        update
+        for _, update in seen
+        if update.position_source == "none" and update.altitude_ft is not None
+    ]
+    assert mode_s_updates
+    assert all(update.position is None for update in mode_s_updates)
+    assert all(update.squawk is not None for update in mode_s_updates)
+
+
+def test_ground_traffic_is_reported_on_ground() -> None:
+    roster = _roster()
+    clock = ManualClock()
+    live = LiveStore(clock=clock, receiver_location=DEFAULT_CENTER)
+
+    seen = _drive(roster, live, clock, DRIVE_TICKS)
+
+    assert any(update.on_ground is True for _, update in seen)
+
+
+def test_military_style_callsigns_appear() -> None:
+    roster = _roster()
+    icao_category = {profile.icao: profile.category for profile in roster}
+    clock = ManualClock()
+    live = LiveStore(clock=clock, receiver_location=DEFAULT_CENTER)
+
+    seen = _drive(roster, live, clock, DRIVE_TICKS)
+    military_callsigns = {
+        update.callsign
+        for _, update in seen
+        if icao_category[update.icao] == Category.MILITARY and update.callsign
+    }
+
+    assert military_callsigns
+    assert any(
+        callsign.startswith(prefix)
+        for callsign in military_callsigns
+        for prefix in MILITARY_CALLSIGN_PREFIXES
+    )
+
+
+def test_emergency_squawks_7700_and_7600_both_occur() -> None:
+    roster = _roster()
+    clock = ManualClock()
+    live = LiveStore(clock=clock, receiver_location=DEFAULT_CENTER)
+
+    seen = _drive(roster, live, clock, DRIVE_TICKS)
+    squawks_seen = {update.squawk for _, update in seen}
+
+    assert "7700" in squawks_seen
+    assert "7600" in squawks_seen
+
+
+def test_first_ever_aircraft_appears_exactly_once_across_two_periods() -> None:
+    """A ``first_ever`` profile transmits during the first period and never again.
+
+    This is a property of the scenario function itself
+    (:func:`~flightsite.demo.scenario.update_at`), so it is checked directly
+    rather than through a 3 600-tick ``LiveStore`` drive — cheap enough to
+    run over the full two periods with no sampling gaps.
+    """
+    roster = _roster()
+    first_ever = next(p for p in roster if p.category == Category.FIRST_EVER)
+
+    periods_seen = {
+        tick // PERIOD_S for tick in range(2 * PERIOD_S) if update_at(first_ever, tick) is not None
+    }
+
+    assert periods_seen == {0}
+
+
+def test_commercial_aircraft_are_the_live_majority() -> None:
+    roster = _roster()
+    icao_category = {profile.icao: profile.category for profile in roster}
+    clock = ManualClock()
+    live = LiveStore(clock=clock, receiver_location=DEFAULT_CENTER)
+
+    _drive(roster, live, clock, DRIVE_TICKS)
+    snapshot = live.snapshot()
+    assert snapshot, "expected aircraft to be live after the drive"
+
+    commercial = sum(
+        1 for aircraft in snapshot if icao_category[aircraft.icao] == Category.COMMERCIAL
+    )
+    assert commercial > len(snapshot) / 2
+
+
+def test_a_silent_aircraft_goes_stale_then_is_removed() -> None:
+    """A guaranteed-early representative stops transmitting well within the
+    drive window; as ordinary lifecycle sweeps continue to run — the same as
+    the background task in production — it must age out to stale and then
+    removed, without disturbing aircraft still on the air.
+
+    Ingestion continues throughout (every tick still applies its batch): the
+    point is that *this one aircraft* falls silent while its neighbours keep
+    transmitting, not that the whole feed stops.
+    """
+    roster = _roster()
+    # `_build_rare(..., early=True)` — see build_roster's fixed append order
+    # — always finishes its active window by tick 500 (its active-tick range
+    # is 200-500 and the "early" schedule caps spawn + active <= 500).
+    target = roster[7]
+    assert target.category == Category.RARE
+    silent_from = target.spawn_tick + target.active_ticks
+    assert silent_from <= 550
+
+    clock = ManualClock()
+    live = LiveStore(clock=clock, receiver_location=DEFAULT_CENTER, stale_s=15.0, remove_s=60.0)
+
+    # Drive tick by tick, sweeping after every tick — exactly what the
+    # production background task does at its 1 s interval — so the target's
+    # silence is timed against a clock that keeps moving for everyone.
+    stale_seen = False
+    for tick in range(silent_from + 100):
+        live.apply(batch_at(roster, tick))
+        clock.advance(1.0)
+        live.sweep()
+        if tick == silent_from + 30:
+            stale_aircraft = live.get(target.icao)
+            assert stale_aircraft is not None, "target should still be live, just stale"
+            assert stale_aircraft.state is LiveState.STALE
+            stale_seen = True
+
+    assert stale_seen
+    assert target.icao not in live
+
+    # Aircraft still being fed updates every tick were never touched by this.
+    assert len(live) > 0

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -416,7 +416,7 @@ slices:
     title: "Demo mode"
     phase: 2
     branch: "011-demo-mode"
-    status: planned
+    status: merged
     depends_on: ["007", "008"]
     objective: "Provide a deterministic demo adapter simulating rich traffic for development, tests, and visual regression."
     scope:


### PR DESCRIPTION
## Slice
- **Slice ID:** 011 — Demo mode
- **Roadmap:** `planning/roadmap.yaml` slice 011 (phase 2)
- **Issue:** Closes #29

## Objective
Deterministic demo adapter simulating rich traffic for development, tests, and visual regression.

## Implementation summary
- `flightsite.demo`: closed-form constant-turn-rate motion (tracks are pure functions of elapsed time — no simulation state); seeded roster with realistic identities; batch_at(seed, tick) purity; DemoAdapter implementing DecoderAdapter
- Scenario coverage in the first 10 simulated minutes: commercial majority, military/government/police, non-positioned Mode S, MLAT, ground traffic, 7700 + 7600 emergencies, rare + first-ever aircraft, stale→disappearing aircraft
- FLIGHTSITE_DEMO=1 env activation; works with zero config (default receiver center injected); health payload gains "demo": true
- Validated live: full stack runs first-run with demo traffic

## Acceptance criteria
- [x] runs the full stack with no decoder and no internet
- [x] same seed ⇒ identical update sequences (byte-equality tests)
- [x] all scenario types observable within the first simulated 10 minutes (LiveStore-driven test)

## Tests added/run
34 new tests (determinism, coverage, realism/no-teleporting, wiring); suite 586 passed; coverage **98.65%**. Reviewer re-ran gates on the dev-merged tree.

## Performance / Security / Data considerations
Closed-form math, no allocation-heavy loops; env-only activation; no DB, no secrets.

## Documentation updates
None required.

## Known limitations
Population constants are documented heuristics (~40–80 concurrent, scalable for perf work).

## Follow-up work
Slice 020 builds Playwright E2E on this; slice 047 relies on its determinism.

## Fable self-review (SPEC §104)
- [x] Full diff inspected; determinism approach verified (fixed epoch, injectable clock); wiring confined to the adapter-selection point; no TODO/FIXME
- [x] Reconciled with dev (clean); 586 tests green post-merge
- [ ] CI green on this PR (gate before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)