### PR TITLE
Slice 010: Live API & WebSocket

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -10,6 +10,16 @@ uv run pytest
 uv run flightsite-serve
 ```
 
+## API
+
+The documented read-only surface is `/api/v1` and its OpenAPI document is
+served beside it: schema at `/api/v1/openapi.json`, interactive docs at
+`/api/v1/docs`. `/api/internal` is the frontend's unsupported mutation surface
+and is excluded from that schema.
+
+The live WebSocket, `/api/v1/ws/live`, cannot be described in OpenAPI; its
+protocol reference is the `flightsite.api.ws` module docstring.
+
 ## Database
 
 SQLite (WAL) at `<data dir>/flightsite.sqlite3`, reached through

--- a/backend/src/flightsite/api/__init__.py
+++ b/backend/src/flightsite/api/__init__.py
@@ -1,3 +1,18 @@
-"""REST API routers."""
+"""The HTTP and WebSocket surface: routers, payload shapes, live broadcaster.
+
+Four supporting modules, split by what changes for what reason:
+
+* :mod:`flightsite.api.serializers` — domain records to the JSON shapes
+  ``docs/API.md`` documents. Pure functions, no application state.
+* :mod:`flightsite.api.schemas` — the Pydantic models those shapes are
+  published and validated as, which is what ``/api/v1/openapi.json`` describes.
+* :mod:`flightsite.api.context` — assembles payloads from a running app's
+  state, so REST and the WebSocket answer from one implementation.
+* :mod:`flightsite.api.ws` — the live WebSocket protocol and its broadcaster.
+
+:mod:`flightsite.api.v1` mounts the documented read-only surface;
+:mod:`flightsite.api.internal` mounts the unsupported mutation surface, which
+is excluded from the published schema (ADR-0007).
+"""
 
 from __future__ import annotations

--- a/backend/src/flightsite/api/context.py
+++ b/backend/src/flightsite/api/context.py
@@ -122,8 +122,20 @@ class LiveApiContext:
         return payloads
 
     async def receiver(self) -> dict[str, Any]:
-        """The §3.2 receiver info block, including T0."""
-        return receiver_payload(self.settings, demo_mode=self.demo_mode, t0=await self._t0())
+        """The §3.2 receiver info block, including T0.
+
+        The location comes from the live store rather than from settings: it
+        is the position distances and bearings are actually measured from, so
+        it is the one a client should draw its receiver marker and range rings
+        at. They differ only in demo mode, which injects a location into an
+        otherwise unconfigured install.
+        """
+        return receiver_payload(
+            self.settings,
+            demo_mode=self.demo_mode,
+            t0=await self._t0(),
+            location=self.live.receiver_location,
+        )
 
     async def _t0(self) -> datetime | None:
         """T0 as an aware UTC datetime, or ``None`` if it is unavailable.

--- a/backend/src/flightsite/api/context.py
+++ b/backend/src/flightsite/api/context.py
@@ -1,0 +1,146 @@
+"""One place where API payloads are assembled from application state.
+
+``GET /api/v1/aircraft/current`` and the WebSocket's ``snapshot`` frame must
+describe the same instant identically — roadmap slice 010's first acceptance
+criterion — and the cheapest way to guarantee that is to give them one
+implementation rather than two that agree by inspection. Both call
+:meth:`LiveApiContext.aircraft`; the same is true of the receiver block, which
+appears in ``GET /api/v1/receiver`` and in every snapshot.
+
+The context reads ``app.state`` lazily on every call rather than capturing its
+contents at construction. That is not indirection for its own sake: ``PUT
+/api/internal/config`` replaces ``app.state.settings`` on a running app, so a
+captured ``Settings`` would serve a stale receiver block for the rest of the
+process's life. Reading late also means the context can be built before the
+lifespan hook has started anything.
+
+Nothing here touches SQLite on the aircraft path — the live registry answers
+from memory, which is the invariant ``docs/ARCHITECTURE.md`` §3.1 states as
+"no live request or decoder poll ever waits on SQLite". The one database read
+in this module is T0 for the receiver block, which is a single indexed lookup
+on a write-once key, made on a REST request or a WebSocket connect and never
+per frame.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime
+from typing import Any
+
+import structlog
+from fastapi import FastAPI
+
+from flightsite.api.serializers import aircraft_payload, receiver_payload
+from flightsite.config import Settings
+from flightsite.db import Database, MetaRepository, from_epoch_ms
+from flightsite.live import LiveAircraft, LiveStore
+from flightsite.sightings import PersistenceWorker
+
+logger = structlog.get_logger(__name__)
+
+
+def _wanted(record: LiveAircraft, positioned: bool | None) -> bool:
+    """Apply the §3.3 ``positioned`` filter; ``None`` means "everything"."""
+    return positioned is None or record.has_position is positioned
+
+
+class LiveApiContext:
+    """Assembles the live API payloads from a running app's state.
+
+    Args:
+        app: the application whose ``state`` holds the live registry, the
+            persistence worker, the database and the effective settings.
+    """
+
+    __slots__ = ("_app",)
+
+    def __init__(self, app: FastAPI) -> None:
+        self._app = app
+
+    # ----------------------------------------------------------------- state
+
+    @property
+    def live(self) -> LiveStore:
+        """The in-memory live aircraft registry."""
+        store: LiveStore = self._app.state.live
+        return store
+
+    @property
+    def settings(self) -> Settings:
+        """The currently effective configuration."""
+        settings: Settings = self._app.state.settings
+        return settings
+
+    @property
+    def demo_mode(self) -> bool:
+        """True when this process serves simulated traffic (SPEC §76)."""
+        demo: bool = self._app.state.demo_enabled
+        return demo
+
+    # -------------------------------------------------------------- payloads
+
+    def aircraft(self, *, positioned: bool | None = None) -> list[dict[str, Any]]:
+        """The live set as §3.3 aircraft objects, ordered by ICAO address.
+
+        Sorted so that two reads of the same instant — one over REST, one over
+        the WebSocket — are identical documents rather than merely equal sets.
+        Sorting a few hundred already-interned strings costs far less than the
+        serialization it accompanies.
+
+        Args:
+            positioned: ``True`` for aircraft with a known position, ``False``
+                for those tracked without one (SPEC §20), ``None`` for the full
+                live picture, which is the default and the documented one.
+        """
+        worker: PersistenceWorker = self._app.state.persistence
+        records = sorted(self.live.snapshot(), key=lambda record: record.icao)
+        return [
+            aircraft_payload(record, sighting_id=worker.sighting_id_for(record.icao))
+            for record in records
+            if _wanted(record, positioned)
+        ]
+
+    def aircraft_for(self, icaos: Iterable[str]) -> list[dict[str, Any]]:
+        """Serialize the named aircraft, in the order given, skipping absentees.
+
+        Used to build a delta's ``updated`` list from the ICAOs one tick's
+        events named. The payload is read from the live store *now* rather than
+        from the records the events carried, so a burst of updates for one
+        aircraft costs one serialization of its latest state instead of several
+        of its intermediate ones. An ICAO that left the live set between the
+        event and this call is simply absent — the same tick's ``removed`` list
+        is the notice that matters.
+        """
+        worker: PersistenceWorker = self._app.state.persistence
+        live = self.live
+        payloads: list[dict[str, Any]] = []
+        for icao in icaos:
+            record = live.get(icao)
+            if record is not None:
+                payloads.append(aircraft_payload(record, sighting_id=worker.sighting_id_for(icao)))
+        return payloads
+
+    async def receiver(self) -> dict[str, Any]:
+        """The §3.2 receiver info block, including T0."""
+        return receiver_payload(self.settings, demo_mode=self.demo_mode, t0=await self._t0())
+
+    async def _t0(self) -> datetime | None:
+        """T0 as an aware UTC datetime, or ``None`` if it is unavailable.
+
+        A database that failed to migrate leaves ``/api/v1/ready`` answering
+        503 but must not take the receiver block down with it: the rest of that
+        payload is pure configuration, and the live picture behind it is fine.
+        An unreadable T0 is therefore reported as "unknown" (§2.7) rather than
+        as a 500, with the reason logged once per read.
+        """
+        database: Database = self._app.state.database
+        try:
+            t0_ms = await MetaRepository(database).get_t0()
+        except Exception as exc:
+            logger.warning("t0_unavailable", error=str(exc), error_type=type(exc).__name__)
+            return None
+        return None if t0_ms is None else from_epoch_ms(t0_ms)
+
+
+__all__ = ["LiveApiContext"]

--- a/backend/src/flightsite/api/schemas.py
+++ b/backend/src/flightsite/api/schemas.py
@@ -1,0 +1,153 @@
+"""Typed response models for the published ``/api/v1`` OpenAPI schema.
+
+``docs/API.md`` §2.10 puts an OpenAPI document at ``/api/v1/openapi.json``, and
+a schema is only worth serving if it is accurate. These models are therefore
+not decoration: every REST endpoint in this slice declares one as its
+``response_model``, so FastAPI validates the dict
+:mod:`flightsite.api.serializers` produced against the shape it just published.
+A serializer that drifted from the documented shape fails the request instead
+of quietly serving something the schema denies.
+
+The WebSocket endpoint has no entry here because OpenAPI 3.1 does not describe
+WebSockets; its protocol is documented in :mod:`flightsite.api.ws`, and the
+aircraft objects it carries are exactly :class:`AircraftView` — the same
+serializer builds both.
+
+Every field is optional-by-value rather than optional-by-absence: §2.7 makes
+``null`` the representation of unknown, and §6 lets v1 add fields but not
+remove them, so a client can rely on the key set being stable.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+#: ``docs/API.md`` §2.8 / SPEC §21. ``none`` means tracked without a valid
+#: position (Mode S only), which is a first-class live entry, not an error.
+PositionSourceLiteral = Literal["adsb", "mlat", "none", "other"]
+
+#: §2.2: UTC ISO-8601 with a ``Z`` suffix and millisecond precision.
+IsoTimestamp = Annotated[str, Field(examples=["2026-08-31T14:03:22.418Z"])]
+
+
+class _Model(BaseModel):
+    """Base for the response models: no extra keys, no silent coercion."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class GeoPosition(_Model):
+    """A WGS-84 surface position in decimal degrees."""
+
+    lat: float
+    lon: float
+
+
+class Classification(_Model):
+    """Military / government / law-enforcement classification (slice 024).
+
+    Modelled now because it is part of the §3.3 object a client codes against;
+    live payloads carry ``null`` until the classification engine lands.
+    """
+
+    military: bool
+    government: bool
+    law_enforcement: bool
+    mission: str | None = None
+    icon_category: str | None = None
+    confidence: str | None = None
+
+
+class InterestingMatch(_Model):
+    """An active alert match (slice 038); ``null`` when nothing matches."""
+
+    severity: Literal["info", "interesting", "high", "critical"]
+    reasons: list[str] = Field(default_factory=list)
+
+
+class AircraftView(_Model):
+    """One live aircraft — ``docs/API.md`` §3.3.
+
+    The same object appears in ``GET /api/v1/aircraft/current`` and in every
+    WebSocket ``snapshot`` and ``delta`` frame.
+    """
+
+    icao: Annotated[str, Field(pattern=r"^[0-9a-f]{6}$", examples=["ae1463"])]
+    callsign: str | None = None
+    registration: str | None = None
+
+    position: GeoPosition | None = None
+    position_source: PositionSourceLiteral = "none"
+    altitude_ft: float | None = None
+    ground_speed_kt: float | None = None
+    track_deg: float | None = None
+    vertical_rate_fpm: float | None = None
+    squawk: str | None = None
+    emergency: Literal["7500", "7600", "7700"] | None = None
+    on_ground: bool | None = None
+
+    distance_nm: float | None = None
+    bearing_deg: float | None = None
+    rssi_db: float | None = None
+    message_count: int | None = None
+    seen_s: float | None = None
+    seen_pos_s: float | None = None
+
+    last_seen: IsoTimestamp
+    state: Literal["live", "stale"]
+    sighting_id: int | None = None
+
+    aircraft_type: str | None = None
+    model: str | None = None
+    operator: str | None = None
+    operator_group: str | None = None
+    classification: Classification | None = None
+    interesting: InterestingMatch | None = None
+
+    #: §2.6. Keys name fields; values are the canonical provenance vocabulary.
+    #: A field with no entry is decoder-direct.
+    provenance: dict[str, str] = Field(default_factory=dict)
+
+
+class CurrentAircraftResponse(_Model):
+    """The full live picture — positioned and non-positioned (SPEC §20).
+
+    ``items``/``total`` is the §2.4 list envelope. ``limit`` and ``offset`` are
+    absent on purpose: this endpoint is not paginated (a truncated live picture
+    would be a wrong one), so a page window would be a field that never means
+    anything. ``total`` is the exact size of the returned set.
+    """
+
+    items: list[AircraftView] = Field(default_factory=list)
+    total: int
+
+
+class ReceiverInfo(_Model):
+    """Non-secret receiver identity and configuration — ``docs/API.md`` §3.2."""
+
+    site_name: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    antenna_height_ft: float | None = None
+    timezone: str
+    units: Literal["aviation", "metric"]
+    display_radius_nm: float
+    alert_radius_nm: float | None = None
+    demo_mode: bool
+    #: SPEC §16: when FlightSite first persisted an observation. ``null`` on an
+    #: install that has not seen an aircraft yet.
+    t0: IsoTimestamp | None = None
+
+
+__all__ = [
+    "AircraftView",
+    "Classification",
+    "CurrentAircraftResponse",
+    "GeoPosition",
+    "InterestingMatch",
+    "IsoTimestamp",
+    "PositionSourceLiteral",
+    "ReceiverInfo",
+]

--- a/backend/src/flightsite/api/serializers.py
+++ b/backend/src/flightsite/api/serializers.py
@@ -56,6 +56,7 @@ from datetime import UTC, datetime
 from typing import Any, Final
 
 from flightsite.config import Settings
+from flightsite.ingest import Position
 from flightsite.live import LiveAircraft
 from flightsite.sightings.vocabulary import EMERGENCY_SQUAWKS
 
@@ -154,7 +155,13 @@ def aircraft_payload(record: LiveAircraft, *, sighting_id: int | None = None) ->
     }
 
 
-def receiver_payload(settings: Settings, *, demo_mode: bool, t0: datetime | None) -> dict[str, Any]:
+def receiver_payload(
+    settings: Settings,
+    *,
+    demo_mode: bool,
+    t0: datetime | None,
+    location: Position | None,
+) -> dict[str, Any]:
     """The ``docs/API.md`` §3.2 receiver info block.
 
     Non-secret by construction: every value is read from a named field of the
@@ -169,13 +176,20 @@ def receiver_payload(settings: Settings, *, demo_mode: bool, t0: datetime | None
         demo_mode: whether this process is serving simulated traffic.
         t0: the moment FlightSite first persisted an observation (SPEC §16),
             or ``None`` on an install that has never seen an aircraft.
+        location: the position FlightSite is *actually* measuring from —
+            :attr:`~flightsite.live.store.LiveStore.receiver_location`, not the
+            configured one. The two are the same everywhere except demo mode,
+            which injects a location into an unconfigured install so the
+            simulated sky has ranges (SPEC §76). Reporting the configured
+            ``null`` there would leave a client drawing range rings around
+            nothing while every aircraft carried a ``distance_nm``.
     """
-    location = settings.location
+    site = settings.location
     return {
-        "site_name": location.site_name,
-        "latitude": location.latitude,
-        "longitude": location.longitude,
-        "antenna_height_ft": location.antenna_height_ft,
+        "site_name": site.site_name,
+        "latitude": None if location is None else location.latitude,
+        "longitude": None if location is None else location.longitude,
+        "antenna_height_ft": site.antenna_height_ft,
         "timezone": settings.timezone,
         "units": settings.units,
         "display_radius_nm": settings.display_radius_nm,

--- a/backend/src/flightsite/api/serializers.py
+++ b/backend/src/flightsite/api/serializers.py
@@ -1,0 +1,195 @@
+"""Domain records to the JSON shapes ``docs/API.md`` documents.
+
+One function per documented shape, each returning a plain JSON-ready ``dict``.
+Plain dicts rather than Pydantic instances are deliberate: the WebSocket
+broadcaster serializes an aircraft **once per frame** and hands the same bytes
+to every connected client (``docs/ARCHITECTURE.md`` §3.3), so the hot path must
+not pay for model construction per client. The Pydantic models in
+:mod:`flightsite.api.schemas` describe these same shapes for OpenAPI and
+validate them on the REST path, which keeps the published schema and the
+WebSocket payload provably one shape rather than two that drift.
+
+What the aircraft payload does and does not contain
+---------------------------------------------------
+
+``docs/API.md`` §3.3 shows the full v1 aircraft object, which spans several
+slices. This slice owns the live-state half of it — identity, position,
+kinematics, receiver-relative range, lifecycle state and the open sighting id.
+The metadata half (``registration``, ``aircraft_type``, ``model``,
+``operator``, ``operator_group``, ``classification``) arrives with slices
+021-024 and the alert match (``interesting``) with slice 038. Those keys are
+present and ``null`` rather than absent: §2.7 makes ``null`` the honest
+statement of "unknown", and emitting the full key set now means a client
+written against §3.3 needs no change when the values start arriving.
+
+``emergency`` is not a separate decoder field — it is the squawk restated when
+the squawk is one of the three emergency codes (:data:`EMERGENCY_SQUAWKS`), so
+a client does not have to carry the code list to render an emergency.
+
+Provenance
+----------
+
+§2.6: a ``provenance`` entry names the source of a non-decoder field, and
+fields without an entry are decoder-direct. The live record
+(:mod:`flightsite.live.aircraft`) tracks provenance for the three values that
+layer decides — ``distance_nm``, ``bearing_deg`` and ``ground_state`` — and
+this payload publishes the first two, which are the two that appear in it.
+``ground_state`` is deliberately not published: the API field is ``on_ground``,
+which carries the decoder's own determination or ``null``, never the live
+layer's airborne inference, so there is no derived value here to attribute.
+
+Rounding
+--------
+
+``distance_nm`` and ``bearing_deg`` are computed from a great-circle formula
+and arrive with full float precision, which is fifteen significant digits of
+which about five mean anything. They are rounded — to about two metres and to
+a hundredth of a degree respectively — because at 500 aircraft and 1 Hz the
+unrounded digits are pure payload weight. Every other number is passed through
+exactly as the decoder reported it; FlightSite does not re-derive or "tidy"
+decoder values.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Final
+
+from flightsite.config import Settings
+from flightsite.live import LiveAircraft
+from flightsite.sightings.vocabulary import EMERGENCY_SQUAWKS
+
+#: Provenance keys from the live record that name a field this payload exposes.
+#: See the module docstring for why ``ground_state`` is not among them.
+EXPOSED_PROVENANCE_FIELDS: Final[frozenset[str]] = frozenset({"distance_nm", "bearing_deg"})
+
+#: Decimal places kept on the two derived receiver-relative values.
+DISTANCE_DECIMALS: Final = 3
+BEARING_DECIMALS: Final = 2
+
+
+def iso_utc(moment: datetime) -> str:
+    """Format an instant as ``docs/API.md`` §2.2 UTC ISO-8601.
+
+    Millisecond precision with a literal ``Z``: ``2026-08-31T14:03:22.418Z``.
+    Naive datetimes are rejected rather than assumed to be UTC — the same rule
+    the storage layer applies (:func:`flightsite.db.clock.to_epoch_ms`), for
+    the same reason.
+    """
+    if moment.tzinfo is None:
+        raise ValueError("refusing to serialize a naive datetime; timestamps must be UTC-aware")
+    utc = moment.astimezone(UTC)
+    return f"{utc.strftime('%Y-%m-%dT%H:%M:%S')}.{utc.microsecond // 1000:03d}Z"
+
+
+def _position(record: LiveAircraft) -> dict[str, float] | None:
+    """The ``{lat, lon}`` block, or ``None`` for a non-positioned aircraft."""
+    position = record.position
+    if position is None:
+        return None
+    return {"lat": position.latitude, "lon": position.longitude}
+
+
+def _emergency(squawk: str | None) -> str | None:
+    """The squawk when it declares an emergency, else ``None`` (§3.3)."""
+    return squawk if squawk in EMERGENCY_SQUAWKS else None
+
+
+def _round(value: float | None, decimals: int) -> float | None:
+    return None if value is None else round(value, decimals)
+
+
+def _provenance(record: LiveAircraft) -> dict[str, str]:
+    """The §2.6 provenance map, restricted to fields this payload publishes."""
+    return {
+        field: provenance.value
+        for field, provenance in record.provenance.items()
+        if field in EXPOSED_PROVENANCE_FIELDS
+    }
+
+
+def aircraft_payload(record: LiveAircraft, *, sighting_id: int | None = None) -> dict[str, Any]:
+    """One live aircraft as the ``docs/API.md`` §3.3 object.
+
+    The same object is served by ``GET /api/v1/aircraft/current`` and carried
+    by every WebSocket ``snapshot`` and ``delta`` frame — §3.3 says "the same
+    shape used by the WebSocket", and one function is how that stays true.
+
+    Args:
+        record: the live registry's current record for the aircraft.
+        sighting_id: the id of its open sighting, or ``None`` when the
+            persistence worker has not committed one yet (the normal state for
+            the first second or so of a new aircraft, and the permanent state
+            when persistence is degraded).
+    """
+    return {
+        "icao": record.icao,
+        "callsign": record.callsign,
+        "registration": None,
+        "position": _position(record),
+        "position_source": record.position_source,
+        "altitude_ft": record.altitude_ft,
+        "ground_speed_kt": record.ground_speed_kt,
+        "track_deg": record.track_deg,
+        "vertical_rate_fpm": record.vertical_rate_fpm,
+        "squawk": record.squawk,
+        "emergency": _emergency(record.squawk),
+        "on_ground": record.on_ground,
+        "distance_nm": _round(record.distance_nm, DISTANCE_DECIMALS),
+        "bearing_deg": _round(record.bearing_deg, BEARING_DECIMALS),
+        "rssi_db": record.rssi_db,
+        "message_count": record.messages,
+        "seen_s": record.seen_s,
+        "seen_pos_s": record.seen_pos_s,
+        "last_seen": iso_utc(record.last_seen),
+        "state": record.state.value,
+        "sighting_id": sighting_id,
+        "aircraft_type": None,
+        "model": None,
+        "operator": None,
+        "operator_group": None,
+        "classification": None,
+        "interesting": None,
+        "provenance": _provenance(record),
+    }
+
+
+def receiver_payload(settings: Settings, *, demo_mode: bool, t0: datetime | None) -> dict[str, Any]:
+    """The ``docs/API.md`` §3.2 receiver info block.
+
+    Non-secret by construction: every value is read from a named field of the
+    settings model, so no secret can arrive here by accident (SPEC §29). An
+    unconfigured receiver — the first-run state, before the setup wizard of
+    slice 018 — reports ``null`` location fields rather than an error; §2.7
+    makes that the honest answer, and the live picture works without them.
+
+    Args:
+        settings: the running configuration (read from ``app.state`` per
+            request, since ``PUT /api/internal/config`` replaces it).
+        demo_mode: whether this process is serving simulated traffic.
+        t0: the moment FlightSite first persisted an observation (SPEC §16),
+            or ``None`` on an install that has never seen an aircraft.
+    """
+    location = settings.location
+    return {
+        "site_name": location.site_name,
+        "latitude": location.latitude,
+        "longitude": location.longitude,
+        "antenna_height_ft": location.antenna_height_ft,
+        "timezone": settings.timezone,
+        "units": settings.units,
+        "display_radius_nm": settings.display_radius_nm,
+        "alert_radius_nm": settings.alert_radius_nm,
+        "demo_mode": demo_mode,
+        "t0": None if t0 is None else iso_utc(t0),
+    }
+
+
+__all__ = [
+    "BEARING_DECIMALS",
+    "DISTANCE_DECIMALS",
+    "EXPOSED_PROVENANCE_FIELDS",
+    "aircraft_payload",
+    "iso_utc",
+    "receiver_payload",
+]

--- a/backend/src/flightsite/api/v1.py
+++ b/backend/src/flightsite/api/v1.py
@@ -1,25 +1,46 @@
 """Versioned, documented, read-only public API: ``/api/v1``.
 
-This slice only adds the health and readiness endpoints; the remainder of the
-``/api/v1`` surface (aircraft, sightings, WebSocket, ...) arrives in later
-slices.
+Everything mounted here is safe to hand to another LAN tool: it never mutates
+application state, it never returns a secret, and its shapes are the ones
+``docs/API.md`` publishes (SPEC §74). Mutations live on the unsupported
+``/api/internal`` surface instead.
+
+This slice adds the live picture — ``GET /aircraft/current`` (§3.3), ``GET
+/receiver`` (§3.2) and the ``ws/live`` WebSocket (§4, documented in
+:mod:`flightsite.api.ws`) — on top of the health and readiness endpoints from
+slice 001. The remainder (history, sightings, analytics, diagnostics) arrives
+in later slices.
+
+The REST endpoints declare Pydantic response models, so the OpenAPI document
+served at ``/api/v1/openapi.json`` (§2.10) describes them exactly and every
+response is validated against the shape that was published.
 """
 
 from __future__ import annotations
 
 import time
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Request, Response, status
+from fastapi import APIRouter, Query, Request, Response, status
 
 from flightsite import __version__
+from flightsite.api.context import LiveApiContext
+from flightsite.api.schemas import CurrentAircraftResponse, ReceiverInfo
+from flightsite.api.ws import router as ws_router
 from flightsite.counters import counters
 from flightsite.readiness import ReadinessRegistry
 
 router = APIRouter()
+router.include_router(ws_router)
 
 
-@router.get("/health")
+def _context(request: Request) -> LiveApiContext:
+    """The app's live API context, built once in the application factory."""
+    context: LiveApiContext = request.app.state.api_context
+    return context
+
+
+@router.get("/health", tags=["service"])
 async def health(request: Request) -> dict[str, Any]:
     """Liveness endpoint: always 200 once the app is answering requests."""
     start_time: float = request.app.state.start_time
@@ -37,7 +58,7 @@ async def health(request: Request) -> dict[str, Any]:
     }
 
 
-@router.get("/ready")
+@router.get("/ready", tags=["service"])
 async def ready(request: Request, response: Response) -> dict[str, Any]:
     """Readiness endpoint: 200 once ready, 503 while started-but-not-ready."""
     readiness: ReadinessRegistry = request.app.state.readiness
@@ -45,3 +66,59 @@ async def ready(request: Request, response: Response) -> dict[str, Any]:
     if not is_ready:
         response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
     return {"ready": is_ready, "subsystems": readiness.snapshot()}
+
+
+@router.get(
+    "/receiver",
+    response_model=ReceiverInfo,
+    tags=["live"],
+    summary="Receiver identity and configuration",
+)
+async def receiver(request: Request) -> dict[str, Any]:
+    """Non-secret receiver info — ``docs/API.md`` §3.2.
+
+    Site name, location, antenna height, configured timezone and units, the
+    display and alert radii, whether this process is running demo traffic, and
+    T0. Every field comes from a named configuration field or from the
+    write-once T0 key, so no secret can reach it (SPEC §29).
+
+    Before the setup wizard has collected a receiver position the location
+    fields are ``null``, and on an install that has never persisted an
+    observation ``t0`` is ``null``. Both are ordinary first-run states, not
+    errors.
+    """
+    return await _context(request).receiver()
+
+
+@router.get(
+    "/aircraft/current",
+    response_model=CurrentAircraftResponse,
+    tags=["live"],
+    summary="The current live aircraft picture",
+)
+async def current_aircraft(
+    request: Request,
+    positioned: Annotated[
+        bool | None,
+        Query(
+            description=(
+                "Restrict the result to aircraft with a known position "
+                "(`true`) or to those tracked without one (`false`). "
+                "Omit for the full live picture."
+            )
+        ),
+    ] = None,
+) -> dict[str, Any]:
+    """The live set — positioned **and** non-positioned aircraft (SPEC §20).
+
+    Answered entirely from the in-memory live registry; nothing on this path
+    touches SQLite (``docs/ARCHITECTURE.md`` §3.1). The objects are the §3.3
+    shape, identical to the ones the WebSocket carries, and the response
+    describes the same instant a snapshot taken now would.
+
+    Not paginated: a truncated live picture would be a wrong one, so the §2.4
+    envelope appears without ``limit``/``offset`` and ``total`` is the exact
+    size of the returned set.
+    """
+    items = _context(request).aircraft(positioned=positioned)
+    return {"items": items, "total": len(items)}

--- a/backend/src/flightsite/api/ws.py
+++ b/backend/src/flightsite/api/ws.py
@@ -258,16 +258,6 @@ class ClientConnection:
         """Human-readable close reason, sent alongside the code."""
         return self._close_reason
 
-    @property
-    def pending(self) -> int:
-        """Frames queued and not yet written to the socket."""
-        return self._queue.qsize()
-
-    @property
-    def capacity(self) -> int:
-        """Bound on :attr:`pending` before this client is dropped."""
-        return self._queue.maxsize
-
     def deliver(self, frame: Frame) -> bool:
         """Queue ``frame`` for this connection.
 

--- a/backend/src/flightsite/api/ws.py
+++ b/backend/src/flightsite/api/ws.py
@@ -1,0 +1,699 @@
+"""The live WebSocket: ``/api/v1/ws/live`` — protocol, broadcaster, clients.
+
+OpenAPI 3.1 cannot describe a WebSocket, so ``docs/API.md`` §2.10's published
+schema stops at the REST surface and **this docstring is the reference for the
+socket**. It restates ``docs/API.md`` §4 and pins down the two things a
+document can leave implicit: the exact order a client applies a delta in, and
+what the server does to a client that cannot keep up.
+
+Envelope
+--------
+
+Every server-to-client frame is one JSON object (§4.1)::
+
+    {"type": "snapshot", "seq": 1, "ts": "2026-08-31T14:03:22.418Z", "data": {...}}
+
+``seq`` is **per connection** and starts at 1 with the snapshot. It exists so a
+client can detect a gap; this server never leaves one, because a client it
+cannot deliver to in order is disconnected instead (see *Slow consumers*).
+``ts`` is the server's UTC send time in the §2.2 format. ``type`` is one of
+``snapshot``, ``delta``, ``ping`` or ``pong`` in this slice; slice 035 adds
+``activity``. Per §6 a client must ignore types it does not know.
+
+Frames
+------
+
+**snapshot** — sent immediately on connect, and again if the broadcaster has to
+resync (below). It replaces the client's entire picture::
+
+    {"aircraft": [ /* §3.3 objects */ ], "receiver": { /* §3.2 block */ }}
+
+**delta** — emitted about once a second, batching everything that happened in
+that second (§4.3)::
+
+    {"updated": [ /* complete §3.3 objects */ ], "stale": ["ae1463"], "removed": ["a9c2f0"]}
+
+``updated`` carries **complete** aircraft objects, never field patches, so a
+client can upsert without merge logic. A frame with nothing in any of the three
+lists is not sent — silence means nothing changed, and ``ping`` is the
+keepalive.
+
+*Application order is: ``removed``, then ``stale``, then ``updated``.* Within
+one batch an aircraft is listed at most once in ``removed``, and an aircraft
+that both changed and crossed the staleness threshold appears in ``stale``
+*and* in ``updated`` — its complete object already carries ``state: "stale"``,
+so the two agree and the order only matters for a client that applies ``stale``
+as a flag flip. A client that follows this order ends each batch holding
+exactly what ``GET /api/v1/aircraft/current`` would have returned at the moment
+the frame was built, which is roadmap slice 010's REST/WS agreement criterion.
+
+**ping / pong** — the server sends a ``ping`` frame every
+:data:`DEFAULT_PING_INTERVAL_S` seconds and the client **must** answer with
+``{"type": "pong"}`` (a bare ``"ping"``/``"pong"`` string is also accepted).
+A client that has not sent *anything* across :data:`MISSED_PING_LIMIT`
+consecutive pings is disconnected (§4.5). A client may also send
+``{"type": "ping"}`` at any time and gets a ``pong`` envelope back. This is the
+application-level keepalive, layered over — not instead of — the transport
+ping frames uvicorn sends; the application-level one is what survives an
+intermediary proxy that answers protocol pings on the client's behalf.
+
+Reconnect and resync
+--------------------
+
+There is no delta replay (§4.5). Every connection begins with a snapshot, and
+the snapshot is the only resync mechanism, which is why a client's recovery
+from any inconsistency is simply to reconnect with backoff.
+
+The server resyncs the same way. The broadcaster reads the live store through a
+bounded event subscription; if it ever falls far enough behind that the store
+sheds events, its stream has a hole, and it broadcasts a fresh ``snapshot``
+frame to every client instead of a delta built on a gap
+(:mod:`flightsite.live.events` calls this drop-and-resync).
+
+Slow consumers
+--------------
+
+Each connection has its own bounded outbound queue
+(:data:`DEFAULT_CLIENT_QUEUE_SIZE` frames). When a frame will not fit, that
+client is disconnected with close code :data:`RESYNC_CLOSE_CODE` and the
+``ws_disconnects`` counter rises. The server never buffers without bound and
+never waits for a slow socket — SPEC §5 and ``docs/ARCHITECTURE.md`` §3.3 both
+say distribution must not stall, and one client on a saturated Wi-Fi link must
+not be able to slow ingestion, the live store, or anybody else's stream. The
+dropped client reconnects and gets a coherent snapshot, which is strictly
+better than a stream it is already behind on.
+
+Serialization cost
+------------------
+
+One frame is serialized **once** per tick, not once per client: the aircraft
+objects and the frame body are rendered to a JSON string a single time, and
+each client's envelope is finished by splicing its own ``seq`` around that
+string (:class:`Frame`). Fanning out to N clients therefore costs N small
+string joins rather than N JSON encodings of 500 aircraft.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any, Final
+
+import structlog
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from flightsite.api.context import LiveApiContext
+from flightsite.api.serializers import iso_utc
+from flightsite.counters import WS_DISCONNECTS, CounterRegistry
+from flightsite.counters import counters as default_counters
+from flightsite.live import (
+    DEFAULT_QUEUE_SIZE,
+    AircraftAppeared,
+    AircraftRemoved,
+    AircraftStale,
+    AircraftUpdated,
+    EventSubscription,
+    LiveEvent,
+)
+
+logger = structlog.get_logger(__name__)
+
+#: How often batched deltas are emitted (``docs/API.md`` §4.3, "~1 Hz").
+DEFAULT_BROADCAST_INTERVAL_S: Final = 1.0
+
+#: How often a ``ping`` frame is sent (§4.5).
+DEFAULT_PING_INTERVAL_S: Final = 30.0
+
+#: Consecutive unanswered pings after which a client is disconnected (§4.5).
+MISSED_PING_LIMIT: Final = 2
+
+#: Frames buffered per connection before the client is dropped.
+#:
+#: Thirty-two frames is half a minute of deltas: long enough to absorb a
+#: garbage-collection pause, a browser tab being restored, or a burst of
+#: snapshot-sized frames, and short enough that a client which has genuinely
+#: stopped reading is disconnected before its buffer matters against the
+#: <1 GB process budget. The bound is frames, not bytes, because the failure
+#: being defended against is a socket that has stopped draining at all.
+DEFAULT_CLIENT_QUEUE_SIZE: Final = 32
+
+#: Close code for a server-initiated drop. 1013 ("try again later") says
+#: exactly what the client should do: reconnect with backoff and take the
+#: fresh snapshot (§4.5).
+RESYNC_CLOSE_CODE: Final = 1013
+
+#: Close code used when the process is shutting down.
+GOING_AWAY_CLOSE_CODE: Final = 1001
+
+#: A source of monotonically increasing seconds, injected for tests.
+MonotonicClock = Callable[[], float]
+
+
+class MessageType(StrEnum):
+    """Frame types this slice's protocol defines (``docs/API.md`` §4)."""
+
+    SNAPSHOT = "snapshot"
+    DELTA = "delta"
+    PING = "ping"
+    PONG = "pong"
+
+
+@dataclass(frozen=True, slots=True)
+class Frame:
+    """One rendered frame body, ready to be given a per-connection ``seq``.
+
+    The expensive half of a frame — the ``data`` object — is JSON-encoded once
+    in :meth:`build`; :meth:`render` only splices the envelope around it. Every
+    value interpolated into the envelope is server-generated and drawn from a
+    fixed vocabulary (a :class:`MessageType`, a formatted timestamp, an
+    integer), so the concatenation cannot produce anything but valid JSON.
+    """
+
+    type: MessageType
+    ts: str
+    data_json: str
+
+    @classmethod
+    def build(cls, message_type: MessageType, data: Any) -> Frame:
+        """Encode ``data`` once, stamped with the current UTC instant."""
+        return cls(
+            type=message_type,
+            ts=iso_utc(datetime.now(UTC)),
+            data_json=json.dumps(data, separators=(",", ":")),
+        )
+
+    def render(self, seq: int) -> str:
+        """The complete §4.1 envelope for a connection at sequence ``seq``."""
+        return (
+            f'{{"type":"{self.type.value}","seq":{seq},"ts":"{self.ts}","data":{self.data_json}}}'
+        )
+
+
+class ClientConnection:
+    """One WebSocket client's outbound queue, sequence counter and liveness.
+
+    Owned by the connection's request handler for its lifetime and written to
+    by the broadcaster. Nothing here awaits: enqueueing is ``put_nowait`` and a
+    full queue disconnects the client rather than applying backpressure to the
+    broadcaster, which is the whole point (§4.5).
+    """
+
+    __slots__ = (
+        "_close_code",
+        "_close_reason",
+        "_closed",
+        "_counters",
+        "_name",
+        "_pings_outstanding",
+        "_queue",
+        "_seq",
+    )
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        queue_size: int = DEFAULT_CLIENT_QUEUE_SIZE,
+        counters: CounterRegistry = default_counters,
+    ) -> None:
+        if queue_size < 1:
+            raise ValueError("client queue size must be at least 1")
+        self._name = name
+        self._queue: asyncio.Queue[str | None] = asyncio.Queue(maxsize=queue_size)
+        self._counters = counters
+        self._seq = 0
+        self._pings_outstanding = 0
+        self._closed = False
+        self._close_code = RESYNC_CLOSE_CODE
+        self._close_reason = ""
+
+    @property
+    def name(self) -> str:
+        """Connection label used in logs."""
+        return self._name
+
+    @property
+    def seq(self) -> int:
+        """Sequence number of the last frame handed to this connection."""
+        return self._seq
+
+    @property
+    def closed(self) -> bool:
+        """True once the server has decided this connection is finished."""
+        return self._closed
+
+    @property
+    def close_code(self) -> int:
+        """WebSocket close code the writer should use."""
+        return self._close_code
+
+    @property
+    def close_reason(self) -> str:
+        """Human-readable close reason, sent alongside the code."""
+        return self._close_reason
+
+    @property
+    def pending(self) -> int:
+        """Frames queued and not yet written to the socket."""
+        return self._queue.qsize()
+
+    @property
+    def capacity(self) -> int:
+        """Bound on :attr:`pending` before this client is dropped."""
+        return self._queue.maxsize
+
+    def deliver(self, frame: Frame) -> bool:
+        """Queue ``frame`` for this connection.
+
+        Returns:
+            ``False`` when the client could not take it and has been dropped —
+            either because it was already closed or because its queue is full.
+            The caller's only job on ``False`` is to stop tracking it.
+        """
+        if self._closed:
+            return False
+        # The sequence number advances only if the frame is actually queued, so
+        # a dropped frame cannot leave a hole in a surviving connection's
+        # numbering (§4.1 gives `seq` gaps a meaning, so they must not happen
+        # by accident).
+        seq = self._seq + 1
+        try:
+            self._queue.put_nowait(frame.render(seq))
+        except asyncio.QueueFull:
+            self._terminate(RESYNC_CLOSE_CODE, "slow_consumer", counted=True)
+            return False
+        self._seq = seq
+        return True
+
+    def note_client_message(self) -> None:
+        """Record that the client is alive, clearing its unanswered pings."""
+        self._pings_outstanding = 0
+
+    def note_ping(self) -> bool:
+        """Account for a ping about to be sent.
+
+        Returns:
+            ``False`` if the client has already ignored
+            :data:`MISSED_PING_LIMIT` pings, in which case it has been dropped.
+        """
+        if self._pings_outstanding >= MISSED_PING_LIMIT:
+            self._terminate(RESYNC_CLOSE_CODE, "unresponsive", counted=True)
+            return False
+        self._pings_outstanding += 1
+        return True
+
+    def shut_down(self) -> None:
+        """End the connection because the server is stopping.
+
+        Deliberately not counted: ``ws_disconnects`` measures clients the
+        server had to abandon (§4.5), and a clean shutdown is not one.
+        """
+        self._terminate(GOING_AWAY_CLOSE_CODE, "shutdown", counted=False)
+
+    def _terminate(self, code: int, reason: str, *, counted: bool) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._close_code = code
+        self._close_reason = reason
+        # Discard whatever is queued before signalling: those frames describe a
+        # picture the client is about to be resynced out of, and holding them
+        # would only delay the close behind a backlog.
+        while True:
+            try:
+                self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        self._queue.put_nowait(None)
+        if counted:
+            self._counters.increment(WS_DISCONNECTS)
+            logger.warning(
+                "ws_client_dropped",
+                client=self._name,
+                reason=reason,
+                seq=self._seq,
+                capacity=self._queue.maxsize,
+            )
+
+    async def next_frame(self) -> str | None:
+        """Await the next frame to write, or ``None`` once the client is done."""
+        return await self._queue.get()
+
+
+class LiveBroadcaster:
+    """The single app-level task that fans live changes out to every client.
+
+    One subscription to the live event stream, one delta built per tick, one
+    serialization per frame — see the module docstring. Constructing it
+    subscribes to nothing and starts nothing; :meth:`start` does both.
+
+    Args:
+        context: assembles the aircraft and receiver payloads.
+        interval_s: delta batching period (§4.3's "~1 Hz").
+        ping_interval_s: keepalive period (§4.5).
+        client_queue_size: per-connection outbound bound.
+        event_queue_size: bound on this broadcaster's live-event subscription.
+            Overflowing it triggers a snapshot resync, never a stall.
+        clock: monotonic seconds source, injected for tests.
+        counters: registry receiving ``ws_disconnects``.
+    """
+
+    __slots__ = (
+        "_client_queue_size",
+        "_clients",
+        "_clock",
+        "_connections",
+        "_context",
+        "_counters",
+        "_event_queue_size",
+        "_interval_s",
+        "_last_ping",
+        "_ping_interval_s",
+        "_subscription",
+        "_task",
+    )
+
+    def __init__(
+        self,
+        *,
+        context: LiveApiContext,
+        interval_s: float = DEFAULT_BROADCAST_INTERVAL_S,
+        ping_interval_s: float = DEFAULT_PING_INTERVAL_S,
+        client_queue_size: int = DEFAULT_CLIENT_QUEUE_SIZE,
+        event_queue_size: int = DEFAULT_QUEUE_SIZE,
+        clock: MonotonicClock = time.monotonic,
+        counters: CounterRegistry = default_counters,
+    ) -> None:
+        if interval_s <= 0.0:
+            raise ValueError("broadcast interval must be greater than zero")
+        if ping_interval_s <= 0.0:
+            raise ValueError("ping interval must be greater than zero")
+
+        self._context = context
+        self._interval_s = interval_s
+        self._ping_interval_s = ping_interval_s
+        self._client_queue_size = client_queue_size
+        self._event_queue_size = event_queue_size
+        self._clock = clock
+        self._counters = counters
+
+        self._clients: list[ClientConnection] = []
+        self._subscription: EventSubscription | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._last_ping = 0.0
+        self._connections = 0
+
+    # ------------------------------------------------------------ inspection
+
+    @property
+    def running(self) -> bool:
+        """True while the broadcast task is alive."""
+        return self._task is not None and not self._task.done()
+
+    @property
+    def client_count(self) -> int:
+        """Connections currently receiving frames."""
+        return len(self._clients)
+
+    # -------------------------------------------------------------- lifecycle
+
+    async def start(self) -> None:
+        """Subscribe to live events and start broadcasting. Idempotent."""
+        if self.running:
+            return
+        self._subscription = self._context.live.subscribe(
+            "websocket", maxsize=self._event_queue_size
+        )
+        self._last_ping = self._clock()
+        self._task = asyncio.create_task(self._loop(), name="flightsite-ws-broadcast")
+        logger.info(
+            "ws_broadcaster_started",
+            interval_s=self._interval_s,
+            ping_interval_s=self._ping_interval_s,
+            client_queue_size=self._client_queue_size,
+        )
+
+    async def stop(self) -> None:
+        """Stop broadcasting and close every connection. Idempotent."""
+        task, self._task = self._task, None
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+        subscription, self._subscription = self._subscription, None
+        if subscription is not None:
+            subscription.close()
+
+        clients, self._clients = self._clients, []
+        for client in clients:
+            client.shut_down()
+        logger.info("ws_broadcaster_stopped", clients=len(clients))
+
+    # ------------------------------------------------------------ connections
+
+    def connect(self, receiver: dict[str, Any]) -> ClientConnection:
+        """Register a new client and queue its opening snapshot (§4.2).
+
+        Synchronous from end to end, and that is the point: the live snapshot
+        is taken and the connection joins the fan-out set without an ``await``
+        between the two, so no delta can be published into the gap. The
+        connection's first frame is ``seq: 1``, a full picture, every time.
+
+        Args:
+            receiver: the §3.2 block to embed, already read by the caller (it
+                needs a database round trip for T0, which must happen before
+                this call rather than inside it).
+        """
+        self._connections += 1
+        client = ClientConnection(
+            name=f"ws-{self._connections}",
+            queue_size=self._client_queue_size,
+            counters=self._counters,
+        )
+        client.deliver(self._snapshot_frame(receiver))
+        self._clients.append(client)
+        logger.info("ws_client_connected", client=client.name, clients=len(self._clients))
+        return client
+
+    def disconnect(self, client: ClientConnection) -> None:
+        """Stop delivering to ``client``. Idempotent."""
+        if client in self._clients:
+            self._clients.remove(client)
+            logger.info("ws_client_disconnected", client=client.name, clients=len(self._clients))
+
+    # ------------------------------------------------------------ broadcasting
+
+    async def broadcast_once(self) -> None:
+        """Run one tick: drain events, emit a delta or a resync, then keepalive.
+
+        Split out from :meth:`_loop` so tests drive it a tick at a time instead
+        of sleeping (``docs/TEST_STRATEGY.md`` §3).
+        """
+        subscription = self._subscription
+        if subscription is None:
+            return
+
+        events = subscription.drain()
+        overflowed = subscription.overflowed
+        if overflowed:
+            subscription.acknowledge_overflow()
+
+        # With nobody listening the events are simply discarded: draining is
+        # what keeps the subscription from overflowing on an idle socket, and
+        # serializing frames no one will read would be pure waste.
+        if self._clients:
+            if overflowed:
+                await self._resync()
+            else:
+                self._emit_delta(events)
+        self._maybe_ping()
+
+    async def _loop(self) -> None:
+        while True:
+            await asyncio.sleep(self._interval_s)
+            try:
+                await self.broadcast_once()
+            except Exception as exc:  # pragma: no cover - defensive
+                # One bad tick must not end live distribution for the process:
+                # a dead broadcaster would leave every client silently frozen
+                # on a stale picture, which is worse than a skipped frame.
+                logger.warning("ws_broadcast_error", error=str(exc), error_type=type(exc).__name__)
+
+    def _snapshot_frame(self, receiver: dict[str, Any]) -> Frame:
+        return Frame.build(
+            MessageType.SNAPSHOT,
+            {"aircraft": self._context.aircraft(), "receiver": receiver},
+        )
+
+    async def _resync(self) -> None:
+        """Broadcast a fresh snapshot after the event stream lost events.
+
+        The receiver block needs a database read, so it is fetched first and
+        the live snapshot is taken *after* the await — the frame then describes
+        one coherent instant no earlier than the gap it repairs.
+        """
+        receiver = await self._context.receiver()
+        self._deliver_all(self._snapshot_frame(receiver))
+        logger.warning("ws_resynced_from_snapshot", clients=len(self._clients))
+
+    def _emit_delta(self, events: Sequence[LiveEvent]) -> None:
+        """Collapse one tick's events into a single §4.3 delta frame."""
+        if not events:
+            return
+
+        # The last event for an ICAO decides which notice it belongs in;
+        # `observed` remembers whether it also carried a new observation, so an
+        # aircraft that changed and then went stale in the same second is
+        # reported in both lists rather than losing its update.
+        last: dict[str, type[LiveEvent]] = {}
+        observed: set[str] = set()
+        for event in events:
+            last[event.icao] = type(event)
+            if isinstance(event, AircraftAppeared | AircraftUpdated):
+                observed.add(event.icao)
+            elif isinstance(event, AircraftRemoved):
+                observed.discard(event.icao)
+
+        removed = [icao for icao, kind in last.items() if kind is AircraftRemoved]
+        stale = [icao for icao, kind in last.items() if kind is AircraftStale]
+        updated = self._context.aircraft_for(icao for icao in last if icao in observed)
+        if not (updated or stale or removed):
+            return
+
+        self._deliver_all(
+            Frame.build(
+                MessageType.DELTA,
+                {"updated": updated, "stale": stale, "removed": removed},
+            )
+        )
+
+    def _maybe_ping(self) -> None:
+        """Send a keepalive if one is due, dropping clients that ignored two."""
+        now = self._clock()
+        if now - self._last_ping < self._ping_interval_s:
+            return
+        self._last_ping = now
+
+        frame = Frame.build(MessageType.PING, {})
+        for client in list(self._clients):
+            if not client.note_ping() or not client.deliver(frame):
+                self._clients.remove(client)
+
+    def _deliver_all(self, frame: Frame) -> None:
+        for client in list(self._clients):
+            if not client.deliver(frame):
+                self._clients.remove(client)
+
+
+router = APIRouter()
+
+
+@router.websocket("/ws/live")
+async def live_stream(websocket: WebSocket) -> None:
+    """The live picture: a snapshot on connect, then ~1 Hz deltas (§4).
+
+    Documented in this module's docstring; OpenAPI has no vocabulary for it.
+    """
+    broadcaster: LiveBroadcaster = websocket.app.state.broadcaster
+    context: LiveApiContext = websocket.app.state.api_context
+
+    await websocket.accept()
+    # Read the receiver block (one indexed T0 lookup) before registering: the
+    # snapshot and the fan-out registration must not be separated by an await.
+    receiver = await context.receiver()
+    client = broadcaster.connect(receiver)
+    try:
+        await _serve(websocket, client)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        broadcaster.disconnect(client)
+
+
+async def _serve(websocket: WebSocket, client: ClientConnection) -> None:
+    """Run the connection's reader and writer until either one finishes."""
+    tasks = {
+        asyncio.create_task(_read_from_client(websocket, client), name=f"{client.name}-reader"),
+        asyncio.create_task(_write_to_client(websocket, client), name=f"{client.name}-writer"),
+    }
+    done: set[asyncio.Task[None]] = set()
+    try:
+        done, _pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+    finally:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    for task in done:
+        error = task.exception()
+        if error is not None and not isinstance(error, WebSocketDisconnect):
+            raise error
+
+
+async def _write_to_client(websocket: WebSocket, client: ClientConnection) -> None:
+    """Drain the connection's queue to the socket until it is closed."""
+    while True:
+        frame = await client.next_frame()
+        try:
+            if frame is None:
+                await websocket.close(code=client.close_code, reason=client.close_reason)
+                return
+            await websocket.send_text(frame)
+        except RuntimeError:
+            # Starlette raises RuntimeError when the peer has already gone.
+            # There is nothing to report: the reader sees the same disconnect
+            # and the handler's `finally` deregisters the client either way.
+            return
+
+
+async def _read_from_client(websocket: WebSocket, client: ClientConnection) -> None:
+    """Track client liveness and answer client-initiated pings (§4.5)."""
+    while True:
+        message = await websocket.receive()
+        if message["type"] == "websocket.disconnect":
+            return
+        client.note_client_message()
+        text = message.get("text")
+        if text is not None and _is_ping(text) and not client.deliver(_pong_frame()):
+            return
+
+
+def _pong_frame() -> Frame:
+    return Frame.build(MessageType.PONG, {})
+
+
+def _is_ping(text: str) -> bool:
+    """True when a client message is a ping — an envelope or a bare word."""
+    stripped = text.strip()
+    if stripped == MessageType.PING.value:
+        return True
+    try:
+        message: Any = json.loads(stripped)
+    except ValueError:
+        return False
+    if isinstance(message, str):
+        return message == MessageType.PING.value
+    return isinstance(message, dict) and message.get("type") == MessageType.PING.value
+
+
+__all__ = [
+    "DEFAULT_BROADCAST_INTERVAL_S",
+    "DEFAULT_CLIENT_QUEUE_SIZE",
+    "DEFAULT_PING_INTERVAL_S",
+    "GOING_AWAY_CLOSE_CODE",
+    "MISSED_PING_LIMIT",
+    "RESYNC_CLOSE_CODE",
+    "ClientConnection",
+    "Frame",
+    "LiveBroadcaster",
+    "MessageType",
+    "MonotonicClock",
+    "router",
+]

--- a/backend/src/flightsite/app.py
+++ b/backend/src/flightsite/app.py
@@ -11,8 +11,10 @@ import structlog
 from fastapi import FastAPI
 
 from flightsite import __version__
+from flightsite.api.context import LiveApiContext
 from flightsite.api.internal import router as internal_router
 from flightsite.api.v1 import router as v1_router
+from flightsite.api.ws import LiveBroadcaster
 from flightsite.config import ConfigStore, Settings
 from flightsite.db import Database, database_path, initialize_database
 from flightsite.db.startup import DATABASE_SUBSYSTEM
@@ -126,6 +128,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     database: Database = app.state.database
     live: LiveStore = app.state.live
     persistence: PersistenceWorker = app.state.persistence
+    broadcaster: LiveBroadcaster = app.state.broadcaster
 
     # Migrations and the integrity check run before startup is declared
     # complete. They never abort startup: a failure leaves the `database`
@@ -145,6 +148,11 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     # empty live set costs nothing to sweep, and starting it unconditionally
     # means the store behaves identically the moment ingestion does start.
     await live.start()
+    # Started before ingestion, so the broadcaster's subscription is attached
+    # before the first decoder batch is applied: a client connecting during
+    # startup then gets a snapshot and a continuous delta stream, never a
+    # snapshot followed by a gap.
+    await broadcaster.start()
     app.state.ingestion = await _start_ingestion(app)
     readiness.mark_startup_complete()
     logger.info("app_startup_complete")
@@ -153,13 +161,15 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     finally:
         # Shut down along the direction of data flow, so each stage has
         # already stopped producing before its consumer stops: ingestion, then
-        # the live store's sweep, then the persistence worker — which drains
-        # what those two last emitted and flushes every open sighting before
-        # the engines close.
+        # the live store's sweep, then its two consumers — the WebSocket
+        # broadcaster (which closes every client cleanly) and the persistence
+        # worker, which drains what the first two last emitted and flushes
+        # every open sighting before the engines close.
         service: IngestionService | None = app.state.ingestion
         if service is not None:
             await service.stop()
         await live.stop()
+        await broadcaster.stop()
         await persistence.stop()
         await database.dispose()
         logger.info("app_shutdown")
@@ -194,6 +204,13 @@ def create_app(data_dir: str | os.PathLike[str] | None = None) -> FastAPI:
     process's single SQLite writer (ADR-0008); startup attaches it once the
     schema is known good, and shutdown flushes it before the engines close.
 
+    The live API context and the WebSocket broadcaster are constructed here
+    too, as ``app.state.api_context`` and ``app.state.broadcaster``. The
+    broadcaster is the second consumer of the live event stream: startup gives
+    it its subscription and its ~1 Hz task, and shutdown closes every connected
+    client. The context is what makes ``GET /api/v1/aircraft/current`` and the
+    WebSocket snapshot one implementation rather than two.
+
     Args:
         data_dir: overrides data-directory resolution (``FLIGHTSITE_DATA_DIR``,
             then ``/opt/flightsite/data``). Used by tests.
@@ -206,7 +223,18 @@ def create_app(data_dir: str | os.PathLike[str] | None = None) -> FastAPI:
     # it here keeps the env override winning (SPEC §30).
     configure_logging(level=settings.log_level)
 
-    app = FastAPI(title="FlightSite", version=__version__, lifespan=_lifespan)
+    # docs/API.md §2.10 places the published schema and its interactive docs
+    # under the versioned prefix, not at the server root: the OpenAPI document
+    # describes /api/v1 and nothing else, so it belongs beside what it
+    # describes. The internal router is excluded from it below.
+    app = FastAPI(
+        title="FlightSite",
+        version=__version__,
+        lifespan=_lifespan,
+        openapi_url="/api/v1/openapi.json",
+        docs_url="/api/v1/docs",
+        redoc_url=None,
+    )
     app.state.config_store = store
     app.state.settings = settings
     app.state.readiness = ReadinessRegistry()
@@ -222,6 +250,12 @@ def create_app(data_dir: str | os.PathLike[str] | None = None) -> FastAPI:
     # process-level run mode (FLIGHTSITE_DEMO), not something that changes
     # while the app is up.
     app.state.demo_enabled = demo_enabled()
+    # One assembler for the live payloads, shared by REST and the WebSocket so
+    # the two cannot describe the same instant differently. It reads app.state
+    # lazily, so it is safe to build before the lifespan hook has started
+    # anything and it follows `PUT /api/internal/config` replacing settings.
+    app.state.api_context = LiveApiContext(app)
+    app.state.broadcaster = LiveBroadcaster(context=app.state.api_context)
 
     app.include_router(v1_router, prefix="/api/v1")
     # /api/internal is an unsupported, unversioned surface (ADR-0007) and is

--- a/backend/src/flightsite/counters.py
+++ b/backend/src/flightsite/counters.py
@@ -22,11 +22,18 @@ from typing import Final
 #: visible rather than silent.
 LIVE_EVENTS_DROPPED: Final = "live_events_dropped"
 
+#: WebSocket clients the server had to abandon: a slow consumer whose outbound
+#: queue overflowed, or one that ignored two consecutive pings
+#: (``docs/API.md`` §4.5). A clean disconnect — the client closing, or the
+#: process shutting down — is not counted here, so a rising value always means
+#: distribution shed a client rather than stalling for it.
+WS_DISCONNECTS: Final = "ws_disconnects"
+
 KNOWN_COUNTERS: Final[tuple[str, ...]] = (
     "ingestion_failures",
     "db_errors",
     "enrichment_failures",
-    "ws_disconnects",
+    WS_DISCONNECTS,
     LIVE_EVENTS_DROPPED,
 )
 

--- a/backend/src/flightsite/sightings/worker.py
+++ b/backend/src/flightsite/sightings/worker.py
@@ -247,6 +247,20 @@ class PersistenceWorker:
         """The accumulator tracking ``icao``, live or pending, if any."""
         return self._active.get(icao) or self._pending.get(icao)
 
+    def sighting_id_for(self, icao: str) -> int | None:
+        """The id of ``icao``'s open sighting row, or ``None`` if there is none.
+
+        ``None`` covers three real states and is the honest answer to all of
+        them (``docs/API.md`` §2.7): no sighting is open, one is open but its
+        ``INSERT`` has not committed yet (the first second or so of a new
+        aircraft), or persistence is degraded and no row exists at all. The
+        live API reads this per aircraft when it serializes the live set, so it
+        is a plain in-memory lookup — asking the database here would put SQLite
+        on the live path, which ``docs/ARCHITECTURE.md`` §3.1 forbids.
+        """
+        active = self.sighting_for(icao)
+        return None if active is None else active.sighting_id
+
     # -------------------------------------------------------------- lifecycle
 
     async def start(self) -> None:

--- a/backend/tests/api/__init__.py
+++ b/backend/tests/api/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ``/api/v1`` live surface: REST, WebSocket, and their schema."""

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -1,0 +1,244 @@
+"""Harness for the live API: a hand-driven app and an in-loop WebSocket probe.
+
+Two decisions shape everything here.
+
+**Time is driven, never waited on.** The live store gets the same
+:class:`~tests.live.conftest.ManualClock` its own tests use and a sweep
+interval long enough that only explicit :meth:`LiveApp.sweep` calls advance the
+lifecycle; the broadcaster gets a second manual clock for its ping schedule and
+an interval long enough that only explicit
+:meth:`~flightsite.api.ws.LiveBroadcaster.broadcast_once` calls emit a frame.
+So a test spells out exactly which frames exist and in which order, and a
+loaded machine cannot change the answer (``docs/TEST_STRATEGY.md`` §3).
+
+**The WebSocket is driven through ASGI on the test's own event loop.**
+``TestClient`` runs the app in a second thread, which would make "inject an
+update, then broadcast, then assert on the next frame" a race rather than a
+sequence — and its send side is unbounded, so a client that stops reading is
+not actually slow and slow-consumer eviction could not be observed at all.
+:class:`WebSocketProbe` speaks the ASGI WebSocket protocol directly, one
+coroutine on one loop, and can stall its send side to make a client genuinely
+unable to keep up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, MutableMapping
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from flightsite.api.ws import (
+    DEFAULT_CLIENT_QUEUE_SIZE,
+    DEFAULT_PING_INTERVAL_S,
+    LiveBroadcaster,
+)
+from flightsite.app import create_app
+from flightsite.ingest import AircraftStateUpdate
+from flightsite.live import DEFAULT_QUEUE_SIZE, LiveStore
+from flightsite.sightings import PersistenceWorker
+
+from ..live.conftest import SEATTLE, ManualClock
+
+#: Long enough that no background sweep or broadcast tick ever fires during a
+#: test: every transition and every frame is one the test asked for.
+NEVER_S = 3_600.0
+
+WS_PATH = "/api/v1/ws/live"
+
+
+async def settle(cycles: int = 5) -> None:
+    """Let queued reader/writer tasks run without advancing wall-clock time.
+
+    ``asyncio.sleep(0)`` yields exactly one scheduling round, so a handful of
+    them lets a connection's reader consume a pong and its writer drain a
+    frame. This is not a timeout in disguise — nothing here waits on time
+    passing, only on the loop draining work that is already ready.
+    """
+    for _ in range(cycles):
+        await asyncio.sleep(0)
+
+
+@dataclass(slots=True)
+class LiveApp:
+    """An application whose live store and broadcaster the test drives."""
+
+    app: FastAPI
+    live: LiveStore
+    broadcaster: LiveBroadcaster
+    clock: ManualClock
+    ping_clock: ManualClock
+
+    def feed(self, *updates: AircraftStateUpdate) -> None:
+        """Apply decoder observations straight to the live store."""
+        self.live.apply_updates(updates)
+
+    def advance(self, seconds: float) -> None:
+        """Move the live store's monotonic clock forward."""
+        self.clock.advance(seconds)
+
+    def sweep(self) -> None:
+        """Run one lifecycle pass (stale marking, removal)."""
+        self.live.sweep()
+
+    async def broadcast(self) -> None:
+        """Emit one broadcaster tick and let the connections drain it."""
+        await self.broadcaster.broadcast_once()
+        await settle()
+
+
+def build_live_app(
+    *,
+    client_queue_size: int = DEFAULT_CLIENT_QUEUE_SIZE,
+    ping_interval_s: float = DEFAULT_PING_INTERVAL_S,
+    event_queue_size: int = DEFAULT_QUEUE_SIZE,
+) -> LiveApp:
+    """Build an app whose live store and broadcaster answer to the test.
+
+    The store and the persistence worker are replaced together, so the worker
+    is subscribed to the store the test actually feeds; the broadcaster reads
+    ``app.state`` lazily and therefore picks both up without being told.
+    """
+    app = create_app()
+    clock = ManualClock()
+    live = LiveStore(clock=clock, receiver_location=SEATTLE, sweep_interval_s=NEVER_S)
+    app.state.live = live
+    app.state.persistence = PersistenceWorker(database=app.state.database, live=live)
+
+    ping_clock = ManualClock()
+    broadcaster = LiveBroadcaster(
+        context=app.state.api_context,
+        interval_s=NEVER_S,
+        ping_interval_s=ping_interval_s,
+        client_queue_size=client_queue_size,
+        event_queue_size=event_queue_size,
+        clock=ping_clock,
+    )
+    app.state.broadcaster = broadcaster
+    return LiveApp(app=app, live=live, broadcaster=broadcaster, clock=clock, ping_clock=ping_clock)
+
+
+@pytest.fixture
+async def live_app() -> AsyncIterator[LiveApp]:
+    """A started app on driven clocks, torn down through its real lifespan."""
+    harness = build_live_app()
+    async with harness.app.router.lifespan_context(harness.app):
+        yield harness
+
+
+@pytest.fixture
+async def rest(live_app: LiveApp) -> AsyncIterator[AsyncClient]:
+    """An HTTP client for the same app, on the same event loop."""
+    async with AsyncClient(
+        transport=ASGITransport(app=live_app.app), base_url="http://testserver"
+    ) as client:
+        yield client
+
+
+@dataclass(slots=True)
+class WebSocketProbe:
+    """A WebSocket client that speaks ASGI to the app on the test's own loop.
+
+    Frames the app sends land in :attr:`_inbound`; text the test sends lands in
+    :attr:`_outbound`. :meth:`stall` blocks the send side, which is what a
+    client on a saturated link looks like from the server's point of view.
+    """
+
+    app: FastAPI
+    path: str = WS_PATH
+    _inbound: asyncio.Queue[MutableMapping[str, Any]] = field(default_factory=asyncio.Queue)
+    _outbound: asyncio.Queue[MutableMapping[str, Any]] = field(default_factory=asyncio.Queue)
+    _stalled: asyncio.Event | None = None
+    _task: asyncio.Task[None] | None = None
+
+    async def _receive(self) -> MutableMapping[str, Any]:
+        return await self._outbound.get()
+
+    async def _send(self, message: MutableMapping[str, Any]) -> None:
+        stalled = self._stalled
+        if stalled is not None:
+            await stalled.wait()
+        await self._inbound.put(message)
+
+    async def connect(self) -> None:
+        """Open the connection and wait for the server to accept it."""
+        scope: dict[str, Any] = {
+            "type": "websocket",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "scheme": "ws",
+            "path": self.path,
+            "raw_path": self.path.encode(),
+            "query_string": b"",
+            "root_path": "",
+            "headers": [(b"host", b"testserver")],
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+            "subprotocols": [],
+            "state": {},
+        }
+        await self._outbound.put({"type": "websocket.connect"})
+        self._task = asyncio.create_task(self.app(scope, self._receive, self._send))
+        accept = await self._inbound.get()
+        assert accept["type"] == "websocket.accept", accept
+
+    def stall(self) -> None:
+        """Stop draining the socket: every further server send blocks."""
+        self._stalled = asyncio.Event()
+
+    def resume(self) -> None:
+        """Start draining again."""
+        stalled, self._stalled = self._stalled, None
+        if stalled is not None:
+            stalled.set()
+
+    async def frame(self) -> dict[str, Any]:
+        """The next envelope the server sent, decoded."""
+        message = await self._inbound.get()
+        assert message["type"] == "websocket.send", message
+        decoded: dict[str, Any] = json.loads(message["text"])
+        return decoded
+
+    async def frames(self) -> list[dict[str, Any]]:
+        """Every envelope buffered so far, decoded, without waiting for more."""
+        collected: list[dict[str, Any]] = []
+        while not self._inbound.empty():
+            message = self._inbound.get_nowait()
+            if message["type"] != "websocket.send":
+                break
+            collected.append(json.loads(message["text"]))
+        return collected
+
+    async def close_code(self) -> int:
+        """Read forward to the server's close message and return its code."""
+        while True:
+            message = await self._inbound.get()
+            if message["type"] == "websocket.close":
+                code: int = message["code"]
+                return code
+
+    async def send(self, payload: Any) -> None:
+        """Send a text message to the server."""
+        text = payload if isinstance(payload, str) else json.dumps(payload)
+        await self._outbound.put({"type": "websocket.receive", "text": text})
+        await settle()
+
+    async def disconnect(self) -> None:
+        """Close from the client side and wait for the handler to finish."""
+        await self._outbound.put({"type": "websocket.disconnect", "code": 1000})
+        task = self._task
+        if task is not None:
+            await asyncio.wait_for(task, timeout=5.0)
+            self._task = None
+
+
+async def open_probe(harness: LiveApp) -> tuple[WebSocketProbe, dict[str, Any]]:
+    """Connect a probe and return it with its opening snapshot frame."""
+    probe = WebSocketProbe(app=harness.app)
+    await probe.connect()
+    return probe, await probe.frame()

--- a/backend/tests/api/test_demo_live_api.py
+++ b/backend/tests/api/test_demo_live_api.py
@@ -1,0 +1,112 @@
+"""Demo mode end to end: the live API serving simulated traffic.
+
+SPEC §76 wants the full stack usable with no decoder and no internet, and
+slice 011's demo adapter supplies the traffic. This is the check that the
+slice 010 surface is part of "the full stack": with ``FLIGHTSITE_DEMO=1`` and
+nothing configured, a client gets a growing live picture over REST and the
+same picture over the WebSocket.
+
+Unlike the rest of this package these tests run on the real wall clock — the
+demo adapter's poll loop is production wiring with no injected clock, so a
+short wait is the only way to watch it actually produce traffic. They assert
+on outcomes (aircraft appeared, frames arrived), never on how long anything
+took.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from flightsite.api.schemas import AircraftView, ReceiverInfo
+from flightsite.app import create_app
+from flightsite.config import ConfigStore
+
+from .conftest import WebSocketProbe
+
+#: One demo poll interval plus margin. The adapter ticks on the wall clock, so
+#: the traffic this waits for is real elapsed time, not simulated.
+DEMO_WARMUP_S = 1.5
+
+
+@pytest.fixture(autouse=True)
+def demo_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FLIGHTSITE_DEMO", "1")
+
+
+async def test_demo_mode_serves_a_growing_live_picture(isolated_data_dir: Path) -> None:
+    assert ConfigStore(isolated_data_dir).first_run is True
+    app = create_app()
+
+    async with (
+        app.router.lifespan_context(app),
+        AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver") as client,
+    ):
+        await asyncio.sleep(DEMO_WARMUP_S)
+        body = (await client.get("/api/v1/aircraft/current")).json()
+
+        assert body["total"] > 0
+        assert body["total"] == len(body["items"])
+        for item in body["items"]:
+            AircraftView.model_validate(item)
+
+
+async def test_the_positioned_filter_partitions_the_demo_traffic(isolated_data_dir: Path) -> None:
+    app = create_app()
+
+    async with (
+        app.router.lifespan_context(app),
+        AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver") as client,
+    ):
+        await asyncio.sleep(DEMO_WARMUP_S)
+        everything = (await client.get("/api/v1/aircraft/current")).json()
+        positioned = (await client.get("/api/v1/aircraft/current?positioned=true")).json()
+        unpositioned = (await client.get("/api/v1/aircraft/current?positioned=false")).json()
+
+        assert positioned["total"] > 0
+        # The two filters partition the live set: every aircraft either has a
+        # position or is tracked without one (SPEC §20), and none is dropped.
+        assert positioned["total"] + unpositioned["total"] == everything["total"]
+        assert all(item["position"] is not None for item in positioned["items"])
+        assert all(item["position"] is None for item in unpositioned["items"])
+
+
+async def test_demo_mode_is_declared_by_the_receiver_endpoint(isolated_data_dir: Path) -> None:
+    app = create_app()
+
+    async with (
+        app.router.lifespan_context(app),
+        AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver") as client,
+    ):
+        info = ReceiverInfo.model_validate((await client.get("/api/v1/receiver")).json())
+
+        # No config.yaml exists, but demo mode injects a receiver location so
+        # distance and bearing still compute — and it says it is demo traffic.
+        assert info.demo_mode is True
+        assert info.latitude is not None
+
+
+async def test_demo_mode_streams_snapshot_then_deltas(isolated_data_dir: Path) -> None:
+    app = create_app()
+
+    async with app.router.lifespan_context(app):
+        await asyncio.sleep(DEMO_WARMUP_S)
+        probe = WebSocketProbe(app=app)
+        await probe.connect()
+        try:
+            snapshot = await probe.frame()
+            assert snapshot["type"] == "snapshot"
+            assert len(snapshot["data"]["aircraft"]) > 0
+            assert snapshot["data"]["receiver"]["demo_mode"] is True
+
+            # The production broadcaster is running on its own ~1 Hz task here,
+            # so the next frame arrives because the sky moved, not because the
+            # test asked for it.
+            delta = await asyncio.wait_for(probe.frame(), timeout=10.0)
+            assert delta["type"] in {"delta", "snapshot"}
+            assert delta["seq"] == 2
+        finally:
+            await probe.disconnect()

--- a/backend/tests/api/test_openapi.py
+++ b/backend/tests/api/test_openapi.py
@@ -1,0 +1,86 @@
+"""The published schema — ``docs/API.md`` §2.10.
+
+A schema is only worth serving if it is accurate and if it covers exactly the
+supported surface: the documented read-only endpoints, never the unsupported
+internal one (ADR-0007, SPEC §74).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from flightsite.app import create_app
+
+
+def schema() -> dict[str, Any]:
+    with TestClient(create_app()) as client:
+        response = client.get("/api/v1/openapi.json")
+        assert response.status_code == 200
+        document: dict[str, Any] = response.json()
+        return document
+
+
+def test_the_schema_is_served_under_the_versioned_prefix() -> None:
+    # §2.10 puts the document beside what it describes, not at the server root.
+    with TestClient(create_app()) as client:
+        assert client.get("/api/v1/openapi.json").status_code == 200
+        assert client.get("/openapi.json").status_code == 404
+
+
+def test_the_interactive_docs_are_served_under_the_versioned_prefix() -> None:
+    with TestClient(create_app()) as client:
+        assert client.get("/api/v1/docs").status_code == 200
+
+
+def test_the_live_endpoints_are_documented() -> None:
+    paths = schema()["paths"]
+
+    assert "/api/v1/aircraft/current" in paths
+    assert "/api/v1/receiver" in paths
+    assert "/api/v1/health" in paths
+    assert "/api/v1/ready" in paths
+
+
+def test_the_internal_surface_is_absent() -> None:
+    paths = schema()["paths"]
+
+    assert not any(path.startswith("/api/internal") for path in paths)
+
+
+def test_the_websocket_is_not_in_the_schema() -> None:
+    # OpenAPI 3.1 has no vocabulary for WebSockets; the protocol lives in the
+    # flightsite.api.ws module docstring instead.
+    paths = schema()["paths"]
+
+    assert not any("ws/live" in path for path in paths)
+
+
+def test_the_aircraft_object_is_described_by_a_component() -> None:
+    components = schema()["components"]["schemas"]
+
+    assert "AircraftView" in components
+    properties = components["AircraftView"]["properties"]
+    for field in ("icao", "position_source", "state", "sighting_id", "provenance"):
+        assert field in properties, field
+
+
+def test_the_receiver_block_is_described_by_a_component() -> None:
+    components = schema()["components"]["schemas"]
+
+    assert "ReceiverInfo" in components
+    assert "t0" in components["ReceiverInfo"]["properties"]
+
+
+def test_the_position_source_vocabulary_is_published() -> None:
+    # §2.8's canonical vocabulary, in the schema rather than only in prose.
+    properties = schema()["components"]["schemas"]["AircraftView"]["properties"]
+
+    assert set(properties["position_source"]["enum"]) == {"adsb", "mlat", "none", "other"}
+
+
+def test_the_positioned_filter_is_documented() -> None:
+    operation = schema()["paths"]["/api/v1/aircraft/current"]["get"]
+
+    assert [parameter["name"] for parameter in operation["parameters"]] == ["positioned"]

--- a/backend/tests/api/test_rest_endpoints.py
+++ b/backend/tests/api/test_rest_endpoints.py
@@ -1,0 +1,227 @@
+"""``GET /api/v1/aircraft/current`` and ``GET /api/v1/receiver`` over HTTP."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from flightsite.api.schemas import AircraftView, ReceiverInfo
+from flightsite.app import create_app
+from flightsite.config import ConfigStore
+from flightsite.db import MetaRepository
+from flightsite.ingest import Position
+
+from ..live.conftest import make_update
+from .conftest import LiveApp
+
+NEARBY = Position(latitude=47.6205, longitude=-122.3493)
+
+
+def icaos(body: dict[str, Any]) -> list[str]:
+    return [item["icao"] for item in body["items"]]
+
+
+# --------------------------------------------------------- aircraft/current
+
+
+async def test_an_empty_sky_is_an_empty_list_not_an_error(
+    live_app: LiveApp, rest: AsyncClient
+) -> None:
+    response = await rest.get("/api/v1/aircraft/current")
+
+    assert response.status_code == 200
+    assert response.json() == {"items": [], "total": 0}
+
+
+async def test_the_live_set_is_returned_in_the_documented_shape(
+    live_app: LiveApp, rest: AsyncClient
+) -> None:
+    live_app.feed(make_update("ae1463", position=NEARBY, callsign="RCH492", altitude_ft=24_975.0))
+
+    body = (await rest.get("/api/v1/aircraft/current")).json()
+
+    assert body["total"] == 1
+    aircraft = AircraftView.model_validate(body["items"][0])
+    assert aircraft.icao == "ae1463"
+    assert aircraft.callsign == "RCH492"
+    assert aircraft.altitude_ft == 24_975.0
+    assert aircraft.position is not None
+
+
+async def test_non_positioned_aircraft_are_part_of_the_live_picture(
+    live_app: LiveApp, rest: AsyncClient
+) -> None:
+    # SPEC §20: the endpoint returns positioned *and* non-positioned aircraft.
+    live_app.feed(make_update("ae1463", position=NEARBY), make_update("a9c2f0"))
+
+    body = (await rest.get("/api/v1/aircraft/current")).json()
+
+    assert icaos(body) == ["a9c2f0", "ae1463"]
+    assert body["total"] == 2
+
+
+async def test_the_positioned_filter_selects_aircraft_with_a_position(
+    live_app: LiveApp, rest: AsyncClient
+) -> None:
+    live_app.feed(make_update("ae1463", position=NEARBY), make_update("a9c2f0"))
+
+    with_position = (await rest.get("/api/v1/aircraft/current?positioned=true")).json()
+    without = (await rest.get("/api/v1/aircraft/current?positioned=false")).json()
+
+    assert icaos(with_position) == ["ae1463"]
+    assert icaos(without) == ["a9c2f0"]
+    assert with_position["total"] == 1
+
+
+async def test_an_unparseable_filter_is_a_validation_error(
+    live_app: LiveApp, rest: AsyncClient
+) -> None:
+    response = await rest.get("/api/v1/aircraft/current?positioned=perhaps")
+
+    assert response.status_code == 422
+
+
+async def test_the_result_is_ordered_by_icao(live_app: LiveApp, rest: AsyncClient) -> None:
+    # Deterministic order is what lets a REST read and a WebSocket snapshot of
+    # the same instant be compared as documents rather than as sets.
+    live_app.feed(
+        make_update("ff0011", position=NEARBY),
+        make_update("00aabb"),
+        make_update("a9c2f0", position=NEARBY),
+    )
+
+    body = (await rest.get("/api/v1/aircraft/current")).json()
+
+    assert icaos(body) == ["00aabb", "a9c2f0", "ff0011"]
+
+
+async def test_a_removed_aircraft_leaves_the_live_picture(
+    live_app: LiveApp, rest: AsyncClient
+) -> None:
+    live_app.feed(make_update("ae1463", position=NEARBY))
+    live_app.advance(live_app.live.remove_s + 1.0)
+    live_app.sweep()
+
+    body = (await rest.get("/api/v1/aircraft/current")).json()
+
+    assert body == {"items": [], "total": 0}
+
+
+async def test_a_stale_aircraft_stays_in_the_picture_and_says_so(
+    live_app: LiveApp, rest: AsyncClient
+) -> None:
+    live_app.feed(make_update("ae1463", position=NEARBY))
+    live_app.advance(live_app.live.stale_s + 1.0)
+    live_app.sweep()
+
+    body = (await rest.get("/api/v1/aircraft/current")).json()
+
+    assert body["items"][0]["state"] == "stale"
+
+
+async def test_the_open_sighting_id_reaches_the_payload(
+    live_app: LiveApp, rest: AsyncClient
+) -> None:
+    live_app.feed(make_update("ae1463", position=NEARBY))
+    # One persistence cycle commits the sighting row and assigns its id; until
+    # it does, `sighting_id` is null, which is also a documented state.
+    before = (await rest.get("/api/v1/aircraft/current")).json()
+    await live_app.app.state.persistence.process_pending()
+    after = (await rest.get("/api/v1/aircraft/current")).json()
+
+    assert before["items"][0]["sighting_id"] is None
+    assert (
+        after["items"][0]["sighting_id"]
+        == live_app.app.state.persistence.sighting_for("ae1463").sighting_id
+    )
+
+
+# ------------------------------------------------------------------ receiver
+
+
+async def test_receiver_on_a_first_run_reports_nulls_not_an_error() -> None:
+    # No config.yaml, no setup wizard yet: no location, and nothing persisted,
+    # so no T0. Both are ordinary states (§2.7), not failures. Built from the
+    # unmodified factory, because a first run is precisely an app nobody has
+    # configured anything on.
+    app = create_app()
+
+    async with (
+        app.router.lifespan_context(app),
+        AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver") as client,
+    ):
+        response = await client.get("/api/v1/receiver")
+
+    assert response.status_code == 200
+    info = ReceiverInfo.model_validate(response.json())
+    assert info.site_name is None
+    assert info.latitude is None
+    assert info.longitude is None
+    assert info.t0 is None
+    assert info.demo_mode is False
+
+
+async def test_receiver_reports_the_configured_site(isolated_data_dir: Path) -> None:
+    ConfigStore(isolated_data_dir).apply_update(
+        {
+            "location": {
+                "latitude": 47.6205,
+                "longitude": -122.3493,
+                "site_name": "Rooftop Pi",
+                "antenna_height_ft": 120.0,
+            },
+            "timezone": "America/Los_Angeles",
+            "display_radius_nm": 180.0,
+        }
+    )
+    app = create_app()
+
+    async with (
+        app.router.lifespan_context(app),
+        AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver") as client,
+    ):
+        body = (await client.get("/api/v1/receiver")).json()
+
+    assert body["site_name"] == "Rooftop Pi"
+    assert body["latitude"] == pytest.approx(47.6205)
+    assert body["timezone"] == "America/Los_Angeles"
+    assert body["display_radius_nm"] == pytest.approx(180.0)
+
+
+async def test_receiver_reports_t0_once_an_observation_is_persisted(
+    live_app: LiveApp, rest: AsyncClient
+) -> None:
+    live_app.feed(make_update("ae1463", position=NEARBY))
+    await live_app.app.state.persistence.process_pending()
+
+    body = (await rest.get("/api/v1/receiver")).json()
+
+    assert body["t0"] is not None
+    assert body["t0"].endswith("Z")
+
+
+async def test_receiver_never_returns_a_secret(live_app: LiveApp, rest: AsyncClient) -> None:
+    # SPEC §29: secrets must not reach /api/v1 at all. The response model's
+    # field set is the enforcement; this pins the intent.
+    body = (await rest.get("/api/v1/receiver")).json()
+
+    assert set(body) == set(ReceiverInfo.model_fields)
+
+
+async def test_an_unreadable_t0_does_not_take_the_receiver_endpoint_down(
+    live_app: LiveApp, rest: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A database that failed to migrate already makes /ready answer 503; it
+    # must not also take down a payload that is otherwise pure configuration.
+    async def unavailable(self: MetaRepository) -> int | None:
+        raise RuntimeError("database is unavailable")
+
+    monkeypatch.setattr(MetaRepository, "get_t0", unavailable)
+
+    response = await rest.get("/api/v1/receiver")
+
+    assert response.status_code == 200
+    assert response.json()["t0"] is None

--- a/backend/tests/api/test_rest_ws_agreement.py
+++ b/backend/tests/api/test_rest_ws_agreement.py
@@ -1,0 +1,167 @@
+"""REST and the WebSocket describe the same instant identically.
+
+Roadmap slice 010's first acceptance criterion, tested twice over: the
+snapshot a connection opens with equals what ``GET /api/v1/aircraft/current``
+returns at that moment, and a client that applies the delta stream in the
+documented order stays equal to it — which is the stronger claim, because a
+snapshot that matches once proves nothing about the deltas that follow.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from httpx import ASGITransport, AsyncClient
+
+from flightsite.ingest import Position
+
+from ..live.conftest import make_update
+from .conftest import LiveApp, build_live_app, open_probe
+
+NEARBY = Position(latitude=47.6205, longitude=-122.3493)
+FARTHER = Position(latitude=48.2, longitude=-121.4)
+
+
+def apply_delta(picture: dict[str, dict[str, Any]], delta: dict[str, Any]) -> None:
+    """Fold one delta into a client's picture, in the documented order.
+
+    ``removed``, then ``stale``, then ``updated`` — the order
+    :mod:`flightsite.api.ws` specifies. A real client (slice 014's store) does
+    exactly this.
+    """
+    for icao in delta["removed"]:
+        picture.pop(icao, None)
+    for icao in delta["stale"]:
+        if icao in picture:
+            picture[icao]["state"] = "stale"
+    for aircraft in delta["updated"]:
+        picture[aircraft["icao"]] = aircraft
+
+
+async def rest_picture(client: AsyncClient) -> dict[str, dict[str, Any]]:
+    body = (await client.get("/api/v1/aircraft/current")).json()
+    return {aircraft["icao"]: aircraft for aircraft in body["items"]}
+
+
+async def test_the_opening_snapshot_equals_the_rest_picture(
+    live_app: LiveApp, rest: AsyncClient
+) -> None:
+    live_app.feed(
+        make_update("ae1463", position=NEARBY, callsign="RCH492", altitude_ft=24_975.0),
+        make_update("a9c2f0", position=FARTHER, squawk="7700"),
+        make_update("00beef"),
+    )
+
+    probe, snapshot = await open_probe(live_app)
+    try:
+        body = (await rest.get("/api/v1/aircraft/current")).json()
+
+        # Identical documents, not merely equal sets: both are ordered by ICAO
+        # and built by the same serializer.
+        assert snapshot["data"]["aircraft"] == body["items"]
+    finally:
+        await probe.disconnect()
+
+
+async def test_the_snapshot_receiver_block_equals_the_receiver_endpoint(
+    live_app: LiveApp, rest: AsyncClient
+) -> None:
+    probe, snapshot = await open_probe(live_app)
+    try:
+        body = (await rest.get("/api/v1/receiver")).json()
+
+        assert snapshot["data"]["receiver"] == body
+    finally:
+        await probe.disconnect()
+
+
+async def test_applying_the_delta_stream_converges_on_the_rest_picture(
+    live_app: LiveApp, rest: AsyncClient
+) -> None:
+    live_app.feed(
+        make_update("ae1463", position=NEARBY, altitude_ft=20_000.0),
+        make_update("a9c2f0", position=FARTHER),
+        make_update("00beef"),
+    )
+
+    probe, snapshot = await open_probe(live_app)
+    try:
+        picture = {entry["icao"]: entry for entry in snapshot["data"]["aircraft"]}
+
+        # A second of ordinary traffic: one aircraft climbs, one appears.
+        live_app.feed(
+            make_update("ae1463", offset_s=1.0, position=NEARBY, altitude_ft=21_000.0),
+            make_update("ffaa11", offset_s=1.0, position=FARTHER, callsign="DAL42"),
+        )
+        await live_app.broadcast()
+        apply_delta(picture, (await probe.frame())["data"])
+        assert picture == await rest_picture(rest)
+
+        # Then silence: one crosses the stale threshold, and later leaves.
+        live_app.advance(live_app.live.stale_s + 1.0)
+        live_app.sweep()
+        await live_app.broadcast()
+        apply_delta(picture, (await probe.frame())["data"])
+        assert picture == await rest_picture(rest)
+
+        live_app.advance(live_app.live.remove_s)
+        live_app.sweep()
+        await live_app.broadcast()
+        apply_delta(picture, (await probe.frame())["data"])
+        assert picture == await rest_picture(rest)
+        assert picture == {}
+    finally:
+        await probe.disconnect()
+
+
+async def test_a_reconnecting_client_gets_a_coherent_fresh_snapshot(
+    live_app: LiveApp, rest: AsyncClient
+) -> None:
+    live_app.feed(make_update("ae1463", position=NEARBY))
+    first, _snapshot = await open_probe(live_app)
+
+    # The client goes away mid-stream and misses everything that follows;
+    # §4.5 has no delta replay, so its recovery is entirely the new snapshot.
+    await first.disconnect()
+    live_app.feed(make_update("a9c2f0", position=FARTHER, callsign="DAL42"))
+    live_app.advance(live_app.live.stale_s + 1.0)
+    live_app.sweep()
+    await live_app.broadcast()
+
+    second, snapshot = await open_probe(live_app)
+    try:
+        assert snapshot["seq"] == 1
+        assert (
+            snapshot["data"]["aircraft"]
+            == (await rest.get("/api/v1/aircraft/current")).json()["items"]
+        )
+        states = {entry["icao"]: entry["state"] for entry in snapshot["data"]["aircraft"]}
+        assert states == {"a9c2f0": "stale", "ae1463": "stale"}
+    finally:
+        await second.disconnect()
+
+
+async def test_a_resync_snapshot_equals_the_rest_picture() -> None:
+    # The broadcaster's own event stream loses events, so it resyncs everyone
+    # with a fresh snapshot rather than a delta built on a gap. That snapshot
+    # is read from the live store, so it is exactly what REST would say.
+    harness = build_live_app(event_queue_size=8)
+    async with (
+        harness.app.router.lifespan_context(harness.app),
+        AsyncClient(
+            transport=ASGITransport(app=harness.app), base_url="http://testserver"
+        ) as client,
+    ):
+        probe, _snapshot = await open_probe(harness)
+        try:
+            for index in range(16):
+                harness.feed(make_update(f"{index:06x}", position=NEARBY))
+            await harness.broadcast()
+
+            resync = await probe.frame()
+            assert resync["type"] == "snapshot"
+            picture = {entry["icao"]: entry for entry in resync["data"]["aircraft"]}
+
+            assert picture == await rest_picture(client)
+        finally:
+            await probe.disconnect()

--- a/backend/tests/api/test_serializers.py
+++ b/backend/tests/api/test_serializers.py
@@ -1,0 +1,313 @@
+"""The §3.3 and §3.2 payload shapes, field by field.
+
+These are the contract tests for what FlightSite says about an aircraft: that
+unknown is ``null`` rather than a guess or an absent key, that the canonical
+vocabulary is spelled the way ``docs/API.md`` §2.8 spells it, that timestamps
+are §2.2 UTC, and that derived values — and only derived values — carry
+provenance (§2.6).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from flightsite.api.schemas import AircraftView, ReceiverInfo
+from flightsite.api.serializers import aircraft_payload, iso_utc, receiver_payload
+from flightsite.config import ConfigStore, LocationSettings, Settings
+from flightsite.ingest import Position
+from flightsite.live import LiveAircraft, LiveState, appear, mark_stale, merge
+
+from ..live.conftest import SEATTLE, ManualClock, make_update
+
+NEARBY = Position(latitude=47.6205, longitude=-122.3493)
+
+
+def positioned_record(**fields: Any) -> LiveAircraft:
+    """A live record for an aircraft with a position, seen from Seattle."""
+    return appear(make_update(position=NEARBY, **fields), now=1_000.0, receiver=SEATTLE)
+
+
+def mode_s_record(**fields: Any) -> LiveAircraft:
+    """A live record for an aircraft tracked without a position (SPEC §20)."""
+    return appear(make_update(**fields), now=1_000.0, receiver=SEATTLE)
+
+
+# --------------------------------------------------------------- timestamps
+
+
+def test_iso_utc_uses_millisecond_precision_and_a_z_suffix() -> None:
+    moment = datetime(2026, 8, 31, 14, 3, 22, 418_912, tzinfo=UTC)
+
+    assert iso_utc(moment) == "2026-08-31T14:03:22.418Z"
+
+
+def test_iso_utc_converts_a_non_utc_offset_to_utc() -> None:
+    moment = datetime(2026, 8, 31, 16, 3, 22, tzinfo=timezone(timedelta(hours=2)))
+
+    assert iso_utc(moment) == "2026-08-31T14:03:22.000Z"
+
+
+def test_iso_utc_refuses_a_naive_datetime() -> None:
+    # A naive datetime would silently adopt the host's zone, which is the
+    # exact ambiguity SPEC §15's UTC rule exists to remove.
+    with pytest.raises(ValueError, match="naive"):
+        iso_utc(datetime(2026, 8, 31, 14, 3, 22))
+
+
+def test_last_seen_is_the_decoders_timestamp_not_the_servers() -> None:
+    record = positioned_record()
+
+    assert aircraft_payload(record)["last_seen"] == iso_utc(record.last_seen)
+
+
+# ----------------------------------------------------------------- the shape
+
+
+def test_the_payload_validates_against_the_published_model() -> None:
+    # The response model forbids extra keys, so this fails if the serializer
+    # grows a field the OpenAPI schema does not promise.
+    payload = aircraft_payload(positioned_record(callsign="RCH492", squawk="4521"))
+
+    assert AircraftView.model_validate(payload).icao == payload["icao"]
+
+
+def test_every_documented_key_is_present_even_when_unknown() -> None:
+    payload = aircraft_payload(mode_s_record())
+
+    assert set(payload) == set(AircraftView.model_fields)
+
+
+def test_a_positioned_aircraft_reports_lat_lon_and_its_source() -> None:
+    payload = aircraft_payload(positioned_record())
+
+    assert payload["position"] == {"lat": NEARBY.latitude, "lon": NEARBY.longitude}
+    assert payload["position_source"] == "adsb"
+
+
+def test_a_non_positioned_aircraft_is_a_first_class_entry() -> None:
+    # SPEC §20: Mode S-only aircraft are live entries, not discards.
+    payload = aircraft_payload(mode_s_record(callsign="SWA1234"))
+
+    assert payload["position"] is None
+    assert payload["position_source"] == "none"
+    assert payload["callsign"] == "SWA1234"
+
+
+def test_mlat_positions_keep_their_source() -> None:
+    record = positioned_record(position_source="mlat")
+
+    assert aircraft_payload(record)["position_source"] == "mlat"
+
+
+def test_unreported_fields_are_null_rather_than_zero() -> None:
+    payload = aircraft_payload(mode_s_record())
+
+    for field in ("callsign", "squawk", "altitude_ft", "ground_speed_kt", "track_deg"):
+        assert payload[field] is None, field
+    for field in ("vertical_rate_fpm", "on_ground", "rssi_db", "message_count"):
+        assert payload[field] is None, field
+
+
+def test_metadata_fields_are_null_until_their_own_slices() -> None:
+    # Enrichment (021-024) and alert matching (038) have not landed; §2.7 says
+    # the honest answer is null, and the keys stay so clients can rely on them.
+    payload = aircraft_payload(positioned_record())
+
+    for field in ("registration", "aircraft_type", "model", "operator", "operator_group"):
+        assert payload[field] is None, field
+    assert payload["classification"] is None
+    assert payload["interesting"] is None
+
+
+def test_decoder_values_are_passed_through_unrounded() -> None:
+    record = positioned_record(altitude_ft=24_975.0, ground_speed_kt=442.0, rssi_db=-12.1)
+    payload = aircraft_payload(record)
+
+    assert payload["altitude_ft"] == 24_975.0
+    assert payload["ground_speed_kt"] == 442.0
+    assert payload["rssi_db"] == -12.1
+
+
+def test_message_count_carries_the_decoders_message_total() -> None:
+    assert aircraft_payload(positioned_record(messages=4812))["message_count"] == 4812
+
+
+# ------------------------------------------------------------------- states
+
+
+def test_state_is_the_canonical_lifecycle_word() -> None:
+    live = positioned_record()
+
+    assert aircraft_payload(live)["state"] == "live"
+    assert aircraft_payload(mark_stale(live))["state"] == "stale"
+    assert mark_stale(live).state is LiveState.STALE
+
+
+@pytest.mark.parametrize("squawk", ["7500", "7600", "7700"])
+def test_an_emergency_squawk_is_restated_as_emergency(squawk: str) -> None:
+    payload = aircraft_payload(positioned_record(squawk=squawk))
+
+    assert payload["squawk"] == squawk
+    assert payload["emergency"] == squawk
+
+
+def test_an_ordinary_squawk_declares_no_emergency() -> None:
+    assert aircraft_payload(positioned_record(squawk="4521"))["emergency"] is None
+
+
+def test_ground_state_comes_from_the_decoder_only() -> None:
+    on_ground = aircraft_payload(positioned_record(on_ground=True))
+    airborne = aircraft_payload(positioned_record(on_ground=False))
+    unstated = aircraft_payload(positioned_record())
+
+    assert on_ground["on_ground"] is True
+    assert airborne["on_ground"] is False
+    assert unstated["on_ground"] is None
+
+
+# --------------------------------------------------------------- provenance
+
+
+def test_derived_range_and_bearing_carry_derived_provenance() -> None:
+    payload = aircraft_payload(positioned_record())
+
+    assert payload["provenance"] == {"distance_nm": "derived", "bearing_deg": "derived"}
+
+
+def test_an_unconfigured_receiver_yields_no_range_and_no_provenance() -> None:
+    # The first-run state: no receiver position, so no receiver-relative fields
+    # and nothing to attribute. Everything else still works.
+    record = appear(make_update(position=NEARBY), now=1_000.0, receiver=None)
+    payload = aircraft_payload(record)
+
+    assert payload["distance_nm"] is None
+    assert payload["bearing_deg"] is None
+    assert payload["provenance"] == {}
+
+
+def test_ground_state_provenance_is_not_published_as_a_field() -> None:
+    # The live layer attributes its `ground_state` inference, but the API
+    # publishes `on_ground` — the decoder's own word — so there is no derived
+    # value here to attribute and no entry for one.
+    record = positioned_record(on_ground=True)
+
+    assert "ground_state" in record.provenance
+    assert "ground_state" not in aircraft_payload(record)["provenance"]
+    assert "on_ground" not in aircraft_payload(record)["provenance"]
+
+
+def test_derived_range_is_rounded_but_not_invented() -> None:
+    record = positioned_record()
+    payload = aircraft_payload(record)
+
+    assert record.distance_nm is not None
+    assert payload["distance_nm"] == pytest.approx(record.distance_nm, abs=1e-3)
+    assert payload["bearing_deg"] == pytest.approx(record.bearing_deg, abs=1e-2)
+
+
+# ------------------------------------------------------------- sighting ids
+
+
+def test_sighting_id_is_null_until_persistence_has_opened_one() -> None:
+    assert aircraft_payload(positioned_record())["sighting_id"] is None
+
+
+def test_sighting_id_is_reported_when_the_row_exists() -> None:
+    assert aircraft_payload(positioned_record(), sighting_id=88_213)["sighting_id"] == 88_213
+
+
+# ------------------------------------------------------------------ merging
+
+
+def test_a_merged_record_serializes_its_latest_values() -> None:
+    clock = ManualClock()
+    first = positioned_record(callsign="RCH492")
+    second, _changed = merge(
+        first,
+        make_update(offset_s=1.0, position=NEARBY, squawk="4521"),
+        now=clock.advance(1.0),
+        receiver=SEATTLE,
+    )
+    payload = aircraft_payload(second)
+
+    assert payload["callsign"] == "RCH492"
+    assert payload["squawk"] == "4521"
+
+
+# ---------------------------------------------------------------- receiver
+
+
+def default_settings(store: ConfigStore) -> Settings:
+    return store.load()
+
+
+def test_receiver_payload_reports_an_unconfigured_location_as_null(store: ConfigStore) -> None:
+    payload = receiver_payload(default_settings(store), demo_mode=False, t0=None, location=None)
+
+    assert payload["site_name"] is None
+    assert payload["latitude"] is None
+    assert payload["longitude"] is None
+    assert payload["antenna_height_ft"] is None
+    assert payload["t0"] is None
+    assert ReceiverInfo.model_validate(payload).demo_mode is False
+
+
+def test_receiver_payload_reports_the_configured_site(store: ConfigStore) -> None:
+    settings = store.load()
+    settings.location = LocationSettings(
+        latitude=47.6205, longitude=-122.3493, site_name="Rooftop Pi", antenna_height_ft=120.0
+    )
+    payload = receiver_payload(
+        settings,
+        demo_mode=True,
+        t0=datetime(2026, 4, 2, 18, 11, 9, tzinfo=UTC),
+        location=Position(latitude=47.6205, longitude=-122.3493),
+    )
+
+    assert payload["site_name"] == "Rooftop Pi"
+    assert payload["latitude"] == pytest.approx(47.6205)
+    assert payload["longitude"] == pytest.approx(-122.3493)
+    assert payload["antenna_height_ft"] == pytest.approx(120.0)
+    assert payload["t0"] == "2026-04-02T18:11:09.000Z"
+    assert payload["demo_mode"] is True
+
+
+def test_receiver_payload_carries_the_unit_and_radius_settings(store: ConfigStore) -> None:
+    payload = receiver_payload(default_settings(store), demo_mode=False, t0=None, location=None)
+
+    assert payload["units"] == "aviation"
+    assert payload["timezone"] == "UTC"
+    assert payload["display_radius_nm"] == pytest.approx(250.0)
+    assert payload["alert_radius_nm"] is None
+
+
+def test_receiver_payload_never_carries_a_secret(store: ConfigStore) -> None:
+    settings = store.load()
+    settings.enrichment = settings.enrichment.model_copy(
+        update={"aerodatabox_api_key": None, "aerodatabox_enabled": False}
+    )
+    payload = receiver_payload(settings, demo_mode=False, t0=None, location=None)
+
+    assert set(payload) == set(ReceiverInfo.model_fields)
+    assert not any("key" in field or "secret" in field for field in payload)
+
+
+def test_receiver_payload_reports_the_position_ranges_are_measured_from(
+    store: ConfigStore,
+) -> None:
+    # Demo mode's shape: nothing configured, but a location injected into the
+    # live store so the simulated sky has ranges. Reporting the configured
+    # null there would leave a client with no marker to draw.
+    payload = receiver_payload(
+        default_settings(store),
+        demo_mode=True,
+        t0=None,
+        location=Position(latitude=47.4502, longitude=-122.3088),
+    )
+
+    assert payload["latitude"] == pytest.approx(47.4502)
+    assert payload["longitude"] == pytest.approx(-122.3088)
+    assert payload["site_name"] is None

--- a/backend/tests/api/test_ws_backpressure.py
+++ b/backend/tests/api/test_ws_backpressure.py
@@ -11,6 +11,7 @@ lost.
 from __future__ import annotations
 
 import pytest
+from httpx import ASGITransport, AsyncClient
 
 from flightsite.api.ws import (
     RESYNC_CLOSE_CODE,
@@ -256,3 +257,27 @@ async def test_stopping_twice_is_harmless() -> None:
     await harness.broadcaster.stop()
 
     assert harness.broadcaster.running is False
+
+
+async def test_evictions_are_visible_in_the_health_payload() -> None:
+    # An operator's first question about a flaky client is "is the server
+    # dropping it?", so the counter has to be reachable without a debugger.
+    harness = build_live_app(client_queue_size=1)
+    async with (
+        harness.app.router.lifespan_context(harness.app),
+        AsyncClient(
+            transport=ASGITransport(app=harness.app), base_url="http://testserver"
+        ) as client,
+    ):
+        stalled, _snapshot = await open_probe(harness)
+        stalled.stall()
+        try:
+            for index in range(5):
+                harness.feed(make_update("ae1463", offset_s=index, position=NEARBY))
+                await harness.broadcast()
+
+            health = (await client.get("/api/v1/health")).json()
+            assert health["counters"]["ws_disconnects"] == 1
+        finally:
+            stalled.resume()
+            await stalled.disconnect()

--- a/backend/tests/api/test_ws_backpressure.py
+++ b/backend/tests/api/test_ws_backpressure.py
@@ -1,0 +1,258 @@
+"""Slow consumers and lost events: the two ways the stream refuses to stall.
+
+SPEC §5 and ``docs/ARCHITECTURE.md`` §3.3 make the same demand from two
+directions — one client must never be able to slow ingestion or another
+client, and the broadcaster must never pretend a gap in its own event stream
+was continuity. ``docs/API.md`` §4.5 names both answers: drop the slow client
+so its reconnect resyncs, and resync everyone from a snapshot when events were
+lost.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from flightsite.api.ws import (
+    RESYNC_CLOSE_CODE,
+    ClientConnection,
+    Frame,
+    LiveBroadcaster,
+    MessageType,
+)
+from flightsite.counters import counters
+from flightsite.ingest import Position
+
+from ..live.conftest import make_update
+from .conftest import LiveApp, build_live_app, open_probe, settle
+
+NEARBY = Position(latitude=47.6205, longitude=-122.3493)
+
+#: Small enough that a handful of aircraft overflows the broadcaster's own
+#: event subscription, which is the only way to reach the drop-and-resync path
+#: without publishing thousands of events.
+TINY_EVENT_QUEUE = 8
+
+
+def a_frame() -> Frame:
+    return Frame.build(MessageType.DELTA, {"updated": [], "stale": [], "removed": []})
+
+
+def overflow_the_subscription(harness: LiveApp) -> None:
+    """Publish more events than the broadcaster's subscription can hold."""
+    for index in range(TINY_EVENT_QUEUE + 8):
+        harness.feed(make_update(f"{index:06x}", position=NEARBY))
+
+
+# ----------------------------------------------------- the connection itself
+
+
+def test_a_connection_numbers_the_frames_it_accepted() -> None:
+    client = ClientConnection(name="ws-1", queue_size=4)
+
+    assert client.deliver(a_frame()) is True
+    assert client.deliver(a_frame()) is True
+    assert client.seq == 2
+
+
+async def test_a_full_queue_drops_the_connection() -> None:
+    client = ClientConnection(name="ws-1", queue_size=1)
+    assert client.deliver(a_frame()) is True
+
+    assert client.deliver(a_frame()) is False
+    assert client.closed is True
+    assert client.close_code == RESYNC_CLOSE_CODE
+    assert counters.snapshot()["ws_disconnects"] == 1
+
+
+async def test_a_dropped_connection_discards_its_backlog_and_signals() -> None:
+    client = ClientConnection(name="ws-1", queue_size=1)
+    client.deliver(a_frame())
+    client.deliver(a_frame())
+
+    # The queued frame described a picture the client is about to be resynced
+    # out of; holding it would only delay the close behind a backlog.
+    assert await client.next_frame() is None
+    assert client.deliver(a_frame()) is False
+
+
+def test_a_dropped_frame_does_not_advance_the_sequence() -> None:
+    # §4.1 gives a `seq` gap a meaning, so one must never appear by accident.
+    client = ClientConnection(name="ws-1", queue_size=1)
+    client.deliver(a_frame())
+
+    client.deliver(a_frame())
+
+    assert client.seq == 1
+
+
+def test_a_connection_needs_room_for_at_least_one_frame() -> None:
+    with pytest.raises(ValueError, match="at least 1"):
+        ClientConnection(name="ws-1", queue_size=0)
+
+
+# ------------------------------------------------------ eviction end to end
+
+
+async def test_a_stalled_client_is_evicted_and_the_others_are_untouched() -> None:
+    # A queue of one frame makes "cannot keep up" reachable in a test; the
+    # mechanism is the production one, and so is the eviction it triggers.
+    harness = build_live_app(client_queue_size=1)
+    async with harness.app.router.lifespan_context(harness.app):
+        healthy, _snapshot = await open_probe(harness)
+        stalled, _stalled_snapshot = await open_probe(harness)
+        stalled.stall()
+        try:
+            for index in range(5):
+                harness.feed(make_update("ae1463", offset_s=index, position=NEARBY))
+                await harness.broadcast()
+
+            assert harness.broadcaster.client_count == 1
+            assert counters.snapshot()["ws_disconnects"] == 1
+
+            # The healthy client saw every frame, in order, unaffected by its
+            # neighbour's failure.
+            frames = await healthy.frames()
+            assert [frame["type"] for frame in frames] == ["delta"] * 5
+            assert [frame["seq"] for frame in frames] == [2, 3, 4, 5, 6]
+
+            stalled.resume()
+            assert await stalled.close_code() == RESYNC_CLOSE_CODE
+        finally:
+            await healthy.disconnect()
+            await stalled.disconnect()
+
+
+async def test_a_stalled_client_does_not_stall_the_live_store() -> None:
+    harness = build_live_app(client_queue_size=1)
+    async with harness.app.router.lifespan_context(harness.app):
+        stalled, _snapshot = await open_probe(harness)
+        stalled.stall()
+        try:
+            for index in range(5):
+                harness.feed(make_update("ae1463", offset_s=index, position=NEARBY))
+                await harness.broadcast()
+
+            # Ingestion kept running throughout: the store holds the aircraft
+            # and the REST picture is current, whatever the socket is doing.
+            assert len(harness.live) == 1
+            assert harness.app.state.api_context.aircraft()[0]["icao"] == "ae1463"
+        finally:
+            stalled.resume()
+            await stalled.disconnect()
+
+
+# ---------------------------------------------- resync after lost events
+
+
+async def test_losing_events_broadcasts_a_fresh_snapshot() -> None:
+    harness = build_live_app(event_queue_size=TINY_EVENT_QUEUE)
+    async with harness.app.router.lifespan_context(harness.app):
+        probe, _snapshot = await open_probe(harness)
+        try:
+            # Overflow the broadcaster's own bounded subscription: the live
+            # store sheds its oldest events, so the delta stream has a hole.
+            overflow_the_subscription(harness)
+            await harness.broadcast()
+
+            frame = await probe.frame()
+            assert frame["type"] == "snapshot"
+            assert frame["seq"] == 2
+            icaos = [entry["icao"] for entry in frame["data"]["aircraft"]]
+            assert icaos == sorted(icaos)
+            assert len(icaos) == len(harness.live)
+        finally:
+            await probe.disconnect()
+
+
+async def test_a_resync_is_not_repeated_once_the_gap_is_acknowledged() -> None:
+    harness = build_live_app(event_queue_size=TINY_EVENT_QUEUE)
+    async with harness.app.router.lifespan_context(harness.app):
+        probe, _snapshot = await open_probe(harness)
+        try:
+            overflow_the_subscription(harness)
+            await harness.broadcast()
+            assert (await probe.frame())["type"] == "snapshot"
+
+            harness.feed(make_update("ae1463", offset_s=99.0, position=NEARBY))
+            await harness.broadcast()
+
+            assert (await probe.frame())["type"] == "delta"
+        finally:
+            await probe.disconnect()
+
+
+async def test_events_are_drained_even_with_nobody_listening() -> None:
+    # An idle socket must not let the subscription fill up and start shedding:
+    # draining is cheap, and serializing frames no one will read is not.
+    harness = build_live_app()
+    async with harness.app.router.lifespan_context(harness.app):
+        harness.feed(make_update("ae1463", position=NEARBY))
+        await harness.broadcast()
+
+        assert harness.broadcaster.client_count == 0
+        assert counters.snapshot()["live_events_dropped"] == 0
+
+
+async def test_a_client_connecting_during_a_gap_still_gets_a_coherent_picture() -> None:
+    harness = build_live_app(event_queue_size=TINY_EVENT_QUEUE)
+    async with harness.app.router.lifespan_context(harness.app):
+        overflow_the_subscription(harness)
+
+        probe, snapshot = await open_probe(harness)
+        try:
+            # The snapshot is read from the store, not replayed from events,
+            # so a hole in the event stream cannot make it wrong.
+            await settle()
+            assert len(snapshot["data"]["aircraft"]) == len(harness.live)
+        finally:
+            await probe.disconnect()
+
+
+async def test_dropping_a_connection_twice_counts_once() -> None:
+    client = ClientConnection(name="ws-1", queue_size=1)
+    client.deliver(a_frame())
+
+    client.deliver(a_frame())
+    client.deliver(a_frame())
+
+    # The connection is already gone; counting it again would make
+    # `ws_disconnects` a measure of broadcast attempts rather than of clients.
+    assert counters.snapshot()["ws_disconnects"] == 1
+
+
+def test_a_broadcaster_needs_a_positive_interval() -> None:
+    context = build_live_app().app.state.api_context
+
+    with pytest.raises(ValueError, match="broadcast interval"):
+        LiveBroadcaster(context=context, interval_s=0.0)
+    with pytest.raises(ValueError, match="ping interval"):
+        LiveBroadcaster(context=context, ping_interval_s=-1.0)
+
+
+async def test_starting_twice_keeps_one_subscription() -> None:
+    harness = build_live_app()
+    async with harness.app.router.lifespan_context(harness.app):
+        # The lifespan already started it; a second start must not attach a
+        # second subscription, which would double every event it sees.
+        await harness.broadcaster.start()
+
+        assert harness.broadcaster.running is True
+        assert harness.live.events.subscriber_count == 2  # broadcaster + persistence
+
+
+async def test_broadcasting_before_start_is_a_no_op() -> None:
+    harness = build_live_app()
+
+    await harness.broadcaster.broadcast_once()
+
+    assert harness.broadcaster.client_count == 0
+
+
+async def test_stopping_twice_is_harmless() -> None:
+    harness = build_live_app()
+    async with harness.app.router.lifespan_context(harness.app):
+        pass
+
+    await harness.broadcaster.stop()
+
+    assert harness.broadcaster.running is False

--- a/backend/tests/api/test_ws_protocol.py
+++ b/backend/tests/api/test_ws_protocol.py
@@ -1,0 +1,401 @@
+"""The ``/api/v1/ws/live`` protocol: snapshot, deltas, notices, keepalive.
+
+Every frame in these tests exists because the test asked for it: the live
+store's clock and the broadcaster's tick are both driven by hand, so an
+assertion about "the next frame" is an assertion about the protocol and never
+about scheduling luck.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from flightsite.api.schemas import AircraftView, ReceiverInfo
+from flightsite.counters import counters
+from flightsite.ingest import Position
+
+from ..live.conftest import make_update
+from .conftest import LiveApp, WebSocketProbe, build_live_app, open_probe, settle
+
+NEARBY = Position(latitude=47.6205, longitude=-122.3493)
+FARTHER = Position(latitude=48.0, longitude=-122.0)
+
+
+def data(frame: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = frame["data"]
+    return payload
+
+
+# ------------------------------------------------------------- connect (§4.2)
+
+
+async def test_a_new_connection_is_answered_with_a_snapshot(live_app: LiveApp) -> None:
+    live_app.feed(make_update("ae1463", position=NEARBY, callsign="RCH492"))
+
+    probe, snapshot = await open_probe(live_app)
+    try:
+        assert snapshot["type"] == "snapshot"
+        assert snapshot["seq"] == 1
+        assert snapshot["ts"].endswith("Z")
+        aircraft = data(snapshot)["aircraft"]
+        assert [entry["icao"] for entry in aircraft] == ["ae1463"]
+        AircraftView.model_validate(aircraft[0])
+        ReceiverInfo.model_validate(data(snapshot)["receiver"])
+    finally:
+        await probe.disconnect()
+
+
+async def test_the_snapshot_carries_the_receiver_block(live_app: LiveApp) -> None:
+    probe, snapshot = await open_probe(live_app)
+    try:
+        assert data(snapshot)["receiver"]["demo_mode"] is False
+        assert data(snapshot)["receiver"]["display_radius_nm"] == 250.0
+    finally:
+        await probe.disconnect()
+
+
+async def test_an_empty_sky_still_produces_a_snapshot(live_app: LiveApp) -> None:
+    probe, snapshot = await open_probe(live_app)
+    try:
+        assert data(snapshot)["aircraft"] == []
+    finally:
+        await probe.disconnect()
+
+
+# --------------------------------------------------------------- deltas (§4.3)
+
+
+async def test_a_new_aircraft_arrives_as_a_complete_object(live_app: LiveApp) -> None:
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        live_app.feed(make_update("ae1463", position=NEARBY, callsign="RCH492"))
+        await live_app.broadcast()
+
+        delta = await probe.frame()
+        assert delta["type"] == "delta"
+        assert delta["seq"] == 2
+        updated = data(delta)["updated"]
+        # §4.3: complete aircraft objects, never field patches.
+        assert set(updated[0]) == set(AircraftView.model_fields)
+        assert updated[0]["callsign"] == "RCH492"
+        assert data(delta)["stale"] == []
+        assert data(delta)["removed"] == []
+    finally:
+        await probe.disconnect()
+
+
+async def test_a_batch_reports_one_entry_per_changed_aircraft(live_app: LiveApp) -> None:
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        # Three observations of the same aircraft inside one tick: the delta
+        # carries its latest state once, not three intermediate copies.
+        live_app.feed(make_update("ae1463", position=NEARBY, altitude_ft=20_000.0))
+        live_app.feed(make_update("ae1463", offset_s=1.0, position=NEARBY, altitude_ft=21_000.0))
+        live_app.feed(make_update("ae1463", offset_s=2.0, position=FARTHER, altitude_ft=22_000.0))
+        await live_app.broadcast()
+
+        updated = data(await probe.frame())["updated"]
+        assert len(updated) == 1
+        assert updated[0]["altitude_ft"] == 22_000.0
+    finally:
+        await probe.disconnect()
+
+
+async def test_nothing_happening_produces_no_frame(live_app: LiveApp) -> None:
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        await live_app.broadcast()
+
+        assert await probe.frames() == []
+    finally:
+        await probe.disconnect()
+
+
+async def test_crossing_the_stale_threshold_is_announced(live_app: LiveApp) -> None:
+    live_app.feed(make_update("ae1463", position=NEARBY))
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        live_app.advance(live_app.live.stale_s + 1.0)
+        live_app.sweep()
+        await live_app.broadcast()
+
+        delta = data(await probe.frame())
+        assert delta["stale"] == ["ae1463"]
+        assert delta["removed"] == []
+    finally:
+        await probe.disconnect()
+
+
+async def test_leaving_the_live_set_is_announced(live_app: LiveApp) -> None:
+    live_app.feed(make_update("ae1463", position=NEARBY))
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        live_app.advance(live_app.live.remove_s + 1.0)
+        live_app.sweep()
+        await live_app.broadcast()
+
+        delta = data(await probe.frame())
+        assert delta["removed"] == ["ae1463"]
+        assert delta["updated"] == []
+    finally:
+        await probe.disconnect()
+
+
+async def test_a_removal_supersedes_an_update_in_the_same_batch(live_app: LiveApp) -> None:
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        live_app.feed(make_update("ae1463", position=NEARBY))
+        live_app.advance(live_app.live.remove_s + 1.0)
+        live_app.sweep()
+        await live_app.broadcast()
+
+        delta = data(await probe.frame())
+        # Appeared and removed within one second: the removal is the only
+        # truthful statement, and an `updated` entry for a gone aircraft would
+        # leave the client holding a ghost.
+        assert delta["removed"] == ["ae1463"]
+        assert delta["updated"] == []
+    finally:
+        await probe.disconnect()
+
+
+async def test_an_aircraft_that_changed_and_went_stale_appears_in_both_lists(
+    live_app: LiveApp,
+) -> None:
+    live_app.feed(make_update("ae1463", position=NEARBY, altitude_ft=20_000.0))
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        live_app.feed(make_update("ae1463", offset_s=1.0, position=NEARBY, altitude_ft=21_000.0))
+        live_app.advance(live_app.live.stale_s + 1.0)
+        live_app.sweep()
+        await live_app.broadcast()
+
+        delta = data(await probe.frame())
+        assert delta["stale"] == ["ae1463"]
+        # The update is not lost, and the complete object it carries already
+        # says `stale`, so the two notices cannot contradict each other.
+        assert delta["updated"][0]["altitude_ft"] == 21_000.0
+        assert delta["updated"][0]["state"] == "stale"
+    finally:
+        await probe.disconnect()
+
+
+async def test_an_aircraft_heard_again_after_going_stale_is_live_again(
+    live_app: LiveApp,
+) -> None:
+    live_app.feed(make_update("ae1463", position=NEARBY))
+    live_app.advance(live_app.live.stale_s + 1.0)
+    live_app.sweep()
+    probe, snapshot = await open_probe(live_app)
+    try:
+        assert data(snapshot)["aircraft"][0]["state"] == "stale"
+
+        live_app.feed(make_update("ae1463", offset_s=20.0, position=NEARBY))
+        await live_app.broadcast()
+
+        delta = data(await probe.frame())
+        assert delta["stale"] == []
+        assert delta["updated"][0]["state"] == "live"
+    finally:
+        await probe.disconnect()
+
+
+# ------------------------------------------------------------ sequencing (§4.1)
+
+
+async def test_seq_increases_by_one_per_frame_on_a_connection(live_app: LiveApp) -> None:
+    probe, snapshot = await open_probe(live_app)
+    try:
+        seqs = [snapshot["seq"]]
+        for index in range(4):
+            live_app.feed(make_update("ae1463", offset_s=index, position=NEARBY))
+            await live_app.broadcast()
+            seqs.append((await probe.frame())["seq"])
+
+        assert seqs == [1, 2, 3, 4, 5]
+    finally:
+        await probe.disconnect()
+
+
+async def test_each_connection_has_its_own_sequence(live_app: LiveApp) -> None:
+    first, _snapshot = await open_probe(live_app)
+    try:
+        live_app.feed(make_update("ae1463", position=NEARBY))
+        await live_app.broadcast()
+        assert (await first.frame())["seq"] == 2
+
+        second, late_snapshot = await open_probe(live_app)
+        try:
+            # A client that joined late starts at 1, not at the broadcaster's
+            # running count: `seq` is per connection (§4.1).
+            assert late_snapshot["seq"] == 1
+
+            live_app.feed(make_update("a9c2f0", position=NEARBY))
+            await live_app.broadcast()
+            assert (await first.frame())["seq"] == 3
+            assert (await second.frame())["seq"] == 2
+        finally:
+            await second.disconnect()
+    finally:
+        await first.disconnect()
+
+
+# ------------------------------------------------------- keepalive (§4.5)
+
+
+async def test_the_server_pings_on_its_schedule() -> None:
+    harness = build_live_app(ping_interval_s=30.0)
+    async with harness.app.router.lifespan_context(harness.app):
+        probe, _snapshot = await open_probe(harness)
+        try:
+            await harness.broadcast()
+            assert await probe.frames() == []
+
+            harness.ping_clock.advance(31.0)
+            await harness.broadcast()
+
+            ping = await probe.frame()
+            assert ping["type"] == "ping"
+            assert ping["seq"] == 2
+        finally:
+            await probe.disconnect()
+
+
+async def test_a_client_ping_is_answered_with_a_pong(live_app: LiveApp) -> None:
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        await probe.send({"type": "ping"})
+
+        pong = await probe.frame()
+        assert pong["type"] == "pong"
+        assert pong["seq"] == 2
+    finally:
+        await probe.disconnect()
+
+
+async def test_a_bare_ping_word_is_also_answered(live_app: LiveApp) -> None:
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        await probe.send("ping")
+
+        assert (await probe.frame())["type"] == "pong"
+    finally:
+        await probe.disconnect()
+
+
+async def test_a_client_that_answers_pings_is_kept() -> None:
+    harness = build_live_app(ping_interval_s=30.0)
+    async with harness.app.router.lifespan_context(harness.app):
+        probe, _snapshot = await open_probe(harness)
+        try:
+            for _ in range(4):
+                harness.ping_clock.advance(31.0)
+                await harness.broadcast()
+                assert (await probe.frame())["type"] == "ping"
+                await probe.send({"type": "pong"})
+
+            assert harness.broadcaster.client_count == 1
+        finally:
+            await probe.disconnect()
+
+
+async def test_a_client_that_ignores_two_pings_is_dropped() -> None:
+    harness = build_live_app(ping_interval_s=30.0)
+    async with harness.app.router.lifespan_context(harness.app):
+        probe = WebSocketProbe(app=harness.app)
+        await probe.connect()
+        await probe.frame()
+
+        for _ in range(3):
+            harness.ping_clock.advance(31.0)
+            await harness.broadcast()
+
+        # Two unanswered pings is the documented limit; the third ping's turn
+        # is when the connection goes.
+        assert harness.broadcaster.client_count == 0
+        assert await probe.close_code() == 1013
+        await probe.disconnect()
+
+
+async def test_any_client_message_counts_as_liveness() -> None:
+    harness = build_live_app(ping_interval_s=30.0)
+    async with harness.app.router.lifespan_context(harness.app):
+        probe, _snapshot = await open_probe(harness)
+        try:
+            for _ in range(4):
+                harness.ping_clock.advance(31.0)
+                await harness.broadcast()
+                await probe.frames()
+                # Not a pong, not even a known type — but the client is
+                # demonstrably alive, which is what the check is for.
+                await probe.send({"type": "hello"})
+                await settle()
+
+            assert harness.broadcaster.client_count == 1
+        finally:
+            await probe.disconnect()
+
+
+# ---------------------------------------------------------- disconnect (§4.5)
+
+
+async def test_a_client_disconnect_deregisters_it(live_app: LiveApp) -> None:
+    probe, _snapshot = await open_probe(live_app)
+    assert live_app.broadcaster.client_count == 1
+
+    await probe.disconnect()
+
+    assert live_app.broadcaster.client_count == 0
+
+
+async def test_a_clean_disconnect_is_not_counted_as_a_drop(live_app: LiveApp) -> None:
+    probe, _snapshot = await open_probe(live_app)
+    await probe.disconnect()
+
+    # `ws_disconnects` measures clients the server had to abandon, so a client
+    # closing normally must leave it alone.
+    assert counters.snapshot()["ws_disconnects"] == 0
+
+
+async def test_shutdown_closes_every_client_without_counting_a_drop() -> None:
+    harness = build_live_app()
+    async with harness.app.router.lifespan_context(harness.app):
+        probe, _snapshot = await open_probe(harness)
+
+    assert await probe.close_code() == 1001
+    assert counters.snapshot()["ws_disconnects"] == 0
+    await probe.disconnect()
+
+
+async def test_a_message_that_is_not_json_is_ignored(live_app: LiveApp) -> None:
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        # §6 tells clients to tolerate what they do not understand; the server
+        # extends the same courtesy rather than dropping the connection.
+        await probe.send("not json at all")
+
+        assert await probe.frames() == []
+        assert live_app.broadcaster.client_count == 1
+    finally:
+        await probe.disconnect()
+
+
+async def test_a_json_string_ping_is_answered(live_app: LiveApp) -> None:
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        await probe.send('"ping"')
+
+        assert (await probe.frame())["type"] == "pong"
+    finally:
+        await probe.disconnect()
+
+
+async def test_an_unknown_envelope_type_is_ignored(live_app: LiveApp) -> None:
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        await probe.send({"type": "subscribe", "data": {}})
+
+        assert await probe.frames() == []
+        assert live_app.broadcaster.client_count == 1
+    finally:
+        await probe.disconnect()

--- a/backend/tests/ingest/test_connection_test.py
+++ b/backend/tests/ingest/test_connection_test.py
@@ -223,6 +223,6 @@ def test_connection_test_is_not_in_the_published_openapi_schema(
     app = create_app()
 
     with TestClient(app) as client:
-        schema = client.get("/openapi.json").json()
+        schema = client.get("/api/v1/openapi.json").json()
 
     assert not any("decoder" in path for path in schema["paths"])

--- a/backend/tests/test_config_api.py
+++ b/backend/tests/test_config_api.py
@@ -195,7 +195,7 @@ def test_validation_errors_do_not_echo_the_rejected_secret(client: TestClient) -
 
 
 def test_internal_api_is_excluded_from_the_openapi_schema(client: TestClient) -> None:
-    schema = client.get("/openapi.json").json()
+    schema = client.get("/api/v1/openapi.json").json()
 
     assert "/api/v1/health" in schema["paths"]
     assert not any(path.startswith("/api/internal") for path in schema["paths"])

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,7 +1,7 @@
 # FlightSite frontend nginx config (served by nginxinc/nginx-unprivileged).
 #
 # Serves the built React SPA and reverse-proxies /api (including the
-# WebSocket upgrade needed by the future /api/v1/ws/ live feed) to the
+# WebSocket upgrade needed by the /api/v1/ws/live feed) to the
 # backend container. Per docs/ARCHITECTURE.md §2 and
 # docs/adr/0002-two-container-compose-topology.md, the browser talks only to
 # this container — one origin, no CORS.
@@ -56,7 +56,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
-        # WebSocket upgrade (for /api/v1/ws/live once it lands).
+        # WebSocket upgrade, used by /api/v1/ws/live.
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
 

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -392,7 +392,7 @@ slices:
     title: "Live API & WebSocket"
     phase: 2
     branch: "010-live-api-websocket"
-    status: planned
+    status: merged
     depends_on: ["005", "008", "009"]
     objective: "Expose live aircraft state via versioned REST and a snapshot+delta WebSocket stream."
     scope:


### PR DESCRIPTION
## Slice
- **Slice ID:** 010 — Live API & WebSocket
- **Roadmap:** `planning/roadmap.yaml` slice 010 (phase 2)
- **Issue:** Closes #36

## Objective
Versioned REST + snapshot/delta WebSocket for live aircraft state.

## Implementation summary
- Serializers + typed Pydantic response models to the docs/API.md §3.2/§3.3 shapes; one LiveApiContext assembler so REST and WS cannot disagree by construction; stable key set (metadata fields null until phase 4)
- GET /api/v1/aircraft/current (?positioned filter per doc) + GET /api/v1/receiver (incl. T0; effective receiver location so demo mode draws correctly)
- WS /api/v1/ws/live: per-connection seq envelopes; snapshot on connect with no-await coherence window; ~1 Hz coalesced deltas (complete objects; removed→stale→updated application order documented + tested); app-level ping/pong (proxy-safe) with two-strike drop; per-client bounded queues — slow consumer closed 1013 + ws_disconnects, seq never gaps; broadcaster overflow → fresh snapshot to all; one serialization per tick, per-client seq spliced (N string joins, not N encodings)
- OpenAPI relocated to /api/v1/openapi.json + /api/v1/docs per §2.10; WS documented in the module docstring (its §4 reference)
- PersistenceWorker.sighting_id_for() read-only accessor (in-memory; live path stays DB-free)

## Acceptance criteria
- [x] REST and WS agree for the same instant (client-simulation convergence test)
- [x] reconnect receives a coherent snapshot
- [x] slow consumer never stalls ingestion or other clients (eviction test, counter asserted)
- [x] OpenAPI generated for the documented endpoints

## Tests added/run
105 new tests; suite 771 passed; coverage **98.70%** (ws.py 96%, rest 98–100%). Reviewer re-ran gates on the dev-merged tree.

## Performance considerations
Single-serialization fan-out; bounded everything; demo end-to-end verifies growing live set over the wire.

## Security / Data considerations
Read-only surface; no secrets in payloads; no schema changes.

## Documentation updates
backend/README + nginx comments point at the live API. API.md deviations documented in the PR (envelope without limit/offset for the unpaginatable live set; last_seen added per §6 additive policy; app-level ping) — will fold into API.md at the next docs pass (slice 051 accuracy pass covers it).

## Known limitations
Display-radius filtering deliberately not implemented (not in the documented contract; client-side per §3.2 data).

## Follow-up work
Slice 014 consumes the WS (client must implement pong); slice 035 adds the activity frame.

## Fable self-review (SPEC §104)
- [x] Full diff inspected; protocol coherence mechanisms verified (connect window, seq discipline, resync); deviations all documented and justified; no TODO/FIXME
- [x] Reconciled with dev; 771 tests green post-merge
- [ ] CI green on this PR (gate before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)