### PR TITLE
Slice 053: Unclean-shutdown recovery

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -87,6 +87,12 @@ markers = [
     # regression should fail an ordinary test run — but the marker lets CI or a
     # developer select (`-m perf`) or exclude (`-m 'not perf'`) them.
     "perf: performance sanity checks with a wall-clock budget",
+    # Crash drills that spawn a real application subprocess and kill it. They
+    # run in the normal suite — unclean-shutdown recovery is a SPEC §84
+    # critical-coverage area and a regression must fail an ordinary run — but
+    # they cost seconds rather than milliseconds, so `-m 'not drill'` skips
+    # them during a tight edit loop.
+    "drill: unclean-shutdown drills that spawn and kill a real process",
 ]
 
 [tool.coverage.run]

--- a/backend/src/flightsite/sightings/__init__.py
+++ b/backend/src/flightsite/sightings/__init__.py
@@ -10,6 +10,7 @@ Module                                     Responsibility
 :mod:`~flightsite.sightings.track_codec`   the packed track encoding + decoder
 :mod:`~flightsite.sightings.state`         per-sighting in-memory accumulator
 :mod:`~flightsite.sightings.repository`    SQL for the sighting-owned tables
+:mod:`~flightsite.sightings.recovery`      startup repair after an unclean stop
 :mod:`~flightsite.sightings.worker`        the single-writer persistence worker
 ========================================== =====================================
 
@@ -18,14 +19,21 @@ ADR-0008) and is a pure consumer of the live event stream: nothing in
 :mod:`flightsite.live` or :mod:`flightsite.ingest` depends on it, so a stalled
 database cannot reach back and delay a decoder poll.
 
-Unclean-shutdown recovery (``sightings/recovery.py``, slice 053) extends this
-package later, on the checkpoint rows slice 052 writes: an open sighting's path
-is already durable to within one flush interval, so recovery is a matter of
-closing the sighting from what is on disk rather than of reconstructing it.
+Unclean-shutdown recovery runs at every worker start, on the checkpoint rows
+the previous process wrote: an open sighting's path is already durable to
+within one flush interval, so recovery closes the sighting from what is on disk
+through the ordinary close path rather than reconstructing anything (SPEC §71,
+ADR-0005).
 """
 
 from __future__ import annotations
 
+from flightsite.sightings.recovery import (
+    DEFAULT_RECOVERY_BATCH,
+    RecoveryOutcome,
+    RecoveryReport,
+    ShutdownRecovery,
+)
 from flightsite.sightings.repository import (
     ClosedTrack,
     OpenSightingRow,
@@ -66,6 +74,7 @@ from flightsite.sightings.worker import (
 __all__ = [
     "DEFAULT_CLOSE_S",
     "DEFAULT_FLUSH_INTERVAL_S",
+    "DEFAULT_RECOVERY_BATCH",
     "DEFAULT_TICK_INTERVAL_S",
     "EMERGENCY_SQUAWKS",
     "ENCODING_VERSION",
@@ -82,6 +91,9 @@ __all__ = [
     "PendingEvent",
     "PersistenceWorker",
     "PositionSourceCode",
+    "RecoveryOutcome",
+    "RecoveryReport",
+    "ShutdownRecovery",
     "SightingEventType",
     "SightingIds",
     "SightingRepository",

--- a/backend/src/flightsite/sightings/recovery.py
+++ b/backend/src/flightsite/sightings/recovery.py
@@ -1,0 +1,438 @@
+"""Unclean-shutdown recovery: repairing what a killed process left open.
+
+SPEC §71 asks FlightSite to tolerate host power loss without assuming that any
+shutdown hook ran. What a ``kill -9`` or a pulled plug actually leaves behind is
+narrow and well defined, because the persistence worker only ever writes inside
+short transactions (ADR-0008) on a WAL database:
+
+* **committed rows**, which SQLite's own WAL recovery hands back intact on the
+  next open — that recovery happens below this module, in the first connection
+  :class:`~flightsite.db.engine.Database` opens;
+* **sightings still open** (``ended_ms IS NULL``), with their path sitting in
+  ``sighting_track_checkpoints`` up to the last flush cycle;
+* **nothing else.** A half-written close is not a state this schema can be
+  found in: close packs the track, writes the ``sighting_tracks`` row and
+  deletes the checkpoints in one transaction (ADR-0005), so it either all
+  happened or none of it did.
+
+What recovery therefore has to decide is one question per open sighting: *is
+this aircraft still there?*
+
+Two outcomes, and why they differ
+---------------------------------
+
+**Continuing.** An aircraft last heard within ``close_s`` of now might simply
+still be overhead — the process was down for a moment, not the aircraft. Its
+sighting is handed back to the worker as a pending closure with the deadline it
+would have had, so the next observation *continues* the same row (same id, same
+``started_ms``) and a restart costs the history nothing. If the aircraft really
+has gone, the deadline expires normally and the sighting closes with
+``gap_timeout`` — the ordinary rule, applied to an ordinary absence.
+
+**Recovered.** An aircraft whose last data is older than the closure gap is
+closed here, through the *same* close path a live sighting uses
+(:meth:`~flightsite.sightings.repository.SightingRepository.close_sighting`):
+the checkpoint rows are read back, simplified, packed into one
+``sighting_tracks`` row, and deleted. The reason recorded is
+``shutdown_recovery`` rather than ``gap_timeout``, and the distinction is not
+cosmetic: nobody observed that gap. The process was dead. The aircraft may have
+flown on for another hour with a receiver that was not listening, and
+``gap_timeout`` would assert an observation FlightSite never made.
+
+Bounded loss
+------------
+
+The cost of a power cut to an open sighting is exactly the points harvested
+since its last checkpoint batch — one flush interval, ~30 s (ADR-0005). Nothing
+in this module reconstructs or interpolates anything: the recovered path is the
+points that reached the disk, and the gap at its end is honest.
+
+Idempotence, and crashing during recovery
+-----------------------------------------
+
+Recovery closes sightings in batches, each in its own committed transaction, so
+a crash *during* recovery keeps every batch that had already committed. Re-run
+on the next boot it converges without special handling: a sighting closed by the
+previous attempt is no longer open, so it is not a candidate; its checkpoints
+went with it in the same transaction. There is no recovery marker to keep in
+sync, and no partially-recovered sighting to recognize — the database state
+*is* the progress record.
+
+A batch whose transaction fails (a full disk, a locked file) is not dropped:
+those sightings are handed back to the worker as already-expired pending
+closures carrying ``shutdown_recovery``, so the very next worker cycle retries
+them through the same close path with the same honest reason.
+
+Anomalies
+---------
+
+Three impossible states are checked for anyway, because SPEC §71 asks for
+diagnostics when recovery finds problems rather than for faith:
+
+* checkpoint rows for a sighting that is already closed,
+* checkpoint rows for a sighting row that does not exist,
+* an open sighting that already owns a packed ``sighting_tracks`` row.
+
+None can arise from the atomic close path. All three are cleaned — the leftover
+checkpoints are deleted, and an open sighting holding a packed track is closed
+regardless of its window, since its path has already been archived — and all
+three are counted and logged as anomalies.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Sequence
+from dataclasses import dataclass, field
+from typing import Final
+
+import structlog
+from sqlalchemy import delete, func, or_, select
+
+from flightsite.counters import CounterRegistry
+from flightsite.counters import counters as default_counters
+from flightsite.db.engine import Database
+from flightsite.db.models import Sighting, SightingTrack, SightingTrackCheckpoint
+from flightsite.db.startup import DB_ERRORS_COUNTER
+from flightsite.sightings.repository import OpenSightingRow, SightingRepository
+from flightsite.sightings.state import ActiveSighting
+from flightsite.sightings.vocabulary import ClosureReason
+
+logger = structlog.get_logger(__name__)
+
+#: Sightings closed per recovery transaction. Small enough that a crash loses
+#: little work and a failure quarantines few sightings; large enough that a sky
+#: full of aircraft is a couple of dozen transactions rather than a thousand.
+DEFAULT_RECOVERY_BATCH: Final = 16
+
+#: Ids per ``DELETE ... WHERE sighting_id IN (...)``, well under SQLite's bound
+#: on statement parameters. Only anomalous rows ever reach this path, but the
+#: count is not something recovery gets to assume.
+_DELETE_CHUNK: Final = 500
+
+#: A source of UTC epoch milliseconds; a hand-driven fake in tests.
+EpochClock = Callable[[], int]
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryReport:
+    """What startup recovery did, for the summary log and diagnostics.
+
+    Retained on the persistence worker after :meth:`ShutdownRecovery.run` so
+    the diagnostics surface (slice 042) can report the last boot's recovery
+    without re-deriving it.
+    """
+
+    #: Sightings closed here with ``shutdown_recovery``.
+    recovered: int = 0
+    #: Sightings handed back to the worker to continue.
+    continued: int = 0
+    #: Track points retained across every recovered sighting, after
+    #: simplification — what the packed rows actually hold.
+    points_recovered: int = 0
+    #: Leftover ``sighting_track_checkpoints`` rows deleted.
+    orphan_checkpoints: int = 0
+    #: Sightings those leftover rows belonged to.
+    orphan_sightings: int = 0
+    #: Committed recovery transactions, including the orphan cleanup.
+    transactions: int = 0
+    #: Sightings whose recovery transaction failed and were handed to the
+    #: worker to retry.
+    failed: int = 0
+
+    @property
+    def anomalies(self) -> int:
+        """States recovery had to repair that should not have existed."""
+        return self.orphan_sightings + self.failed
+
+    @property
+    def acted(self) -> bool:
+        """True when there was anything at all to recover, continue or clean."""
+        return bool(self.recovered or self.continued or self.orphan_sightings or self.failed)
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryOutcome:
+    """The report, plus the sightings the worker should carry on holding."""
+
+    report: RecoveryReport
+    #: Accumulators to install as pending closures: the continuing sightings
+    #: with the deadline they would have had, and any whose repair failed with
+    #: an already-expired deadline so the next cycle retries it.
+    pending: tuple[ActiveSighting, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class _Orphans:
+    """Leftover checkpoint rows found by the anomaly scan."""
+
+    sighting_ids: tuple[int, ...] = ()
+    rows: int = 0
+
+    def __bool__(self) -> bool:
+        return bool(self.sighting_ids)
+
+
+@dataclass(frozen=True, slots=True)
+class ShutdownRecovery:
+    """Startup repair of the sightings an unclean shutdown left open.
+
+    Args:
+        database: the application database; recovery writes through its single
+            writer session like every other writer (ADR-0001).
+        repository: the sighting repository, so recovery closes sightings by
+            exactly the same code path a live closure uses.
+        close_ms: the closure gap in milliseconds (``sighting.close_s``). An
+            aircraft silent for longer than this is recovered rather than
+            continued.
+        clock: UTC epoch-millisecond source, injected for tests.
+        batch_size: sightings per committed recovery transaction.
+        counters: registry receiving ``db_errors`` when a batch fails.
+    """
+
+    database: Database
+    repository: SightingRepository
+    close_ms: int
+    clock: EpochClock
+    batch_size: int = DEFAULT_RECOVERY_BATCH
+    counters: CounterRegistry = field(default=default_counters)
+
+    async def run(self) -> RecoveryOutcome:
+        """Clean anomalies, close what is gone, hand back what may return."""
+        now_ms = self.clock()
+
+        orphans = await self._scan_orphans()
+        transactions = 0
+        if orphans:
+            await self._delete_orphans(orphans.sighting_ids)
+            transactions += 1
+            logger.warning(
+                "recovery_orphan_checkpoints_cleaned",
+                sightings=len(orphans.sighting_ids),
+                rows=orphans.rows,
+            )
+
+        # After the cleanup, so the high-water marks a continuing sighting
+        # rehydrates with describe rows that still exist.
+        rows = await self.repository.load_open_sightings()
+        packed = await self._packed_open_ids() if rows else frozenset()
+        stale, continuing = self._partition(rows, now_ms=now_ms, packed=packed)
+
+        recovered = 0
+        points = 0
+        failed: list[OpenSightingRow] = []
+        for batch in _chunks(stale, self.batch_size):
+            transactions += 1
+            closed = await self._close_batch(batch)
+            if closed is None:
+                failed.extend(batch)
+                continue
+            recovered += len(batch)
+            points += closed
+
+        report = RecoveryReport(
+            recovered=recovered,
+            continued=len(continuing),
+            points_recovered=points,
+            orphan_checkpoints=orphans.rows,
+            orphan_sightings=len(orphans.sighting_ids),
+            transactions=transactions,
+            failed=len(failed),
+        )
+        self._log(report)
+        pending = tuple(
+            [self._continuing(row) for row in continuing] + [self._retrying(row) for row in failed]
+        )
+        return RecoveryOutcome(report=report, pending=pending)
+
+    # ------------------------------------------------------------- the choice
+
+    def _partition(
+        self,
+        rows: Sequence[OpenSightingRow],
+        *,
+        now_ms: int,
+        packed: frozenset[int],
+    ) -> tuple[tuple[OpenSightingRow, ...], tuple[OpenSightingRow, ...]]:
+        """Split open sightings into "the aircraft is gone" and "it may not be".
+
+        The window is measured against the sighting's *last data* — the newer of
+        the airframe's last-seen instant and its newest checkpointed point —
+        because either one is evidence the aircraft was still being received.
+        """
+        stale: list[OpenSightingRow] = []
+        continuing: list[OpenSightingRow] = []
+        for row in rows:
+            gone = _last_data_ms(row) + self.close_ms <= now_ms
+            # An open sighting that already owns a packed track is an anomaly
+            # whose path has nevertheless been archived; closing it is the only
+            # repair that leaves the schema in a state a reader can trust.
+            (stale if gone or row.ids.sighting_id in packed else continuing).append(row)
+        return tuple(stale), tuple(continuing)
+
+    def _continuing(self, row: OpenSightingRow) -> ActiveSighting:
+        """Rehydrate a sighting whose aircraft may still be overhead."""
+        adopted = _accumulator(row)
+        adopted.close_deadline_ms = adopted.last_seen_ms + self.close_ms
+        return adopted
+
+    def _retrying(self, row: OpenSightingRow) -> ActiveSighting:
+        """Rehydrate a sighting whose repair failed, for the next worker cycle.
+
+        The deadline is already in the past — that is what made it a recovery
+        candidate — so the next cycle closes it, and the accumulator carries
+        ``shutdown_recovery`` so the retry records the same reason this attempt
+        would have.
+        """
+        retried = _accumulator(row)
+        retried.close_deadline_ms = retried.last_seen_ms + self.close_ms
+        retried.closure_reason = ClosureReason.SHUTDOWN_RECOVERY
+        return retried
+
+    # -------------------------------------------------------------- the close
+
+    async def _close_batch(self, batch: Sequence[OpenSightingRow]) -> int | None:
+        """Close one batch in one transaction; ``None`` if it did not commit.
+
+        Nothing in memory depends on the outcome, so a failure needs no
+        unwinding: the sightings are still open in the database, which is
+        precisely the state the next attempt looks for.
+        """
+        points = 0
+        try:
+            async with self.database.writer_session() as session:
+                for row in batch:
+                    track = await self.repository.close_sighting(
+                        session,
+                        row.ids,
+                        _accumulator(row),
+                        reason=ClosureReason.SHUTDOWN_RECOVERY,
+                    )
+                    points += track.point_count
+        except Exception as exc:
+            self.counters.increment(DB_ERRORS_COUNTER)
+            logger.warning(
+                "recovery_batch_failed",
+                error=str(exc),
+                error_type=type(exc).__name__,
+                sightings=len(batch),
+                remediation="sightings left open; the next worker cycle retries the close",
+            )
+            return None
+
+        for row in batch:
+            logger.debug(
+                "sighting_recovered",
+                icao=row.icao24,
+                sighting_id=row.ids.sighting_id,
+                ended_ms=_accumulator(row).last_seen_ms,
+                checkpoints=row.checkpoint_seq,
+            )
+        return points
+
+    # ------------------------------------------------------------- anomalies
+
+    async def _scan_orphans(self) -> _Orphans:
+        """Checkpoint rows that belong to no open, unpacked sighting.
+
+        Three impossible shapes in one query: a closed sighting, a sighting row
+        that is gone, and a sighting whose track has already been packed.
+        """
+        statement = (
+            select(
+                SightingTrackCheckpoint.sighting_id,
+                func.count().label("rows"),
+            )
+            .outerjoin(Sighting, Sighting.id == SightingTrackCheckpoint.sighting_id)
+            .outerjoin(
+                SightingTrack, SightingTrack.sighting_id == SightingTrackCheckpoint.sighting_id
+            )
+            .where(
+                or_(
+                    Sighting.id.is_(None),
+                    Sighting.ended_ms.is_not(None),
+                    SightingTrack.sighting_id.is_not(None),
+                )
+            )
+            .group_by(SightingTrackCheckpoint.sighting_id)
+            .order_by(SightingTrackCheckpoint.sighting_id)
+        )
+        async with self.database.read_session() as session:
+            found = (await session.execute(statement)).all()
+        return _Orphans(
+            sighting_ids=tuple(int(sighting_id) for sighting_id, _ in found),
+            rows=sum(int(count) for _, count in found),
+        )
+
+    async def _delete_orphans(self, sighting_ids: Sequence[int]) -> None:
+        """Remove the leftover checkpoint rows, in one transaction."""
+        async with self.database.writer_session() as session:
+            for chunk in _chunks(sighting_ids, _DELETE_CHUNK):
+                await session.execute(
+                    delete(SightingTrackCheckpoint).where(
+                        SightingTrackCheckpoint.sighting_id.in_(chunk)
+                    )
+                )
+
+    async def _packed_open_ids(self) -> frozenset[int]:
+        """Open sightings that already own a ``sighting_tracks`` row."""
+        statement = (
+            select(Sighting.id)
+            .join(SightingTrack, SightingTrack.sighting_id == Sighting.id)
+            .where(Sighting.ended_ms.is_(None))
+        )
+        async with self.database.read_session() as session:
+            return frozenset((await session.scalars(statement)).all())
+
+    # ------------------------------------------------------------ diagnostics
+
+    @staticmethod
+    def _log(report: RecoveryReport) -> None:
+        """One structured summary of the boot, or silence on a clean one."""
+        if not report.acted:
+            return
+        logger.info(
+            "sighting_recovery_complete",
+            recovered=report.recovered,
+            continued=report.continued,
+            points_recovered=report.points_recovered,
+            orphan_checkpoints=report.orphan_checkpoints,
+            orphan_sightings=report.orphan_sightings,
+            failed=report.failed,
+            transactions=report.transactions,
+        )
+
+
+def _accumulator(row: OpenSightingRow) -> ActiveSighting:
+    """The rehydrated accumulator for an open sighting row.
+
+    One correction on top of
+    :meth:`~flightsite.sightings.repository.OpenSightingRow.to_accumulator`: a
+    sighting cannot have ended before the last position it recorded, so a
+    checkpoint newer than the airframe's stored last-seen instant moves
+    ``last_seen_ms`` — and therefore ``ended_ms`` — forward to meet it.
+    """
+    adopted = row.to_accumulator()
+    adopted.last_seen_ms = _last_data_ms(row)
+    return adopted
+
+
+def _last_data_ms(row: OpenSightingRow) -> int:
+    """The newest instant this sighting has any evidence of reception for."""
+    if row.checkpoint_ms is None:
+        return row.last_known_ms
+    return max(row.last_known_ms, row.checkpoint_ms)
+
+
+def _chunks[T](items: Sequence[T], size: int) -> Iterator[Sequence[T]]:
+    """``items`` in slices of at most ``size``, in order."""
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+__all__ = [
+    "DEFAULT_RECOVERY_BATCH",
+    "EpochClock",
+    "RecoveryOutcome",
+    "RecoveryReport",
+    "ShutdownRecovery",
+]

--- a/backend/src/flightsite/sightings/state.py
+++ b/backend/src/flightsite/sightings/state.py
@@ -57,7 +57,7 @@ from typing import Final, NamedTuple
 from flightsite.db.clock import to_epoch_ms
 from flightsite.live import GroundState, LiveAircraft
 from flightsite.sightings.tracks import TrackSample, from_track_point, thin_for_checkpoint
-from flightsite.sightings.vocabulary import EMERGENCY_SQUAWKS, SightingEventType
+from flightsite.sightings.vocabulary import EMERGENCY_SQUAWKS, ClosureReason, SightingEventType
 
 #: Cap on un-checkpointed points held per sighting. Four hours at 1 Hz, the
 #: same bound :data:`~flightsite.live.track.DEFAULT_TRACK_CAPACITY` puts on a
@@ -207,6 +207,14 @@ class ActiveSighting:
     #: heard again. Set when the aircraft leaves the live set; cleared when it
     #: comes back. ``None`` means the aircraft is currently live.
     close_deadline_ms: int | None = None
+    #: Reason to record when this sighting closes. ``gap_timeout`` for the
+    #: ordinary case — an absence the running process actually observed.
+    #: Startup recovery sets ``shutdown_recovery`` on a sighting whose repair
+    #: transaction failed, so the worker's retry records the honest reason
+    #: rather than claiming to have watched a gap nobody was there for; an
+    #: aircraft heard again before that retry resets it, because then the
+    #: sighting is alive and any later closure is an observed one.
+    closure_reason: ClosureReason = ClosureReason.GAP_TIMEOUT
 
     @property
     def duration_ms(self) -> int:

--- a/backend/src/flightsite/sightings/worker.py
+++ b/backend/src/flightsite/sightings/worker.py
@@ -99,16 +99,15 @@ consecutive timestamps rather than as an invented straight line.
 Startup
 -------
 
-Slice 053 owns checkpoint-based unclean-shutdown recovery. Until it lands this
-worker still has to behave sanely when it finds sightings open from a previous
-process, and it does so with the machinery it already has: every open sighting
-is rehydrated as a *pending closure* whose deadline is the airframe's last
-known observation plus ``close_s``. Aircraft still being heard therefore
-continue their sighting across a restart, and everything older is closed on the
-first cycle with ``gap_timeout``, which is what actually happened — the aircraft
-was absent for longer than the gap. Nothing here writes
-``closure_reason='shutdown_recovery'``; that value, and repair from track
-checkpoints, arrive with slice 053.
+Every start runs :class:`~flightsite.sightings.recovery.ShutdownRecovery` before
+the first cycle, because a start is the only moment the process can tell what a
+previous one left behind. It sorts the open sightings into the two things they
+can be — an aircraft that may still be overhead, handed back here as a pending
+closure with the deadline it would have had, and an aircraft long gone, closed
+from its checkpoint rows with ``shutdown_recovery`` — and cleans up any state
+that should not exist. Its reasoning, and why a recovered closure is not a
+``gap_timeout``, is in that module; what this one owes is to hold the pending
+closures it returns and to keep its report available for diagnostics.
 """
 
 from __future__ import annotations
@@ -137,6 +136,7 @@ from flightsite.live import (
     LiveEvent,
     LiveStore,
 )
+from flightsite.sightings.recovery import RecoveryReport, ShutdownRecovery
 from flightsite.sightings.repository import ClosedTrack, SightingIds, SightingRepository
 from flightsite.sightings.state import ActiveSighting, open_from
 from flightsite.sightings.vocabulary import ClosureReason
@@ -215,6 +215,7 @@ class PersistenceWorker:
         "_meta",
         "_pending",
         "_queue_size",
+        "_recovery",
         "_repository",
         "_subscription",
         "_t0_established",
@@ -257,6 +258,7 @@ class PersistenceWorker:
         self._subscription: EventSubscription | None = None
         self._task: asyncio.Task[None] | None = None
         self._t0_established = False
+        self._recovery = RecoveryReport()
 
     # ------------------------------------------------------------ inspection
 
@@ -279,6 +281,17 @@ class PersistenceWorker:
     def t0_established(self) -> bool:
         """True once T0 is known to be recorded (SPEC §16)."""
         return self._t0_established
+
+    @property
+    def recovery(self) -> RecoveryReport:
+        """What unclean-shutdown recovery did at this worker's last start.
+
+        All-zero before :meth:`start` and after a boot that found nothing to
+        repair, which is the ordinary case. Kept here so the diagnostics
+        surface (slice 042) can report the last boot's recovery without
+        re-deriving it from a database that no longer holds the evidence.
+        """
+        return self._recovery
 
     def sighting_for(self, icao: str) -> ActiveSighting | None:
         """The accumulator tracking ``icao``, live or pending, if any."""
@@ -312,7 +325,7 @@ class PersistenceWorker:
         self._subscription = self._live.subscribe("persistence", maxsize=self._queue_size)
 
         self._t0_established = await self._meta.get_t0() is not None
-        await self._adopt_open_sightings()
+        await self._recover_open_sightings()
 
         self._task = asyncio.create_task(self._loop(), name="flightsite-persistence")
         logger.info(
@@ -320,6 +333,7 @@ class PersistenceWorker:
             close_s=self._close_ms / MS_PER_SECOND,
             flush_interval_s=self._flush_interval_ms / MS_PER_SECOND,
             adopted=len(self._pending),
+            recovered=self._recovery.recovered,
             t0_established=self._t0_established,
         )
 
@@ -417,6 +431,9 @@ class PersistenceWorker:
         resumed = self._pending.pop(icao, None)
         if resumed is not None:
             resumed.close_deadline_ms = None
+            # An aircraft that came back is not a crash casualty any more: a
+            # closure from here on is one this process watched happen.
+            resumed.closure_reason = ClosureReason.GAP_TIMEOUT
             resumed.observe(record)
             self._active[icao] = resumed
             logger.debug("sighting_continued", icao=icao, sighting_id=resumed.sighting_id)
@@ -556,7 +573,7 @@ class PersistenceWorker:
                             session,
                             self._resolved(active, opened_ids),
                             active,
-                            reason=ClosureReason.GAP_TIMEOUT,
+                            reason=active.closure_reason,
                         )
                     )
         except Exception as exc:
@@ -591,7 +608,7 @@ class PersistenceWorker:
                 icao=active.icao,
                 sighting_id=active.sighting_id,
                 duration_ms=active.duration_ms,
-                closure_reason=ClosureReason.GAP_TIMEOUT.value,
+                closure_reason=active.closure_reason.value,
                 track_points=track.point_count,
                 track_bytes=track.byte_count,
             )
@@ -640,24 +657,25 @@ class PersistenceWorker:
 
     # ---------------------------------------------------------------- startup
 
-    async def _adopt_open_sightings(self) -> None:
-        """Rehydrate sightings a previous process left open.
+    async def _recover_open_sightings(self) -> None:
+        """Repair what a previous process left open, and adopt the rest.
 
-        Each becomes a pending closure with the deadline it would have had:
-        the airframe's last known observation plus ``close_s``. Aircraft still
-        being heard resume their sighting on the next event; the rest close on
-        the first cycle with ``gap_timeout``, since an absence longer than the
-        gap is precisely what happened. Interim behaviour — slice 053 replaces
-        it with checkpoint-based repair and ``shutdown_recovery``.
+        The judgement — closed here and now with ``shutdown_recovery``, or
+        handed back as a pending closure that an aircraft still overhead can
+        resume — belongs to :mod:`flightsite.sightings.recovery`. What is left
+        for the worker is to hold the accumulators it returns, already carrying
+        their deadlines, and to keep its report for diagnostics.
         """
-        rows = await self._repository.load_open_sightings()
-        if not rows:
-            return
-        for row in rows:
-            adopted = row.to_accumulator()
-            adopted.close_deadline_ms = adopted.last_seen_ms + self._close_ms
+        outcome = await ShutdownRecovery(
+            database=self._database,
+            repository=self._repository,
+            close_ms=self._close_ms,
+            clock=self._clock,
+            counters=self._counters,
+        ).run()
+        self._recovery = outcome.report
+        for adopted in outcome.pending:
             self._pending[adopted.icao] = adopted
-        logger.info("open_sightings_adopted", count=len(rows))
 
 
 __all__ = [

--- a/backend/tests/sightings/test_kill_drill.py
+++ b/backend/tests/sightings/test_kill_drill.py
@@ -1,0 +1,369 @@
+"""The real drills: a killed process, and a WAL that was never checkpointed.
+
+``test_recovery.py`` proves what recovery *does* on simulated time, from
+databases a worker was dropped mid-cycle. These two prove the premise underneath
+it — that the state those drills construct is the state a real operating system
+leaves when a real process stops existing:
+
+* :func:`test_a_killed_app_recovers_on_the_next_start` runs the actual
+  FastAPI application in a subprocess, in demo mode, with real ingestion and
+  the real persistence worker, and terminates it without warning. No lifespan
+  shutdown runs, no accumulator is flushed, no connection is closed.
+* :func:`test_a_never_checkpointed_wal_is_replayed_and_then_recovered` leaves
+  a write-ahead log that SQLite never folded back into the database file, which
+  is what an unclean stop actually leaves on disk (SPEC §71's "SQLite WAL
+  recovery"), and checks that the rows come back and recovery proceeds over
+  them.
+
+Both scripts end in ``os._exit`` or a ``TerminateProcess``/``SIGKILL``, never in
+a return: an ``atexit`` hook, a ``finally`` block or a garbage-collected
+connection would each quietly checkpoint the WAL and destroy the very state
+under test.
+
+The subprocess only ever *makes* the mess. Recovering it happens in-process,
+where the assertions can see the report.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from flightsite.db import Database, Sighting, SightingTrackCheckpoint, database_path
+from flightsite.db.clock import utc_now_ms
+from flightsite.db.engine import QUICK_CHECK_OK
+from flightsite.live import LiveStore
+from flightsite.sightings import ClosureReason, PersistenceWorker, SightingRepository
+
+from .conftest import CLOSE_S, reading
+
+#: Seconds to wait for a subprocess to reach its ready marker. Generous: it
+#: pays for an interpreter start, the SQLAlchemy import graph and a migration
+#: run on a cold filesystem, none of which this drill is measuring.
+STARTUP_TIMEOUT_S = 40.0
+
+#: Seconds to wait for the running app to have checkpointed enough of a track
+#: to make the kill interesting.
+TRAFFIC_TIMEOUT_S = 20.0
+
+#: Checkpoint rows that must exist before the kill, so that recovery has a path
+#: to repair rather than a set of empty sightings.
+REQUIRED_CHECKPOINTS = 20
+
+#: How often the parent polls the child's database while it fills.
+POLL_INTERVAL_S = 0.2
+
+#: Flush cadence forced on the app in the drill. The product's is 30 s, which
+#: would put the whole drill's runtime inside a single checkpoint interval and
+#: leave nothing on disk to recover; a quarter second gives the same shape --
+#: repeated checkpoint batches, then a kill mid-interval -- in a few seconds.
+DRILL_FLUSH_INTERVAL_S = 0.25
+
+
+# ------------------------------------------------------------------- scripts
+
+
+#: Runs the real application: real config load, real lifespan, real demo
+#: ingestion, real persistence worker as the single writer. The one thing the
+#: drill imposes is the worker's flush cadence, for the reason above.
+APP_SCRIPT = """
+import asyncio
+import sys
+from pathlib import Path
+
+from flightsite.app import create_app
+from flightsite.sightings import PersistenceWorker
+
+
+async def main() -> None:
+    ready = Path(sys.argv[1])
+    app = create_app()
+    app.state.persistence = PersistenceWorker(
+        database=app.state.database,
+        live=app.state.live,
+        close_s=app.state.settings.sighting.close_s,
+        flush_interval_s=float(sys.argv[2]),
+    )
+    async with app.router.lifespan_context(app):
+        ready.write_text("ready")
+        while True:
+            await asyncio.sleep(0.1)
+
+
+asyncio.run(main())
+"""
+
+#: Writes a sighting and its checkpoints through the real worker, then stops
+#: existing. Nothing closes the connection, so the WAL is left unmerged.
+WAL_SCRIPT = """
+import asyncio
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from flightsite.db import Database, database_path
+from flightsite.ingest import AircraftStateBatch, AircraftStateUpdate, Position
+from flightsite.live import LiveStore
+from flightsite.sightings import PersistenceWorker
+
+ICAO = "ae1463"
+
+
+async def main() -> None:
+    data_dir = Path(sys.argv[1])
+    database = Database(database_path(data_dir))
+    await database.upgrade_to("head")
+    live = LiveStore(
+        stale_s=15.0,
+        remove_s=60.0,
+        receiver_location=Position(latitude=47.4502, longitude=-122.3088),
+    )
+    worker = PersistenceWorker(
+        database=database, live=live, flush_interval_s=0.001, tick_interval_s=3600.0
+    )
+    await worker.start()
+    base = datetime.now(UTC)
+    for index in range(24):
+        at = base + timedelta(seconds=index)
+        live.apply(
+            AircraftStateBatch(
+                timestamp=at,
+                updates=(
+                    AircraftStateUpdate(
+                        icao=ICAO,
+                        timestamp=at,
+                        position=Position(
+                            latitude=47.4502 + index * 0.02,
+                            longitude=-122.3088 + index * 0.005,
+                        ),
+                        position_source="adsb",
+                        altitude_ft=30_000.0,
+                    ),
+                ),
+            )
+        )
+        await worker.process_pending()
+    Path(sys.argv[2]).write_text("ready")
+    # Not `return`: an ordinary exit would close the connection and checkpoint
+    # the WAL, which is precisely the state this drill must not reach.
+    os._exit(0)
+
+
+asyncio.run(main())
+"""
+
+
+# ------------------------------------------------------------------- harness
+
+
+def spawn(script: str, data_dir: Path, *arguments: str) -> subprocess.Popen[bytes]:
+    """Run ``script`` in a fresh interpreter against ``data_dir``.
+
+    Output goes to a file rather than a pipe: a pipe nobody drains fills its
+    buffer and blocks the child, which in this suite would look exactly like a
+    hung drill.
+    """
+    environment = dict(os.environ)
+    environment.update(FLIGHTSITE_DATA_DIR=str(data_dir), FLIGHTSITE_DEMO="1")
+    log = (data_dir / "drill.log").open("wb")
+    return subprocess.Popen(
+        [sys.executable, "-c", script, *arguments],
+        env=environment,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+async def wait_for(marker: Path, process: subprocess.Popen[bytes], timeout_s: float) -> None:
+    """Wait for the child to signal readiness, or explain why it never did."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if _exists(marker):
+            return
+        if process.poll() is not None:
+            raise AssertionError(f"drill subprocess exited early:\n{_log_of(marker.parent)}")
+        await asyncio.sleep(POLL_INTERVAL_S)
+    raise AssertionError(f"drill subprocess never became ready:\n{_log_of(marker.parent)}")
+
+
+async def wait_for_checkpoints(path: Path, wanted: int, timeout_s: float) -> int:
+    """Poll the child's database until it has checkpointed ``wanted`` points.
+
+    Reading a database another process is writing is exactly what WAL is for,
+    so this is a plain read connection; a lock collision simply means try again
+    in a moment.
+    """
+    deadline = time.monotonic() + timeout_s
+    found = 0
+    while time.monotonic() < deadline:
+        found = _count(path, "sighting_track_checkpoints")
+        if found >= wanted:
+            return found
+        await asyncio.sleep(POLL_INTERVAL_S)
+    raise AssertionError(f"only {found} checkpoint rows after {timeout_s}s")
+
+
+def _count(path: Path, table: str) -> int:
+    connection = sqlite3.connect(f"file:{path.as_posix()}?mode=ro", uri=True)
+    try:
+        return int(connection.execute(f"SELECT count(*) FROM {table}").fetchone()[0])
+    except sqlite3.OperationalError:  # pragma: no cover - momentary lock
+        return 0
+    finally:
+        connection.close()
+
+
+def _exists(path: Path) -> bool:
+    """Filesystem probes live in sync helpers so the drills stay ASYNC-clean."""
+    return path.exists()
+
+
+def wal_bytes(path: Path) -> int:
+    """Size of the write-ahead log beside ``path``, or zero if there is none."""
+    wal = Path(f"{path}-wal")
+    return wal.stat().st_size if wal.exists() else 0
+
+
+def _log_of(data_dir: Path) -> str:
+    log = data_dir / "drill.log"
+    return log.read_text(errors="replace") if log.exists() else "(no output captured)"
+
+
+def long_after_the_gap() -> int:
+    """A clock reading past every closure deadline the child can have armed.
+
+    The alternative — sleeping out a real ``close_s`` — would put ten minutes,
+    or a fragile tiny configured gap, into a drill whose subject is recovery
+    rather than the gap rule.
+    """
+    return utc_now_ms() + int((CLOSE_S + 60.0) * 1_000)
+
+
+async def recover(path: Path) -> tuple[PersistenceWorker, Database]:
+    """Start a worker over the wreckage, exactly as the next boot would."""
+    database = Database(path)
+    worker = PersistenceWorker(
+        database=database,
+        live=LiveStore(stale_s=15.0, remove_s=60.0),
+        close_s=CLOSE_S,
+        tick_interval_s=3_600.0,
+        clock=long_after_the_gap,
+    )
+    await worker.start()
+    return worker, database
+
+
+async def open_sightings(database: Database) -> list[Sighting]:
+    async with reading(database) as session:
+        return list(
+            (await session.scalars(select(Sighting).where(Sighting.ended_ms.is_(None)))).all()
+        )
+
+
+async def all_sightings(database: Database) -> list[Sighting]:
+    async with reading(database) as session:
+        return list((await session.scalars(select(Sighting))).all())
+
+
+# --------------------------------------------------------------- the drills
+
+
+@pytest.mark.drill
+async def test_a_killed_app_recovers_on_the_next_start(isolated_data_dir: Path) -> None:
+    """Terminate the running product mid-flight; restart; check the repair.
+
+    This is the roadmap's acceptance criterion in its literal form: the app is
+    killed while sightings are open, and the next start closes them sanely with
+    ``shutdown_recovery`` and a bounded amount of track lost.
+    """
+    path = database_path(isolated_data_dir)
+    marker = isolated_data_dir / "ready"
+    process = spawn(APP_SCRIPT, isolated_data_dir, str(marker), str(DRILL_FLUSH_INTERVAL_S))
+    try:
+        await wait_for(marker, process, STARTUP_TIMEOUT_S)
+        checkpointed = await wait_for_checkpoints(path, REQUIRED_CHECKPOINTS, TRAFFIC_TIMEOUT_S)
+    finally:
+        # SIGKILL on POSIX, TerminateProcess on Windows: no handler, no
+        # lifespan shutdown, no final flush.
+        process.kill()
+        process.wait(timeout=30)
+
+    assert checkpointed >= REQUIRED_CHECKPOINTS
+    survivor = Database(path)
+    try:
+        assert list(await survivor.quick_check()) == [QUICK_CHECK_OK]
+        left_open = await open_sightings(survivor)
+        # Demo mode fills the sky, so a kill lands across many sightings at
+        # once — the shape a power cut has in the field, not a single row.
+        assert len(left_open) >= 5, f"the kill left only {len(left_open)} sightings open"
+    finally:
+        await survivor.dispose()
+
+    worker, database = await recover(path)
+    try:
+        report = worker.recovery
+        assert report.recovered == len(left_open)
+        assert report.continued == 0
+        assert report.failed == 0
+        assert report.points_recovered > 0
+
+        assert await open_sightings(database) == []
+        closed = await all_sightings(database)
+        assert {row.closure_reason for row in closed} == {ClosureReason.SHUTDOWN_RECOVERY.value}
+        assert all(row.ended_ms is not None for row in closed)
+
+        # The path moved from the checkpoint table into the packed rows, whole.
+        async with reading(database) as session:
+            assert (await session.scalars(select(SightingTrackCheckpoint))).first() is None
+        repository = SightingRepository(database)
+        packed = [await repository.load_track(row.id) for row in closed]
+        assert sum(len(track) for track in packed) == report.points_recovered
+        assert any(track for track in packed)
+    finally:
+        await worker.stop()
+        await database.dispose()
+
+
+async def test_a_never_checkpointed_wal_is_replayed_and_then_recovered(
+    isolated_data_dir: Path,
+) -> None:
+    """SQLite hands the committed rows back; recovery takes it from there.
+
+    Two distinct failures would both show up here and neither is ours to fix in
+    code: a database opened without replaying its WAL would have lost the
+    sighting entirely, and one whose WAL was corrupt would fail ``quick_check``.
+    What the drill adds on top is that recovery then runs over the replayed
+    rows like any other boot.
+    """
+    path = database_path(isolated_data_dir)
+    marker = isolated_data_dir / "written"
+    process = spawn(WAL_SCRIPT, isolated_data_dir, str(isolated_data_dir), str(marker))
+    await wait_for(marker, process, STARTUP_TIMEOUT_S)
+    assert process.wait(timeout=30) == 0
+
+    assert wal_bytes(path) > 0, "the drill must leave an unmerged WAL"
+
+    worker, database = await recover(path)
+    try:
+        assert worker.recovery.recovered == 1
+        assert worker.recovery.points_recovered > 0
+
+        closed = await all_sightings(database)
+        assert len(closed) == 1
+        assert closed[0].closure_reason == ClosureReason.SHUTDOWN_RECOVERY.value
+        track = await SightingRepository(database).load_track(closed[0].id)
+        assert len(track) > 1
+        assert [sample.ts_ms for sample in track] == sorted(sample.ts_ms for sample in track)
+    finally:
+        await worker.stop()
+        await database.dispose()

--- a/backend/tests/sightings/test_recovery.py
+++ b/backend/tests/sightings/test_recovery.py
@@ -1,0 +1,840 @@
+"""Power-cut drills: what survives an unclean shutdown, and what it costs.
+
+Every drill here starts from a database in the state a *killed* process leaves
+behind, built by running the real pipeline and then dropping the worker without
+letting it shut down (:func:`power_cut`). Constructing the rows by hand would
+prove only that the recovery queries work; running the worker and then killing
+it proves that the state recovery expects is the state the worker actually
+produces.
+
+What the drills pin down (SPEC §71, ADR-0005):
+
+* an aircraft long gone is **recovered** — closed with ``shutdown_recovery``
+  from its checkpoint rows, simplified and packed, checkpoints deleted;
+* an aircraft still transmitting is **continued** — same sighting row, no
+  spurious closure;
+* the loss is **bounded**: everything checkpointed comes back, and what does
+  not is at most one flush interval of path;
+* recovery is **idempotent**: a crash between recovery transactions leaves a
+  database the next attempt finishes correctly, and a third attempt finds
+  nothing to do;
+* impossible leftovers — checkpoints on a closed sighting, on a sighting that
+  does not exist, or beside an already-packed track — are cleaned and counted.
+
+The real ``kill -9`` against a real process is ``test_kill_drill.py``; these are
+the fast, deterministic drills that run on simulated time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import sqlite3
+from collections.abc import AsyncIterator, Sequence
+from math import sin
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from flightsite.db import Database, SightingTrack, SightingTrackCheckpoint
+from flightsite.ingest import Position
+from flightsite.live import LiveStore
+from flightsite.logging import configure_logging
+from flightsite.sightings import (
+    ClosureReason,
+    PersistenceWorker,
+    ShutdownRecovery,
+    SightingRepository,
+    TrackSample,
+    from_track_point,
+    pack_track,
+    simplify,
+)
+
+from .conftest import (
+    CLOSE_S,
+    FLUSH_INTERVAL_S,
+    ICAO,
+    REMOVE_S,
+    SEATTLE,
+    FailingOnceDatabase,
+    SimulatedTime,
+    checkpoints_of,
+    existing_aircraft,
+    observe,
+    offset_from,
+    only_sighting,
+    packed_track_of,
+    reading,
+    sightings_of,
+    worker_on,
+)
+
+#: Longitude/latitude tolerance for a round trip through the packed encoding,
+#: whose scale is 1e-5 degrees.
+COORD_TOLERANCE = 1e-5
+
+#: Simulated seconds between observations in the drills — the product's 1 Hz.
+STEP_S = 1.0
+
+
+# --------------------------------------------------------------- the power cut
+
+
+async def power_cut(worker: PersistenceWorker) -> None:
+    """Drop a running worker the way a power cut does: no hooks, no flush.
+
+    Deliberately not :meth:`PersistenceWorker.stop`. A clean stop force-flushes
+    every accumulator, which would leave the database in exactly the state
+    these drills must never start from — SPEC §71's premise is that no shutdown
+    hook runs at all. Cancelling the task and dropping the subscription is the
+    closest an in-process test gets to the plug being pulled; the version with
+    a real ``TerminateProcess`` is ``test_kill_drill.py``.
+    """
+    task, worker._task = worker._task, None
+    if task is not None:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+    subscription, worker._subscription = worker._subscription, None
+    if subscription is not None:
+        subscription.close()
+
+
+@contextlib.asynccontextmanager
+async def doomed_worker(
+    database: Database, live: LiveStore, clock: SimulatedTime
+) -> AsyncIterator[PersistenceWorker]:
+    """A worker that is killed on exit rather than stopped."""
+    worker = PersistenceWorker(
+        database=database,
+        live=live,
+        close_s=CLOSE_S,
+        flush_interval_s=FLUSH_INTERVAL_S,
+        tick_interval_s=3_600.0,
+        clock=clock.epoch_ms,
+    )
+    await worker.start()
+    try:
+        yield worker
+    finally:
+        await power_cut(worker)
+
+
+# ----------------------------------------------------------------- the flight
+
+
+def arc(index: int) -> Position:
+    """A gently curving track: enough shape that thinning keeps real points."""
+    return offset_from(SEATTLE, 5.0 + index * 0.15, 3.0 * sin(index / 12.0))
+
+
+async def fly_under(
+    worker: PersistenceWorker,
+    live: LiveStore,
+    clock: SimulatedTime,
+    seconds: int,
+    *,
+    icao: str = ICAO,
+) -> None:
+    """Observe ``icao`` once a second for ``seconds``, running a cycle each time.
+
+    One cycle per observation is what the running product does (a 1 s tick), so
+    the checkpoint cadence the drill cuts into is the real one.
+    """
+    for index in range(seconds):
+        clock.advance(STEP_S)
+        observe(live, clock, icao, position=arc(index), altitude_ft=30_000.0)
+        await worker.process_pending()
+
+
+def depart(live: LiveStore, clock: SimulatedTime) -> None:
+    """Age every aircraft out of the live set, arming its closure gap.
+
+    The ordinary closure path needs the removal event; only startup recovery
+    reaches a sighting whose aircraft simply stopped existing.
+    """
+    clock.advance(REMOVE_S + 1.0)
+    live.sweep()
+
+
+def flown(live: LiveStore, icao: str = ICAO) -> tuple[TrackSample, ...]:
+    """The full-resolution truth: every point the live track still holds."""
+    for record in live.snapshot():
+        if record.icao == icao:
+            return tuple(from_track_point(point) for point in record.track.points_since(None))
+    raise AssertionError(f"{icao} is not in the live set")
+
+
+# ---------------------------------------------------------------- assertions
+
+
+async def recovered_track(database: Database, sighting_id: int) -> tuple[TrackSample, ...]:
+    """The decoded path of a sighting recovery packed."""
+    return await SightingRepository(database).load_track(sighting_id)
+
+
+def assert_matches_checkpoints(
+    recovered: Sequence[TrackSample], checkpoints: Sequence[SightingTrackCheckpoint]
+) -> None:
+    """Every recovered point is a checkpointed fix, unmoved and in order."""
+    by_ts = {row.ts_ms: row for row in checkpoints}
+    assert recovered, "a positioned sighting must recover a path"
+    assert [sample.ts_ms for sample in recovered] == sorted(sample.ts_ms for sample in recovered)
+    for sample in recovered:
+        # No invention: recovery packs points that were received, never a
+        # curve fitted through them (ADR-0005).
+        row = by_ts.get(sample.ts_ms)
+        assert row is not None, f"recovered a point at {sample.ts_ms} that was never checkpointed"
+        assert sample.latitude == pytest.approx(row.lat, abs=COORD_TOLERANCE)
+        assert sample.longitude == pytest.approx(row.lon, abs=COORD_TOLERANCE)
+        assert sample.altitude_ft == row.alt_ft
+
+
+def execute_raw(path: Path, statement: str, parameters: tuple[object, ...] = ()) -> None:
+    """Run one statement through plain ``sqlite3``, foreign keys off.
+
+    The application's own connections enforce foreign keys (ADR-0001), which
+    is exactly why the anomaly drills cannot use them: the states being forged
+    are ones the schema refuses to create.
+    """
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(statement, parameters)
+        connection.commit()
+    finally:
+        connection.close()
+
+
+# ------------------------------------------------------------------- fixtures
+
+
+@pytest.fixture
+async def crashed(
+    database: Database, live: LiveStore, clock: SimulatedTime
+) -> tuple[int, list[SightingTrackCheckpoint], tuple[TrackSample, ...]]:
+    """A power cut 75 s into a flight, mid checkpoint interval.
+
+    Returns the sighting's id, the checkpoint rows that reached the disk, and
+    the full-resolution truth the dead process still had in memory.
+    """
+    async with doomed_worker(database, live, clock) as worker:
+        await fly_under(worker, live, clock, 75)
+        sighting_id = (await only_sighting(database)).id
+        written = await checkpoints_of(database, sighting_id)
+        truth = flown(live)
+    return sighting_id, written, truth
+
+
+# ------------------------------------------------------------------- recovery
+
+
+async def test_a_power_cut_mid_flight_recovers_the_checkpointed_path(
+    crashed: tuple[int, list[SightingTrackCheckpoint], tuple[TrackSample, ...]],
+    database: Database,
+    live: LiveStore,
+    clock: SimulatedTime,
+) -> None:
+    sighting_id, written, _ = crashed
+    assert written, "the drill is meaningless if nothing was checkpointed"
+
+    clock.advance(CLOSE_S + 1.0)
+    async with worker_on(database, live, clock) as restarted:
+        assert restarted.recovery.recovered == 1
+        assert restarted.recovery.continued == 0
+        assert restarted.pending_count == 0
+
+    sighting = await only_sighting(database)
+    assert sighting.closure_reason == ClosureReason.SHUTDOWN_RECOVERY.value
+    assert sighting.ended_ms is not None
+    assert sighting.duration_ms == sighting.ended_ms - sighting.started_ms
+    # The path exists in exactly one table, which is ADR-0005's invariant.
+    assert await checkpoints_of(database, sighting_id) == []
+    assert await packed_track_of(database, sighting_id) is not None
+    assert_matches_checkpoints(await recovered_track(database, sighting_id), written)
+
+
+async def test_recovery_ends_the_sighting_when_the_aircraft_was_last_heard(
+    crashed: tuple[int, list[SightingTrackCheckpoint], tuple[TrackSample, ...]],
+    database: Database,
+    live: LiveStore,
+    clock: SimulatedTime,
+) -> None:
+    """Not when the gap expired, and not when the process came back.
+
+    The sighting is the observation period. The ten minutes of silence that
+    made it a recovery candidate were not part of it, and neither were the
+    hours the machine may have spent powered off.
+    """
+    _, written, _ = crashed
+    clock.advance(CLOSE_S * 5)
+
+    async with worker_on(database, live, clock):
+        pass
+
+    sighting = await only_sighting(database)
+    assert sighting.ended_ms is not None
+    assert sighting.ended_ms >= written[-1].ts_ms
+    assert sighting.ended_ms < clock.epoch_ms() - int(CLOSE_S * 1_000)
+
+
+async def test_recovery_credits_the_airframe_exactly_once(
+    crashed: tuple[int, list[SightingTrackCheckpoint], tuple[TrackSample, ...]],
+    database: Database,
+    live: LiveStore,
+    clock: SimulatedTime,
+) -> None:
+    clock.advance(CLOSE_S + 1.0)
+    async with worker_on(database, live, clock):
+        pass
+    # A second boot must not add the duration again or open a second sighting.
+    async with worker_on(database, live, clock) as second:
+        assert second.recovery.acted is False
+
+    sighting = await only_sighting(database)
+    aircraft = await existing_aircraft(database)
+    assert aircraft.sighting_count == 1
+    assert aircraft.total_observed_ms == sighting.duration_ms
+
+
+async def test_a_sighting_with_no_checkpoints_recovers_without_a_track(
+    database: Database, live: LiveStore, clock: SimulatedTime
+) -> None:
+    """A Mode S-only aircraft, killed seconds after it was first heard.
+
+    No position ever arrived, so there is nothing to pack — and no row is the
+    right answer, not a track of zero points (SPEC §20).
+    """
+    async with doomed_worker(database, live, clock) as worker:
+        observe(live, clock, squawk="1200")
+        await worker.process_pending()
+        sighting_id = (await only_sighting(database)).id
+        assert await checkpoints_of(database, sighting_id) == []
+
+    clock.advance(CLOSE_S + 1.0)
+    async with worker_on(database, live, clock) as restarted:
+        assert restarted.recovery.recovered == 1
+        assert restarted.recovery.points_recovered == 0
+
+    sighting = await only_sighting(database)
+    assert sighting.closure_reason == ClosureReason.SHUTDOWN_RECOVERY.value
+    assert await packed_track_of(database, sighting_id) is None
+    assert await recovered_track(database, sighting_id) == ()
+
+
+async def test_a_thinned_cruise_leg_recovers_the_points_that_were_kept(
+    database: Database, live: LiveStore, clock: SimulatedTime
+) -> None:
+    """Checkpoint thinning is invisible in the recovered result (ADR-0005).
+
+    A dead-straight leg is checkpointed as a handful of rows, and what recovery
+    packs is the simplification of exactly those rows — no more, and nothing
+    the receiver did not report.
+    """
+    async with doomed_worker(database, live, clock) as worker:
+        for index in range(90):
+            clock.advance(STEP_S)
+            observe(
+                live,
+                clock,
+                position=offset_from(SEATTLE, 5.0 + index * 0.1, 0.0),
+                altitude_ft=30_000.0,
+            )
+            await worker.process_pending()
+        sighting_id = (await only_sighting(database)).id
+        written = await checkpoints_of(database, sighting_id)
+
+    # Thinning collapses the straight legs: far fewer rows than observations.
+    assert 0 < len(written) < 20
+
+    clock.advance(CLOSE_S + 1.0)
+    async with worker_on(database, live, clock):
+        pass
+
+    recovered = await recovered_track(database, sighting_id)
+    expected = simplify(
+        tuple(
+            TrackSample(
+                ts_ms=row.ts_ms,
+                latitude=row.lat,
+                longitude=row.lon,
+                position_source="adsb",
+                altitude_ft=row.alt_ft,
+                ground_speed_kt=row.gs_kt,
+                track_deg=row.track_deg,
+            )
+            for row in written
+        )
+    )
+    assert [sample.ts_ms for sample in recovered] == [sample.ts_ms for sample in expected]
+    assert_matches_checkpoints(recovered, written)
+
+
+# --------------------------------------------------------------- bounded loss
+
+
+async def test_a_power_cut_loses_at_most_one_flush_interval_of_track(
+    crashed: tuple[int, list[SightingTrackCheckpoint], tuple[TrackSample, ...]],
+    database: Database,
+    live: LiveStore,
+    clock: SimulatedTime,
+) -> None:
+    """The guarantee ADR-0005 makes, measured against the in-memory truth.
+
+    Two halves, and both matter: nothing that reached a checkpoint is lost, and
+    what never reached one spans less than a single flush interval.
+    """
+    sighting_id, written, truth = crashed
+    last_checkpoint_ms = written[-1].ts_ms
+
+    lost = [sample for sample in truth if sample.ts_ms > last_checkpoint_ms]
+    assert lost, "the cut must land mid-interval or the drill proves nothing"
+    assert lost[-1].ts_ms - last_checkpoint_ms <= int(FLUSH_INTERVAL_S * 1_000)
+
+    clock.advance(CLOSE_S + 1.0)
+    async with worker_on(database, live, clock):
+        pass
+
+    recovered = await recovered_track(database, sighting_id)
+    # Douglas-Peucker keeps the endpoints, so the recovered path spans the
+    # whole checkpointed record rather than a prefix of it.
+    assert recovered[0].ts_ms == written[0].ts_ms
+    assert recovered[-1].ts_ms == last_checkpoint_ms
+
+    sighting = await only_sighting(database)
+    assert sighting.ended_ms is not None
+    assert truth[-1].ts_ms - sighting.ended_ms <= int(FLUSH_INTERVAL_S * 1_000)
+
+
+# ----------------------------------------------------------------- continuity
+
+
+async def test_an_aircraft_still_transmitting_keeps_its_sighting(
+    database: Database, live: LiveStore, clock: SimulatedTime
+) -> None:
+    """A restart inside the gap is not a closure (the continuity drill).
+
+    The process died; the aircraft did not. Closing here would chop a flight in
+    half and invent a second sighting for the same pass, so the sighting is
+    handed back and the next observation continues it.
+    """
+    async with doomed_worker(database, live, clock) as worker:
+        await fly_under(worker, live, clock, 40)
+        original = await only_sighting(database)
+
+    clock.advance(30.0)
+    async with worker_on(database, live, clock) as restarted:
+        assert restarted.recovery.recovered == 0
+        assert restarted.recovery.continued == 1
+        assert restarted.pending_count == 1
+
+        clock.advance(STEP_S)
+        observe(live, clock, position=arc(41), altitude_ft=31_000.0)
+        await restarted.process_pending()
+
+        continued = await only_sighting(database)
+        assert continued.id == original.id
+        assert continued.started_ms == original.started_ms
+        assert continued.ended_ms is None
+
+    assert (await existing_aircraft(database)).sighting_count == 1
+
+
+async def test_a_continued_sighting_that_never_returns_closes_as_a_gap(
+    database: Database, live: LiveStore, clock: SimulatedTime
+) -> None:
+    """Because that closure *is* observed: this process watched the silence."""
+    async with doomed_worker(database, live, clock) as worker:
+        await fly_under(worker, live, clock, 20)
+
+    clock.advance(30.0)
+    async with worker_on(database, live, clock) as restarted:
+        assert restarted.recovery.continued == 1
+        clock.advance(CLOSE_S)
+        assert (await restarted.process_pending()).closed == 1
+
+    assert (await only_sighting(database)).closure_reason == ClosureReason.GAP_TIMEOUT.value
+
+
+async def test_a_normally_closed_sighting_is_left_alone(
+    database: Database, live: LiveStore, clock: SimulatedTime
+) -> None:
+    async with worker_on(database, live, clock) as worker:
+        await fly_under(worker, live, clock, 20)
+        depart(live, clock)
+        await worker.process_pending()
+        clock.advance(CLOSE_S)
+        assert (await worker.process_pending()).closed == 1
+
+    async with worker_on(database, live, clock) as restarted:
+        assert restarted.recovery.acted is False
+
+    sighting = await only_sighting(database)
+    assert sighting.closure_reason == ClosureReason.GAP_TIMEOUT.value
+
+
+# --------------------------------------------------------------- double crash
+
+
+class FailingAfterDatabase(Database):
+    """A database whose writer transactions fail from the ``allow``-th onward.
+
+    The injected fault stands in for the machine dying between two recovery
+    transactions: everything committed before it stays committed, and
+    everything after it never happened.
+    """
+
+    def __init__(self, path: Path, *, allow: int) -> None:
+        super().__init__(path)
+        self.allow = allow
+        self.used = 0
+
+    @contextlib.asynccontextmanager
+    async def writer_session(self) -> AsyncIterator[AsyncSession]:
+        used, self.used = self.used, self.used + 1
+        if used >= self.allow:
+            raise RuntimeError("simulated power cut mid-recovery")
+        async with super().writer_session() as session:
+            yield session
+
+
+def recovery_over(database: Database, clock: SimulatedTime, *, batch_size: int) -> ShutdownRecovery:
+    return ShutdownRecovery(
+        database=database,
+        repository=SightingRepository(database),
+        close_ms=int(CLOSE_S * 1_000),
+        clock=clock.epoch_ms,
+        batch_size=batch_size,
+    )
+
+
+async def _five_stale_sightings(
+    database: Database, live: LiveStore, clock: SimulatedTime
+) -> tuple[str, ...]:
+    """Five aircraft mid-flight when the power went, all long gone by now."""
+    icaos = tuple(f"ab00{index:02d}" for index in range(5))
+    async with doomed_worker(database, live, clock) as worker:
+        for index in range(20):
+            clock.advance(STEP_S)
+            for offset, icao in enumerate(icaos):
+                observe(
+                    live,
+                    clock,
+                    icao,
+                    position=offset_from(SEATTLE, 5.0 + index * 0.2 + offset, offset * 0.5),
+                    altitude_ft=30_000.0 + offset * 100,
+                )
+            await worker.process_pending()
+    clock.advance(CLOSE_S + 1.0)
+    return icaos
+
+
+async def test_a_crash_during_recovery_converges_on_the_next_attempt(
+    database: Database, live: LiveStore, clock: SimulatedTime, db_path: Path
+) -> None:
+    """The double-crash drill: interrupt recovery, re-run it, check convergence.
+
+    Progress is the database itself — a sighting the first attempt closed is
+    simply not open any more — so the second attempt needs no marker, no
+    resume point and no special case.
+    """
+    icaos = await _five_stale_sightings(database, live, clock)
+
+    interrupted = FailingAfterDatabase(db_path, allow=2)
+    try:
+        first = await recovery_over(interrupted, clock, batch_size=1).run()
+    finally:
+        await interrupted.dispose()
+
+    assert first.report.recovered == 2
+    assert first.report.failed == 3
+    assert first.report.transactions == 5
+    closed = [row for icao in icaos for row in await sightings_of(database, icao) if row.ended_ms]
+    assert len(closed) == 2
+    assert {row.closure_reason for row in closed} == {ClosureReason.SHUTDOWN_RECOVERY.value}
+    # The three that did not commit are untouched, checkpoints and all.
+    for icao in icaos:
+        sighting = await only_sighting(database, icao)
+        if sighting.ended_ms is None:
+            assert await checkpoints_of(database, sighting.id)
+
+    second = await recovery_over(database, clock, batch_size=1).run()
+    assert second.report.recovered == 3
+    assert second.report.failed == 0
+
+    third = await recovery_over(database, clock, batch_size=1).run()
+    assert third.report.acted is False
+    assert third.pending == ()
+
+    for icao in icaos:
+        sighting = await only_sighting(database, icao)
+        assert sighting.closure_reason == ClosureReason.SHUTDOWN_RECOVERY.value
+        assert await checkpoints_of(database, sighting.id) == []
+        assert await packed_track_of(database, sighting.id) is not None
+
+
+async def test_a_failed_recovery_batch_is_retried_by_the_next_cycle(
+    live: LiveStore, clock: SimulatedTime, db_path: Path
+) -> None:
+    """A quarantined sighting keeps its reason, and closes one cycle later.
+
+    Handing it back as an already-expired pending closure means the retry runs
+    through the ordinary close path — and carries ``shutdown_recovery``, not
+    the ``gap_timeout`` the ordinary path would otherwise record for a gap this
+    process never watched.
+    """
+    database = FailingOnceDatabase(db_path)
+    await database.upgrade_to("head")
+    try:
+        async with doomed_worker(database, live, clock) as worker:
+            await fly_under(worker, live, clock, 40)
+        clock.advance(CLOSE_S + 1.0)
+
+        database.fail_next = True
+        async with worker_on(database, live, clock) as restarted:
+            assert restarted.recovery.recovered == 0
+            assert restarted.recovery.failed == 1
+            assert restarted.recovery.anomalies == 1
+            assert restarted.pending_count == 1
+            assert (await only_sighting(database)).ended_ms is None
+
+            assert (await restarted.process_pending()).closed == 1
+
+        sighting = await only_sighting(database)
+        assert sighting.closure_reason == ClosureReason.SHUTDOWN_RECOVERY.value
+        assert await checkpoints_of(database, sighting.id) == []
+    finally:
+        await database.dispose()
+
+
+async def test_a_quarantined_sighting_whose_aircraft_returns_is_not_recovered(
+    live: LiveStore, clock: SimulatedTime, db_path: Path
+) -> None:
+    """Hearing the aircraft again makes any later closure an observed one."""
+    database = FailingOnceDatabase(db_path)
+    await database.upgrade_to("head")
+    try:
+        async with doomed_worker(database, live, clock) as worker:
+            await fly_under(worker, live, clock, 20)
+        clock.advance(CLOSE_S + 1.0)
+
+        database.fail_next = True
+        async with worker_on(database, live, clock) as restarted:
+            assert restarted.recovery.failed == 1
+
+            clock.advance(STEP_S)
+            observe(live, clock, position=arc(21), altitude_ft=30_000.0)
+            await restarted.process_pending()
+            assert restarted.active_count == 1
+
+            depart(live, clock)
+            await restarted.process_pending()
+            clock.advance(CLOSE_S)
+            assert (await restarted.process_pending()).closed == 1
+
+        assert (await only_sighting(database)).closure_reason == ClosureReason.GAP_TIMEOUT.value
+    finally:
+        await database.dispose()
+
+
+# ------------------------------------------------------------------- anomalies
+
+
+async def test_checkpoints_left_on_a_closed_sighting_are_cleaned(
+    database: Database, live: LiveStore, clock: SimulatedTime
+) -> None:
+    """A state the atomic close path cannot produce — repaired anyway.
+
+    Nothing reads checkpoints of a closed sighting, so leaving them would be
+    invisible rather than harmful. That is exactly why they are removed and
+    counted: an anomaly nobody is told about is a corruption that grows.
+    """
+    async with worker_on(database, live, clock) as worker:
+        await fly_under(worker, live, clock, 20)
+        depart(live, clock)
+        await worker.process_pending()
+        clock.advance(CLOSE_S)
+        assert (await worker.process_pending()).closed == 1
+    sighting = await only_sighting(database)
+
+    async with database.writer_session() as session:
+        session.add_all(
+            [
+                SightingTrackCheckpoint(
+                    sighting_id=sighting.id,
+                    seq=seq,
+                    ts_ms=sighting.started_ms + seq,
+                    lat=47.0,
+                    lon=-122.0,
+                    alt_ft=30_000,
+                    gs_kt=None,
+                    track_deg=None,
+                    pos_source=0,
+                )
+                for seq in range(3)
+            ]
+        )
+
+    async with worker_on(database, live, clock) as restarted:
+        assert restarted.recovery.orphan_sightings == 1
+        assert restarted.recovery.orphan_checkpoints == 3
+        assert restarted.recovery.recovered == 0
+
+    assert await checkpoints_of(database, sighting.id) == []
+
+
+async def test_checkpoints_for_a_sighting_that_does_not_exist_are_cleaned(
+    database: Database, live: LiveStore, clock: SimulatedTime, db_path: Path
+) -> None:
+    """Foreign keys make this unreachable in-process, so it is forged in SQL.
+
+    A restore from a mangled backup or a hand-edited database could still
+    present it, and recovery must not leave rows pointing at nothing.
+    """
+    await database.dispose()
+    execute_raw(
+        db_path,
+        "INSERT INTO sighting_track_checkpoints"
+        " (sighting_id, seq, ts_ms, lat, lon, alt_ft, gs_kt, track_deg, pos_source)"
+        " VALUES (424242, 0, 1, 47.0, -122.0, NULL, NULL, NULL, 0)",
+    )
+    reopened = Database(db_path)
+    try:
+        async with worker_on(reopened, live, clock) as restarted:
+            assert restarted.recovery.orphan_sightings == 1
+            assert restarted.recovery.orphan_checkpoints == 1
+        async with reading(reopened) as session:
+            assert (await session.get(SightingTrackCheckpoint, (424242, 0))) is None
+    finally:
+        await reopened.dispose()
+
+
+async def test_an_open_sighting_that_already_has_a_packed_track_is_closed(
+    database: Database, live: LiveStore, clock: SimulatedTime
+) -> None:
+    """The path is archived, so the sighting is finished — window or not.
+
+    Leaving it open would let the next close try to insert a second
+    ``sighting_tracks`` row for the same sighting and fail every cycle
+    thereafter. Closing it is the only repair that leaves the schema in a state
+    a reader can trust.
+    """
+    async with doomed_worker(database, live, clock) as worker:
+        await fly_under(worker, live, clock, 40)
+        sighting_id = (await only_sighting(database)).id
+        written = await checkpoints_of(database, sighting_id)
+
+    packed = pack_track(
+        simplify(
+            tuple(
+                TrackSample(
+                    ts_ms=row.ts_ms,
+                    latitude=row.lat,
+                    longitude=row.lon,
+                    position_source="adsb",
+                    altitude_ft=row.alt_ft,
+                    ground_speed_kt=row.gs_kt,
+                    track_deg=row.track_deg,
+                )
+                for row in written
+            )
+        )
+    )
+    async with database.writer_session() as session:
+        session.add(
+            SightingTrack(
+                sighting_id=sighting_id,
+                encoding_version=packed.encoding_version,
+                point_count=packed.point_count,
+                started_ms=packed.started_ms,
+                points_blob=packed.points_blob,
+            )
+        )
+
+    # Well inside the closure gap: without the anomaly rule this sighting would
+    # have been continued.
+    clock.advance(10.0)
+    async with worker_on(database, live, clock) as restarted:
+        assert restarted.recovery.orphan_sightings == 1
+        assert restarted.recovery.recovered == 1
+        assert restarted.recovery.continued == 0
+
+    sighting = await only_sighting(database)
+    assert sighting.closure_reason == ClosureReason.SHUTDOWN_RECOVERY.value
+    assert await checkpoints_of(database, sighting_id) == []
+    assert (await recovered_track(database, sighting_id)) != ()
+
+
+async def test_a_checkpoint_newer_than_the_airframe_still_ends_the_sighting(
+    database: Database, live: LiveStore, clock: SimulatedTime, db_path: Path
+) -> None:
+    """A sighting cannot have ended before the last position it recorded.
+
+    The airframe row is the ordinary evidence of when an aircraft was last
+    heard, but a checkpoint is evidence too, and the newer of the two is what
+    the window and ``ended_ms`` are measured against.
+    """
+    async with doomed_worker(database, live, clock) as worker:
+        await fly_under(worker, live, clock, 40)
+        sighting = await only_sighting(database)
+        written = await checkpoints_of(database, sighting.id)
+
+    await database.dispose()
+    execute_raw(db_path, "UPDATE aircraft SET last_seen_ms = ?", (sighting.started_ms,))
+    reopened = Database(db_path)
+    try:
+        clock.advance(CLOSE_S + 1.0)
+        async with worker_on(reopened, live, clock) as restarted:
+            assert restarted.recovery.recovered == 1
+        assert (await only_sighting(reopened)).ended_ms == written[-1].ts_ms
+    finally:
+        await reopened.dispose()
+
+
+# ----------------------------------------------------------------- diagnostics
+
+
+async def test_a_clean_boot_recovers_nothing_and_says_nothing(
+    database: Database, live: LiveStore, clock: SimulatedTime
+) -> None:
+    async with worker_on(database, live, clock) as worker:
+        assert worker.recovery.acted is False
+        assert worker.recovery.anomalies == 0
+        assert worker.recovery.transactions == 0
+        assert worker.recovery.recovered == 0
+
+
+async def test_the_recovery_summary_reaches_the_structured_log(
+    database: Database,
+    live: LiveStore,
+    clock: SimulatedTime,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """SPEC §71 asks for diagnostics when recovery happens, not for faith.
+
+    The assertion reads the JSON line an operator (and, from slice 042, the
+    diagnostics surface) actually sees, not a Python-level call record.
+    """
+    icaos = await _five_stale_sightings(database, live, clock)
+
+    configure_logging(level="INFO")
+    capsys.readouterr()
+    async with worker_on(database, live, clock) as restarted:
+        report = restarted.recovery
+
+    events = [
+        json.loads(line)
+        for line in capsys.readouterr().err.splitlines()
+        if line.startswith("{") and '"sighting_recovery_complete"' in line
+    ]
+    assert len(events) == 1
+    summary: dict[str, Any] = events[0]
+    assert summary["recovered"] == len(icaos)
+    assert summary["continued"] == 0
+    assert summary["failed"] == 0
+    assert summary["orphan_sightings"] == 0
+    assert summary["points_recovered"] == report.points_recovered > 0
+    assert summary["transactions"] == report.transactions >= 1

--- a/backend/tests/sightings/test_startup.py
+++ b/backend/tests/sightings/test_startup.py
@@ -1,11 +1,16 @@
 """Restart behaviour: what a new worker does with sightings left open.
 
-Checkpoint-based unclean-shutdown recovery is slice 053's. What slice 009 owes
-is that a restart is not silently destructive: a sighting whose aircraft is
-still being heard continues in the same row, and one whose closure gap expired
-while the process was down is closed honestly with ``gap_timeout`` at the last
-moment the aircraft was actually heard — never left open forever, and never
-duplicated by a second sighting opening alongside it.
+A restart must not be silently destructive: a sighting whose aircraft is still
+being heard continues in the same row, and one whose closure gap expired while
+the process was down is closed at the last moment the aircraft was actually
+heard — never left open forever, and never duplicated by a second sighting
+opening alongside it.
+
+The closure itself is startup recovery's (slice 053): a process that came back
+never watched that gap, so the reason recorded is ``shutdown_recovery`` and the
+close happens inside :meth:`PersistenceWorker.start` rather than on the first
+cycle. The drills covering *what* is recovered live in ``test_recovery.py``;
+what this module pins is that the restart contract around it is unchanged.
 """
 
 from __future__ import annotations
@@ -121,13 +126,12 @@ async def test_a_restart_closes_a_sighting_whose_gap_expired_while_down(
     successor = restart(database, live, clock)
     await successor.start()
     try:
-        result = await successor.process_pending()
-
-        assert result.closed == 1
+        assert successor.recovery.recovered == 1
         sighting = await only_sighting(database)
-        assert sighting.closure_reason == ClosureReason.GAP_TIMEOUT.value
+        assert sighting.closure_reason == ClosureReason.SHUTDOWN_RECOVERY.value
         assert sighting.ended_ms == last_heard_ms
         assert successor.pending_count == 0
+        assert (await successor.process_pending()).wrote is False
     finally:
         await successor.stop()
 
@@ -284,7 +288,8 @@ async def test_a_removal_after_shutdown_is_still_closed_on_the_next_start(
     successor = restart(database, live, clock)
     await successor.start()
     try:
-        assert (await successor.process_pending()).closed == 1
-        assert (await only_sighting(database)).closure_reason == ClosureReason.GAP_TIMEOUT.value
+        assert successor.recovery.recovered == 1
+        sighting = await only_sighting(database)
+        assert sighting.closure_reason == ClosureReason.SHUTDOWN_RECOVERY.value
     finally:
         await successor.stop()

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -369,7 +369,7 @@ slices:
     title: "Unclean-shutdown recovery"
     phase: 2
     branch: "053-shutdown-recovery"
-    status: planned
+    status: merged
     depends_on: ["052"]
     objective: "Recover cleanly from power loss: repair open sightings from checkpoints with bounded data loss and clear diagnostics."
     scope:


### PR DESCRIPTION
## Slice
- **Slice ID:** 053 — Unclean-shutdown recovery
- **Roadmap:** `planning/roadmap.yaml` slice 053 (phase 2; split from original 009)
- **Issue:** Closes #40

## Objective
Power-loss recovery of open sightings from checkpoints with bounded loss and clear diagnostics.

## Implementation summary
- ShutdownRecovery runs at worker start: anomaly cleanup (three impossible states cleaned + counted), continue-vs-recover partition on last-data absence vs close_s, batched individually-committed recovery through the SAME close path as live closure (checkpoints → simplify → pack → delete), closure_reason=shutdown_recovery — because nobody observed the gap (gap_timeout would assert an observation never made)
- ended_ms = last moment heard (checkpoint newer than airframe row moves it forward); failed batches quarantined as expired pending closures retried next cycle with the honest reason; idempotent with no marker — the DB state IS the progress record
- RecoveryReport retained on the worker for slice 042 diagnostics; structured summary log, silent on clean boots
- No migration (none needed — vocabulary and tables existed)

## Acceptance criteria
- [x] kill -9 during active sightings recovers: closed sanely with shutdown_recovery, bounded track loss (real-subprocess TerminateProcess drill + unmerged-WAL drill, in-suite ~7 s)
- [x] double-crash leaves the DB consistent (fault-injected convergence drill)
- [x] recovery outcomes visible in structured logs with counts

## Tests added/run
20 drill/unit tests; suite 904 passed; coverage **98.89%**, recovery.py 100% line+branch. Reviewer re-ran gates.

## Performance / Data considerations
Recovery is batched short transactions on the single writer; clean boots cost one query.

## Documentation updates
None required (ADR-0005 amendment from 052 pre-announced the unified path).

## Known limitations
Flush cadence is not user-configurable (deliberate; noted as a potential roadmap entry, not a TODO).

## Follow-up work
Slice 042 surfaces RecoveryReport; slice 049 measures recovery time.

## Fable self-review (SPEC §104)
- [x] Full diff inspected; recovery semantics verified against SPEC §71; drills are real-process, not simulated-only; two slice-009 test-meaning changes reviewed and correct; no TODO/FIXME
- [x] Branch based on current dev tip (no reconcile needed)
- [ ] CI green on this PR (gate before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)