### PR TITLE
Slice 025: Metadata update action

### DIFF
--- a/backend/src/flightsite/api/internal.py
+++ b/backend/src/flightsite/api/internal.py
@@ -13,10 +13,16 @@ one implementation.
 
 Slice 007 adds the decoder connection test the same two consumers need before
 they can save a receiver endpoint (SPEC §11).
+
+Slice 025 adds the "Update Aircraft Metadata" action: ``POST
+/metadata/update`` starts (or reports the state of) a run of
+:meth:`~flightsite.metadata.MetadataService.update`, and ``GET
+/metadata/status`` reports where each registered source stands.
 """
 
 from __future__ import annotations
 
+import asyncio
 from typing import Annotated, Any
 
 import structlog
@@ -24,7 +30,10 @@ from fastapi import APIRouter, Body, HTTPException, Request, status
 from pydantic import ValidationError
 
 from flightsite.config import ConfigError, ConfigStore, ReceiverSettings, Settings
+from flightsite.db import utc_now_ms
 from flightsite.ingest import ConnectionTestResult, DecoderEndpoint, check_connection
+from flightsite.metadata import ImportRun, MetadataService
+from flightsite.metadata.registry import SourceStatus, SourceStatusRecord
 
 logger = structlog.get_logger(__name__)
 
@@ -125,3 +134,113 @@ async def test_decoder_connection(
             poll_interval_s=candidate.poll_interval_s,
         )
     )
+
+
+# ---------------------------------------------------------- metadata (slice 025)
+
+#: Durable ``SourceStatus`` values as the status endpoint's ``status`` field
+#: spells them (``docs/API.md`` §5: "ok/failed/never-run/running"). Hyphenated
+#: rather than the enum's own snake_case so the wire vocabulary reads as
+#: prose, not as a Python identifier leaking into the API.
+_DURABLE_STATUS_LABELS: dict[SourceStatus, str] = {
+    SourceStatus.NEVER_RUN: "never-run",
+    SourceStatus.OK: "ok",
+    SourceStatus.FAILED: "failed",
+}
+
+
+def _metadata_source_payload(record: SourceStatusRecord) -> dict[str, Any]:
+    """One source's status row as ``GET /metadata/status`` reports it.
+
+    ``running`` — read from the registry's in-flight state, not the durable
+    row — overrides whatever the last completed attempt recorded: a source
+    mid-import still has yesterday's ``ok`` or ``failed`` sitting in
+    ``metadata_sources`` (the durable row only changes when an attempt
+    *finishes*), but what a user watching the Settings page needs to see
+    right now is that it is working, not what it last finished as.
+    """
+    display_status = "running" if record.run.running else _DURABLE_STATUS_LABELS[record.status]
+    return {
+        "name": record.source,
+        "status": display_status,
+        "last_success_ms": record.last_success_ms,
+        "dataset_version": record.dataset_version,
+        "row_count": record.row_count,
+        "last_error": record.last_error,
+    }
+
+
+@router.get("/metadata/status")
+async def get_metadata_status(request: Request) -> dict[str, Any]:
+    """Per-source metadata status: durable outcome merged with in-flight state.
+
+    One row per registered source (``mictronics``, ``faa`` as of slices
+    022/023), each independent of the others (SPEC §27) — a source that has
+    never run reports ``never-run`` beside one that failed yesterday and one
+    that is ``ok`` right now, and none of those three facts affects how the
+    other two are read. The Settings page polls this while a run is in
+    progress and renders each source's outcome on its own, so one source
+    failing never hides another's success.
+    """
+    metadata: MetadataService = request.app.state.metadata
+    statuses = await metadata.statuses()
+    return {"sources": [_metadata_source_payload(record) for record in statuses]}
+
+
+def _log_update_task_result(task: asyncio.Task[ImportRun]) -> None:
+    """Consume a finished background run's exception, if any, into the log.
+
+    Nothing ``await``s this task directly — the HTTP request that started it
+    has already returned, which is the entire point of running it in the
+    background — so nothing else would ever retrieve an exception it raised.
+    Without this callback, a bug here would only surface as asyncio's "Task
+    exception was never retrieved" warning at the next garbage collection,
+    with no context to debug it, instead of a clean log line naming what
+    happened. This is distinct from a source failing its own import: that is
+    caught inside :meth:`~flightsite.metadata.MetadataImporter.run` and
+    reported through ``GET /metadata/status`` as a result, never raised here.
+    """
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("metadata_update_task_failed", error=str(exc), error_type=type(exc).__name__)
+
+
+@router.post("/metadata/update", status_code=status.HTTP_202_ACCEPTED)
+async def trigger_metadata_update(request: Request) -> dict[str, Any]:
+    """Start a metadata update run, or report the one already in progress.
+
+    Downloading and staging a snapshot per source is seconds to minutes of
+    network and disk I/O — nothing an HTTP client should hold a connection
+    open for — so this schedules :meth:`~flightsite.metadata.MetadataService.update`
+    as a background task and returns 202 the instant it is scheduled.
+    Progress and outcome are read back from ``GET /metadata/status``, which
+    the Settings UI polls until every source has settled.
+
+    A trigger that arrives while an earlier one is still running does not
+    start a second run: ``MetadataImporter`` imports its sources one at a
+    time, and two overlapping runs would race each other over the same
+    staging rows for whichever source is current. Instead this reports the
+    in-progress run's own ``started_ms``, which is what lets a double-clicked
+    button or a second open tab coalesce onto the run already happening
+    instead of racing it. The check-and-schedule below never ``await``s in
+    between, so two requests arriving back to back on the same event loop
+    cannot both observe "not running" and both schedule a run.
+    """
+    task: asyncio.Task[ImportRun] | None = request.app.state.metadata_update_task
+    if task is not None and not task.done():
+        return {
+            "started": False,
+            "already_running": True,
+            "started_ms": request.app.state.metadata_update_started_ms,
+        }
+
+    metadata: MetadataService = request.app.state.metadata
+    started_ms = utc_now_ms()
+    new_task = asyncio.create_task(metadata.update(), name="metadata-update")
+    new_task.add_done_callback(_log_update_task_result)
+    request.app.state.metadata_update_task = new_task
+    request.app.state.metadata_update_started_ms = started_ms
+    logger.info("metadata_update_triggered", started_ms=started_ms)
+    return {"started": True, "already_running": False, "started_ms": started_ms}

--- a/backend/src/flightsite/app.py
+++ b/backend/src/flightsite/app.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 
 import structlog
 from fastapi import FastAPI
@@ -22,7 +23,7 @@ from flightsite.demo import DEFAULT_CENTER, DemoAdapter, demo_enabled
 from flightsite.ingest import DecoderEndpoint, IngestionService, Position, build_ingestion_service
 from flightsite.live import LiveStore
 from flightsite.logging import configure_logging
-from flightsite.metadata import MetadataService
+from flightsite.metadata import ImportRun, MetadataService
 from flightsite.metadata.registry import SourceRegistry
 from flightsite.metadata.sources import FaaRegistryProvider, MictronicsProvider
 from flightsite.readiness import ReadinessRegistry
@@ -192,6 +193,17 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
             await service.stop()
         await live.stop()
         await broadcaster.stop()
+        # A slice-025 update run outlives the request that triggered it
+        # (that is the whole point of running it in the background), so one
+        # can still be in flight at shutdown. Cancelling it here rather than
+        # abandoning it means the writer session it holds rolls back
+        # cleanly (``Database.writer_session`` catches ``BaseException``)
+        # instead of racing the engines disposing under it.
+        update_task: asyncio.Task[ImportRun] | None = app.state.metadata_update_task
+        if update_task is not None and not update_task.done():
+            update_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await update_task
         # Before the persistence worker, so no consumer of the live stream is
         # still resolving against the database while the worker takes its final
         # writer transactions.
@@ -234,10 +246,12 @@ def create_app(data_dir: str | os.PathLike[str] | None = None) -> FastAPI:
     registry, the transactional import pipeline, and the metadata & rarity
     cache that keeps SQLite off the live path (``docs/ARCHITECTURE.md`` §3.3).
     Startup attaches the cache to the live event stream on a healthy schema,
-    and shutdown detaches it before the writer takes its last transaction. No
-    HTTP endpoint exposes it yet — ``docs/API.md`` §5 assigns
-    ``/api/internal/metadata/*`` to slice 025, which calls
-    :meth:`~flightsite.metadata.MetadataService.update`.
+    and shutdown detaches it before the writer takes its last transaction.
+    ``docs/API.md`` §5's ``/api/internal/metadata/*`` (slice 025) calls
+    :meth:`~flightsite.metadata.MetadataService.update` from a background
+    task tracked as ``app.state.metadata_update_task``, so a run outlives the
+    request that started it; shutdown cancels one still in flight before the
+    cache and the writer stop underneath it.
 
     The live API context and the WebSocket broadcaster are constructed here
     too, as ``app.state.api_context`` and ``app.state.broadcaster``. The
@@ -292,6 +306,14 @@ def create_app(data_dir: str | os.PathLike[str] | None = None) -> FastAPI:
         data_dir=store.data_dir,
         registry=_build_metadata_registry(),
     )
+    # Slice 025's update-in-progress coordinator: the background task the
+    # current "Update Aircraft Metadata" run is executing in, and when it
+    # started. ``None`` means no run has ever been triggered on this process.
+    # Read and written only from ``POST /api/internal/metadata/update``
+    # handlers, which never ``await`` between checking and replacing it, so
+    # two overlapping requests on the same event loop cannot both start a run.
+    app.state.metadata_update_task = None
+    app.state.metadata_update_started_ms = None
     app.state.start_time = time.monotonic()
     # Read once at app-construction time, not per-request: demo mode is a
     # process-level run mode (FLIGHTSITE_DEMO), not something that changes

--- a/backend/tests/api/test_metadata_api.py
+++ b/backend/tests/api/test_metadata_api.py
@@ -1,0 +1,311 @@
+"""Internal metadata API tests: ``POST``/``GET /api/internal/metadata/*`` (slice 025).
+
+The app the fixtures build here keeps everything else ``create_app`` wires up
+(config, live store, persistence, broadcaster) but swaps ``app.state.metadata``
+for a fresh :class:`~flightsite.metadata.MetadataService` over an empty
+:class:`~flightsite.metadata.SourceRegistry` each test fills with
+:class:`~tests.metadata.provider.InMemoryMetadataProvider` doubles — the same
+substitution ``tests/api/conftest.py``'s live-app harness makes for
+``app.state.live``, and for the same reason: nothing here should ever reach
+the network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from flightsite.api.internal import _log_update_task_result
+from flightsite.app import create_app
+from flightsite.live import LiveStore
+from flightsite.logging import configure_logging
+from flightsite.metadata import ImportRun, MetadataService, SourceRegistry
+from flightsite.metadata.registry import ImportPhase
+
+from ..metadata.conftest import record
+from ..metadata.provider import InMemoryMetadataProvider
+
+METADATA_STATUS_PATH = "/api/internal/metadata/status"
+METADATA_UPDATE_PATH = "/api/internal/metadata/update"
+
+RECORD_A = record("a00001", registration="N1AA", type_code="B738")
+
+
+@pytest.fixture
+def registry() -> SourceRegistry:
+    """An empty registry each test fills with in-memory providers."""
+    return SourceRegistry()
+
+
+@pytest.fixture
+async def app(isolated_data_dir: Path, registry: SourceRegistry) -> AsyncIterator[FastAPI]:
+    """A started app whose metadata service runs over the test's own registry."""
+    application = create_app(isolated_data_dir)
+    application.state.metadata = MetadataService(
+        database=application.state.database,
+        live=LiveStore(clock=lambda: 0.0),
+        data_dir=isolated_data_dir,
+        registry=registry,
+    )
+    async with application.router.lifespan_context(application):
+        yield application
+
+
+@pytest.fixture
+async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as async_client:
+        yield async_client
+
+
+#: Generous relative to how fast this actually resolves (microseconds of
+#: in-thread work): a slow CI runner should never turn scheduling jitter into
+#: a flaky failure.
+_STARTED_TIMEOUT_S = 2.0
+
+
+async def _wait_started(provider: InMemoryMetadataProvider) -> None:
+    """Wait until ``provider.download`` has actually been entered.
+
+    Genuine cross-thread synchronization, not a flaky-assertion workaround:
+    the importer's download stage runs on the same loop, but there is real
+    ``asyncio.to_thread`` work (preparing the run's working directory)
+    between scheduling a background run and it reaching a controlled hold, so
+    a fixed number of loop yields is not a reliable wait.
+    """
+    async with asyncio.timeout(_STARTED_TIMEOUT_S):
+        await provider.started.wait()
+
+
+async def _status_by_name(client: AsyncClient) -> dict[str, dict[str, object]]:
+    response = await client.get(METADATA_STATUS_PATH)
+    assert response.status_code == 200
+    body = response.json()
+    return {entry["name"]: entry for entry in body["sources"]}
+
+
+# --------------------------------------------------------------- POST /update
+
+
+async def test_trigger_returns_before_the_run_completes(
+    app: FastAPI, client: AsyncClient, registry: SourceRegistry
+) -> None:
+    hold = asyncio.Event()
+    provider = InMemoryMetadataProvider([RECORD_A], version="mict-1", hold=hold)
+    registry.register("mictronics", provider)
+
+    response = await client.post(METADATA_UPDATE_PATH)
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["started"] is True
+    assert body["already_running"] is False
+    assert isinstance(body["started_ms"], int)
+
+    # The request already answered, but the run is still blocked on `hold`:
+    # proof that the trigger did not wait for the import to finish.
+    await _wait_started(provider)
+    statuses = await _status_by_name(client)
+    assert statuses["mictronics"]["status"] == "running"
+
+    hold.set()
+    await app.state.metadata_update_task
+
+    statuses = await _status_by_name(client)
+    assert statuses["mictronics"]["status"] == "ok"
+    assert statuses["mictronics"]["dataset_version"] == "mict-1"
+    assert statuses["mictronics"]["row_count"] == 1
+    assert statuses["mictronics"]["last_success_ms"] is not None
+    assert statuses["mictronics"]["last_error"] is None
+
+
+async def test_concurrent_trigger_coalesces_onto_the_running_run(
+    app: FastAPI, client: AsyncClient, registry: SourceRegistry
+) -> None:
+    hold = asyncio.Event()
+    provider = InMemoryMetadataProvider([RECORD_A], hold=hold)
+    registry.register("mictronics", provider)
+
+    first = await client.post(METADATA_UPDATE_PATH)
+    assert first.status_code == 202
+    first_body = first.json()
+    assert first_body["started"] is True
+
+    await _wait_started(provider)
+
+    second = await client.post(METADATA_UPDATE_PATH)
+
+    assert second.status_code == 202
+    second_body = second.json()
+    assert second_body["started"] is False
+    assert second_body["already_running"] is True
+    assert second_body["started_ms"] == first_body["started_ms"]
+    # The coalesced trigger did not start a second import of the same source.
+    assert provider.downloads == 1
+
+    hold.set()
+    await app.state.metadata_update_task
+    assert provider.downloads == 1
+
+
+async def test_a_second_trigger_after_completion_starts_a_new_run(
+    app: FastAPI, client: AsyncClient, registry: SourceRegistry
+) -> None:
+    provider = InMemoryMetadataProvider([RECORD_A])
+    registry.register("mictronics", provider)
+
+    first = await client.post(METADATA_UPDATE_PATH)
+    await app.state.metadata_update_task
+    assert first.json()["started"] is True
+
+    second = await client.post(METADATA_UPDATE_PATH)
+
+    assert second.json()["started"] is True
+    assert second.json()["already_running"] is False
+    await app.state.metadata_update_task
+    assert provider.downloads == 2
+
+
+# ---------------------------------------------------------------- GET /status
+
+
+async def test_status_reports_never_run_for_a_fresh_source(
+    client: AsyncClient, registry: SourceRegistry
+) -> None:
+    registry.register("mictronics", InMemoryMetadataProvider([RECORD_A]))
+
+    statuses = await _status_by_name(client)
+
+    assert statuses["mictronics"] == {
+        "name": "mictronics",
+        "status": "never-run",
+        "last_success_ms": None,
+        "dataset_version": None,
+        "row_count": None,
+        "last_error": None,
+    }
+
+
+async def test_one_source_failing_does_not_affect_the_others_status(
+    app: FastAPI, client: AsyncClient, registry: SourceRegistry
+) -> None:
+    """SPEC §27 independence, at the API layer: each source's own outcome."""
+    registry.register("mictronics", InMemoryMetadataProvider([RECORD_A], version="mict-1"))
+    # An empty snapshot: the importer rejects it at STAGING ("produced no
+    # usable rows"), which is a source failing on its own — no injected fault
+    # needed to exercise the independence guarantee at this layer.
+    registry.register("faa", InMemoryMetadataProvider([]))
+
+    response = await client.post(METADATA_UPDATE_PATH)
+    assert response.status_code == 202
+    await app.state.metadata_update_task
+
+    statuses = await _status_by_name(client)
+
+    assert statuses["mictronics"]["status"] == "ok"
+    assert statuses["mictronics"]["dataset_version"] == "mict-1"
+    assert statuses["mictronics"]["row_count"] == 1
+    assert statuses["mictronics"]["last_error"] is None
+
+    assert statuses["faa"]["status"] == "failed"
+    assert statuses["faa"]["last_success_ms"] is None
+    assert statuses["faa"]["dataset_version"] is None
+    assert statuses["faa"]["last_error"] is not None
+
+
+async def test_a_later_failure_leaves_an_earlier_success_reported_intact(
+    app: FastAPI, client: AsyncClient, registry: SourceRegistry
+) -> None:
+    provider = InMemoryMetadataProvider([RECORD_A], version="mict-1")
+    registry.register("mictronics", provider)
+
+    await client.post(METADATA_UPDATE_PATH)
+    await app.state.metadata_update_task
+
+    provider.fail_at = ImportPhase.DOWNLOAD
+    await client.post(METADATA_UPDATE_PATH)
+    await app.state.metadata_update_task
+
+    statuses = await _status_by_name(client)
+    assert statuses["mictronics"]["status"] == "failed"
+    # The previous dataset's facts (SPEC §27's "leaves the previous working
+    # dataset intact") still describe what is actually installed.
+    assert statuses["mictronics"]["dataset_version"] == "mict-1"
+    assert statuses["mictronics"]["row_count"] == 1
+    assert statuses["mictronics"]["last_error"] is not None
+
+
+async def test_status_is_not_in_the_published_openapi_schema(client: AsyncClient) -> None:
+    schema = (await client.get("/api/v1/openapi.json")).json()
+
+    assert not any("metadata" in path for path in schema["paths"])
+
+
+async def test_shutdown_cancels_an_in_flight_update_task(isolated_data_dir: Path) -> None:
+    """A run outlives its request; shutdown must not abandon it mid-write."""
+    registry = SourceRegistry()
+    provider = InMemoryMetadataProvider([RECORD_A], hold=asyncio.Event())
+    registry.register("mictronics", provider)
+
+    application = create_app(isolated_data_dir)
+    application.state.metadata = MetadataService(
+        database=application.state.database,
+        live=LiveStore(clock=lambda: 0.0),
+        data_dir=isolated_data_dir,
+        registry=registry,
+    )
+
+    async with application.router.lifespan_context(application):
+        async with AsyncClient(
+            transport=ASGITransport(app=application), base_url="http://testserver"
+        ) as async_client:
+            response = await async_client.post(METADATA_UPDATE_PATH)
+            assert response.status_code == 202
+            await _wait_started(provider)
+        task = application.state.metadata_update_task
+
+    assert task is not None
+    assert task.cancelled()
+
+
+# ------------------------------------------------- _log_update_task_result
+
+
+async def _never() -> ImportRun:
+    await asyncio.sleep(10)
+    raise AssertionError("unreachable: cancelled before this returns")
+
+
+async def test_log_update_task_result_ignores_a_cancelled_task() -> None:
+    task: asyncio.Task[ImportRun] = asyncio.create_task(_never())
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    _log_update_task_result(task)  # must not raise
+
+
+async def test_log_update_task_result_logs_an_unretrieved_exception(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    configure_logging(level="INFO")
+
+    async def _boom() -> ImportRun:
+        raise RuntimeError("cache invalidation exploded")
+
+    task: asyncio.Task[ImportRun] = asyncio.create_task(_boom())
+    with pytest.raises(RuntimeError):
+        await task
+
+    _log_update_task_result(task)
+
+    captured = capsys.readouterr()
+    output = captured.out + captured.err
+    assert "metadata_update_task_failed" in output
+    assert "cache invalidation exploded" in output

--- a/backend/tests/metadata/provider.py
+++ b/backend/tests/metadata/provider.py
@@ -14,6 +14,7 @@ suite.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Iterator, Sequence
 from pathlib import Path
@@ -43,6 +44,12 @@ class InMemoryMetadataProvider:
         report: an explicit validation report, overriding the default.
         bad_rows: raw addresses yielded as unnormalizable records, to exercise
             the rejection tolerance.
+        hold: when given, ``download`` awaits this event before proceeding —
+            a way to freeze a run mid-flight (holding the registry's
+            ``running`` state) so a test can observe "in progress" and
+            exercise concurrent-trigger behavior before letting it finish.
+            :attr:`started` is what a test awaits to know the freeze has
+            actually taken hold, rather than polling.
     """
 
     def __init__(
@@ -54,6 +61,7 @@ class InMemoryMetadataProvider:
         fail_after: int = 0,
         report: ValidationReport | None = None,
         bad_rows: int = 0,
+        hold: asyncio.Event | None = None,
     ) -> None:
         self.records = list(records)
         self.version = version
@@ -61,12 +69,19 @@ class InMemoryMetadataProvider:
         self.fail_after = fail_after
         self.report = report
         self.bad_rows = bad_rows
+        self.hold = hold
+        #: Set the instant ``download`` is entered — before it ever waits on
+        #: ``hold`` — so a test can await this rather than poll ``downloads``.
+        self.started = asyncio.Event()
         self.downloads = 0
         self.validations = 0
         self.transforms = 0
 
     async def download(self, workdir: Path) -> SourceArtifact:
         self.downloads += 1
+        self.started.set()
+        if self.hold is not None:
+            await self.hold.wait()
         if self.fail_at is ImportPhase.DOWNLOAD:
             raise ProviderFailure("upstream unreachable")
         path = workdir / "snapshot.json"

--- a/frontend/src/features/settings/SettingsPage.test.tsx
+++ b/frontend/src/features/settings/SettingsPage.test.tsx
@@ -49,6 +49,7 @@ describe("SettingsPage", () => {
       "Alerts",
       "Notifications",
       "Enrichment",
+      "Aircraft Metadata",
       "Retention",
     ]) {
       expect(

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -6,6 +6,7 @@ import { AlertsSection } from "@/features/settings/sections/AlertsSection";
 import { DecoderSection } from "@/features/settings/sections/DecoderSection";
 import { DisplaySection } from "@/features/settings/sections/DisplaySection";
 import { EnrichmentSection } from "@/features/settings/sections/EnrichmentSection";
+import { MetadataSection } from "@/features/settings/sections/MetadataSection";
 import { NotificationsSection } from "@/features/settings/sections/NotificationsSection";
 import { ReceiverSection } from "@/features/settings/sections/ReceiverSection";
 import { RetentionSection } from "@/features/settings/sections/RetentionSection";
@@ -87,6 +88,7 @@ export function SettingsPage() {
         <AlertsSection config={config} />
         <NotificationsSection config={config} />
         <EnrichmentSection config={config} hasStoredKey={hasStoredKey} />
+        <MetadataSection timezone={config.timezone} />
         <RetentionSection config={config} />
       </div>
     </div>

--- a/frontend/src/features/settings/lib/metadataAge.test.ts
+++ b/frontend/src/features/settings/lib/metadataAge.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { overallMetadataAge } from "@/features/settings/lib/metadataAge";
+import { metadataSource } from "@/test/metadataApiMock";
+
+describe("overallMetadataAge", () => {
+  it("is null when there are no sources at all", () => {
+    expect(overallMetadataAge([])).toBeNull();
+  });
+
+  it("is null when no source has ever succeeded — the fresh-install 'never' state", () => {
+    const sources = [
+      metadataSource({ name: "mictronics", status: "never-run" }),
+      metadataSource({ name: "faa", status: "never-run" }),
+    ];
+
+    expect(overallMetadataAge(sources)).toBeNull();
+  });
+
+  it("is the single source's last success when only one has ever run", () => {
+    const sources = [
+      metadataSource({
+        name: "mictronics",
+        status: "ok",
+        last_success_ms: 1_000,
+      }),
+      metadataSource({ name: "faa", status: "never-run" }),
+    ];
+
+    expect(overallMetadataAge(sources)).toBe(1_000);
+  });
+
+  it("is the maximum last_success_ms across every source", () => {
+    const sources = [
+      metadataSource({
+        name: "mictronics",
+        status: "ok",
+        last_success_ms: 5_000,
+      }),
+      metadataSource({ name: "faa", status: "ok", last_success_ms: 9_000 }),
+    ];
+
+    expect(overallMetadataAge(sources)).toBe(9_000);
+  });
+
+  it("keeps a source's earlier success even while it is currently failed", () => {
+    // SPEC §27: a failed import leaves the previous dataset — and its
+    // last_success_ms — intact, so the overall age must not drop it either.
+    const sources = [
+      metadataSource({
+        name: "faa",
+        status: "failed",
+        last_success_ms: 3_000,
+        last_error: "upstream unreachable",
+      }),
+    ];
+
+    expect(overallMetadataAge(sources)).toBe(3_000);
+  });
+});

--- a/frontend/src/features/settings/lib/metadataAge.ts
+++ b/frontend/src/features/settings/lib/metadataAge.ts
@@ -1,0 +1,21 @@
+/**
+ * The overall "metadata last updated" figure (roadmap slice 025), computed
+ * from per-source status rather than stored anywhere of its own — it is
+ * always the max `last_success_ms` across sources, so a fresh install where
+ * nothing has ever run reads as `null` rather than a fabricated zero. Slice
+ * 042's health/diagnostics surface reads this same age.
+ */
+import type { MetadataSourceStatusEntry } from "@/lib/api/metadata";
+
+/** The most recent successful import across every source, in epoch
+ * milliseconds — or `null` when no source has ever completed one, which is
+ * the honest "never" state a fresh install starts in (§2.7 null/unknown
+ * semantics: absence, not a guess). */
+export function overallMetadataAge(
+  sources: readonly MetadataSourceStatusEntry[],
+): number | null {
+  const successes = sources
+    .map((source) => source.last_success_ms)
+    .filter((value): value is number => value !== null);
+  return successes.length === 0 ? null : Math.max(...successes);
+}

--- a/frontend/src/features/settings/sections/MetadataSection.test.tsx
+++ b/frontend/src/features/settings/sections/MetadataSection.test.tsx
@@ -1,0 +1,255 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { formatReceiverLocalTime } from "@/features/aircraft-detail/lib/format";
+import { MetadataSection } from "@/features/settings/sections/MetadataSection";
+import { installMetadataApiMock, metadataSource } from "@/test/metadataApiMock";
+
+const TIMEZONE = "UTC";
+//: A fixed instant far enough in the past that its relative age never
+// resolves to something like "just now" no matter when the suite runs.
+const OK_SUCCESS_MS = Date.UTC(2020, 0, 15, 8, 30, 0);
+const EXPECTED_LOCAL_TIME = formatReceiverLocalTime(
+  new Date(OK_SUCCESS_MS).toISOString(),
+  TIMEZONE,
+);
+
+function renderSection() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MetadataSection timezone={TIMEZONE} />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("MetadataSection", () => {
+  it("renders a never-run source and an overall 'never' age line", async () => {
+    installMetadataApiMock({
+      statusSequence: [{ sources: [metadataSource({ name: "mictronics" })] }],
+    });
+    renderSection();
+
+    expect(await screen.findByText("Mictronics")).toBeInTheDocument();
+    expect(screen.getByText("Never run")).toBeInTheDocument();
+    expect(screen.getByText("Never updated.")).toBeInTheDocument();
+    expect(screen.getByText("never")).toBeInTheDocument();
+  });
+
+  it("renders a successful source with version, row count and the age line", async () => {
+    installMetadataApiMock({
+      statusSequence: [
+        {
+          sources: [
+            metadataSource({
+              name: "mictronics",
+              status: "ok",
+              last_success_ms: OK_SUCCESS_MS,
+              dataset_version: "2026-08-01",
+              row_count: 42_000,
+            }),
+          ],
+        },
+      ],
+    });
+    renderSection();
+
+    expect(await screen.findByText("Up to date")).toBeInTheDocument();
+    expect(
+      screen.getByText("Version 2026-08-01 · 42,000 aircraft"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(new RegExp(`Last updated ${EXPECTED_LOCAL_TIME}`)),
+    ).toBeInTheDocument();
+    // The overall age line uses the same successful timestamp.
+    expect(screen.getByText(/metadata last updated:/i)).toHaveTextContent(
+      EXPECTED_LOCAL_TIME,
+    );
+  });
+
+  it("renders a failing source with its error and a data-safety reassurance, independent of a healthy source", async () => {
+    installMetadataApiMock({
+      statusSequence: [
+        {
+          sources: [
+            metadataSource({
+              name: "mictronics",
+              status: "ok",
+              last_success_ms: OK_SUCCESS_MS,
+              dataset_version: "2026-08-01",
+              row_count: 42_000,
+            }),
+            metadataSource({
+              name: "faa",
+              status: "failed",
+              last_error: "upstream unreachable",
+            }),
+          ],
+        },
+      ],
+    });
+    renderSection();
+
+    // The failing source's own card:
+    expect(await screen.findByText("upstream unreachable")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Previous FAA data is unaffected/i),
+    ).toBeInTheDocument();
+
+    // The healthy source is unobscured — its own success still renders in full.
+    expect(screen.getByText("Up to date")).toBeInTheDocument();
+    expect(
+      screen.getByText("Version 2026-08-01 · 42,000 aircraft"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+
+  it("shows a load error without crashing the section", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("boom", { status: 500 })),
+    );
+    renderSection();
+
+    expect(
+      await screen.findByText(/could not load metadata source status/i),
+    ).toBeInTheDocument();
+  });
+
+  it("triggers an update and reflects the in-progress state from the very next poll", async () => {
+    installMetadataApiMock({
+      statusSequence: [
+        { sources: [metadataSource({ name: "mictronics", status: "ok" })] },
+        {
+          sources: [metadataSource({ name: "mictronics", status: "running" })],
+        },
+      ],
+      triggerResult: {
+        started: true,
+        already_running: false,
+        started_ms: 1_756_600_000_000,
+      },
+    });
+    const user = userEvent.setup();
+    renderSection();
+
+    await screen.findByText("Up to date");
+    await user.click(
+      screen.getByRole("button", { name: /update aircraft metadata/i }),
+    );
+
+    expect(await screen.findByText("Running")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /updating/i })).toBeDisabled();
+  });
+
+  it("polls until the run settles, then stops showing the running state", async () => {
+    installMetadataApiMock({
+      statusSequence: [
+        {
+          sources: [
+            metadataSource({ name: "mictronics", status: "never-run" }),
+          ],
+        },
+        {
+          sources: [metadataSource({ name: "mictronics", status: "running" })],
+        },
+        {
+          sources: [
+            metadataSource({
+              name: "mictronics",
+              status: "ok",
+              last_success_ms: OK_SUCCESS_MS,
+              dataset_version: "2026-08-01",
+              row_count: 10,
+            }),
+          ],
+        },
+      ],
+    });
+    const user = userEvent.setup();
+    renderSection();
+
+    await screen.findByText("Never run");
+    await user.click(
+      screen.getByRole("button", { name: /update aircraft metadata/i }),
+    );
+
+    await screen.findByText("Running");
+    // The next scheduled poll (METADATA_POLL_INTERVAL_MS) picks up the
+    // settled state — no further click or manual refetch involved.
+    expect(
+      await screen.findByText("Up to date", {}, { timeout: 4000 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /update aircraft metadata/i }),
+    ).toBeEnabled();
+  });
+
+  it("reports a coalesced trigger without claiming a fresh run started", async () => {
+    // This tab still shows "ok" (it has not polled since another tab, or a
+    // very close double-click, started a run) — the button is enabled, and
+    // the backend is what tells this trigger it coalesced.
+    installMetadataApiMock({
+      statusSequence: [
+        { sources: [metadataSource({ name: "mictronics", status: "ok" })] },
+      ],
+      triggerResult: {
+        started: false,
+        already_running: true,
+        started_ms: 1_756_600_000_000,
+      },
+    });
+    const user = userEvent.setup();
+    renderSection();
+
+    await screen.findByText("Up to date");
+    await user.click(
+      screen.getByRole("button", { name: /update aircraft metadata/i }),
+    );
+
+    expect(
+      await screen.findByText(/an update was already running/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a trigger error without losing the previously loaded status", async () => {
+    vi.stubGlobal("fetch", (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url === "/api/internal/metadata/status" && method === "GET") {
+        return new Response(
+          JSON.stringify({ sources: [metadataSource({ name: "mictronics" })] }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url === "/api/internal/metadata/update" && method === "POST") {
+        return new Response(JSON.stringify({ detail: "boom" }), {
+          status: 500,
+        });
+      }
+      throw new Error(`Unhandled fetch: ${method} ${url}`);
+    }) as typeof fetch);
+    const user = userEvent.setup();
+    renderSection();
+
+    await screen.findByText("Never run");
+    await user.click(
+      screen.getByRole("button", { name: /update aircraft metadata/i }),
+    );
+
+    expect(await screen.findByText("boom")).toBeInTheDocument();
+    // The section keeps showing the status it already had.
+    expect(screen.getByText("Never run")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/settings/sections/MetadataSection.tsx
+++ b/frontend/src/features/settings/sections/MetadataSection.tsx
@@ -1,0 +1,235 @@
+import {
+  CheckCircle2,
+  CircleDashed,
+  Loader2,
+  type LucideIcon,
+  XCircle,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { formatReceiverLocalTime } from "@/features/aircraft-detail/lib/format";
+import { useRelativeAge } from "@/features/aircraft-detail/lib/useRelativeAge";
+import { SettingsSection } from "@/features/settings/components/SettingsSection";
+import { overallMetadataAge } from "@/features/settings/lib/metadataAge";
+import {
+  useMetadataStatusQuery,
+  useTriggerMetadataUpdateMutation,
+  type MetadataSourceStatus,
+  type MetadataSourceStatusEntry,
+} from "@/lib/api/metadata";
+
+export interface MetadataSectionProps {
+  /** IANA timezone "last updated" times render in — `config.timezone`
+   * (docs/API.md §3.2), the same one the aircraft detail panel uses. */
+  timezone: string;
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  mictronics: "Mictronics",
+  faa: "FAA",
+};
+
+function sourceLabel(name: string): string {
+  return SOURCE_LABELS[name] ?? name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+function epochMsToIso(epochMs: number): string {
+  return new Date(epochMs).toISOString();
+}
+
+const STATUS_META: Record<
+  MetadataSourceStatus,
+  { label: string; className: string; icon: LucideIcon; spin?: boolean }
+> = {
+  ok: {
+    label: "Up to date",
+    className: "text-accent-foreground",
+    icon: CheckCircle2,
+  },
+  failed: { label: "Failed", className: "text-destructive", icon: XCircle },
+  "never-run": {
+    label: "Never run",
+    className: "text-muted-foreground",
+    icon: CircleDashed,
+  },
+  running: {
+    label: "Running",
+    className: "text-accent-foreground",
+    icon: Loader2,
+    spin: true,
+  },
+};
+
+function StatusBadge({ status }: { status: MetadataSourceStatus }) {
+  const meta = STATUS_META[status];
+  const Icon = meta.icon;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs font-medium ${meta.className}`}
+    >
+      <Icon
+        className={`size-3.5 ${meta.spin ? "animate-spin" : ""}`}
+        aria-hidden="true"
+      />
+      {meta.label}
+    </span>
+  );
+}
+
+interface SourceCardProps {
+  source: MetadataSourceStatusEntry;
+  timezone: string;
+}
+
+function SourceCard({ source, timezone }: SourceCardProps) {
+  const lastSuccessIso =
+    source.last_success_ms === null
+      ? null
+      : epochMsToIso(source.last_success_ms);
+  const relativeAge = useRelativeAge(lastSuccessIso);
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border bg-background p-3">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-sm font-medium">{sourceLabel(source.name)}</p>
+        <StatusBadge status={source.status} />
+      </div>
+
+      {lastSuccessIso === null ? (
+        <p className="text-xs text-muted-foreground">Never updated.</p>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          Last updated {formatReceiverLocalTime(lastSuccessIso, timezone)}
+          {relativeAge ? ` · ${relativeAge}` : ""}
+        </p>
+      )}
+
+      {(source.dataset_version !== null || source.row_count !== null) && (
+        <p className="text-xs text-muted-foreground">
+          {source.dataset_version !== null &&
+            `Version ${source.dataset_version}`}
+          {source.dataset_version !== null &&
+            source.row_count !== null &&
+            " · "}
+          {source.row_count !== null &&
+            `${source.row_count.toLocaleString()} aircraft`}
+        </p>
+      )}
+
+      {source.status === "failed" && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 p-2">
+          <p role="alert" className="text-xs text-destructive">
+            {source.last_error ?? "The update failed."}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Previous {sourceLabel(source.name)} data is unaffected — this source
+            only stopped updating, it did not lose what it had.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MetadataAgeLine({
+  sources,
+  timezone,
+}: {
+  sources: MetadataSourceStatusEntry[];
+  timezone: string;
+}) {
+  const ageMs = overallMetadataAge(sources);
+  const ageIso = ageMs === null ? null : epochMsToIso(ageMs);
+  const relativeAge = useRelativeAge(ageIso);
+
+  return (
+    <p className="text-sm text-muted-foreground">
+      Metadata last updated:{" "}
+      {ageIso === null ? (
+        <span className="font-medium text-foreground">never</span>
+      ) : (
+        <span className="font-medium text-foreground">
+          {formatReceiverLocalTime(ageIso, timezone)}
+          {relativeAge ? ` (${relativeAge})` : ""}
+        </span>
+      )}
+    </p>
+  );
+}
+
+/**
+ * Aircraft metadata sources (roadmap slice 025): a status card per
+ * registered source (Mictronics, FAA), an overall "last updated" line (the
+ * age surface slice 042's health page reads), and the "Update Aircraft
+ * Metadata" action. The action polls `GET /metadata/status` until every
+ * source has settled — see `@/lib/api/metadata` — and each source's card
+ * renders its own outcome independently, so one source failing never hides
+ * or delays another's success (SPEC §27).
+ */
+export function MetadataSection({ timezone }: MetadataSectionProps) {
+  const statusQuery = useMetadataStatusQuery();
+  const triggerMutation = useTriggerMetadataUpdateMutation();
+
+  const sources = statusQuery.data?.sources ?? [];
+  const anyRunning = sources.some((source) => source.status === "running");
+  const isBusy = anyRunning || triggerMutation.isPending;
+
+  function handleUpdate() {
+    triggerMutation.mutate();
+  }
+
+  return (
+    <SettingsSection
+      id="settings-metadata"
+      title="Aircraft Metadata"
+      description="Registration, type, and operator data merged from Mictronics and the FAA registry."
+    >
+      <div className="flex flex-col gap-3">
+        <MetadataAgeLine sources={sources} timezone={timezone} />
+
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleUpdate}
+            disabled={isBusy}
+          >
+            {isBusy ? "Updating…" : "Update Aircraft Metadata"}
+          </Button>
+          {triggerMutation.isSuccess &&
+            triggerMutation.data.already_running && (
+              <p className="text-xs text-muted-foreground">
+                An update was already running — watching it finish.
+              </p>
+            )}
+          {triggerMutation.isError && (
+            <p role="alert" className="text-xs text-destructive">
+              {triggerMutation.error instanceof Error
+                ? triggerMutation.error.message
+                : "Could not start the update."}
+            </p>
+          )}
+        </div>
+
+        {statusQuery.isError && (
+          <p role="alert" className="text-sm text-destructive">
+            Could not load metadata source status.
+          </p>
+        )}
+
+        {sources.length > 0 && (
+          <div className="grid gap-3 sm:grid-cols-2">
+            {sources.map((source) => (
+              <SourceCard
+                key={source.name}
+                source={source}
+                timezone={timezone}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </SettingsSection>
+  );
+}

--- a/frontend/src/lib/api/metadata.test.ts
+++ b/frontend/src/lib/api/metadata.test.ts
@@ -1,0 +1,141 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getMetadataStatus,
+  triggerMetadataUpdate,
+  useMetadataStatusQuery,
+  useTriggerMetadataUpdateMutation,
+} from "@/lib/api/metadata";
+import { installMetadataApiMock, metadataSource } from "@/test/metadataApiMock";
+import { createQueryWrapper } from "@/test/queryWrapper";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("getMetadataStatus", () => {
+  it("GETs /api/internal/metadata/status and returns the sources array", async () => {
+    const { fetchMock } = installMetadataApiMock({
+      statusSequence: [{ sources: [metadataSource({ name: "mictronics" })] }],
+    });
+
+    const response = await getMetadataStatus();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/internal/metadata/status",
+      undefined,
+    );
+    expect(response.sources).toHaveLength(1);
+    expect(response.sources[0]?.name).toBe("mictronics");
+  });
+});
+
+describe("triggerMetadataUpdate", () => {
+  it("POSTs /api/internal/metadata/update with no body and returns the trigger envelope", async () => {
+    const { fetchMock } = installMetadataApiMock({
+      triggerResult: { started: true, already_running: false, started_ms: 42 },
+    });
+
+    const response = await triggerMetadataUpdate();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/internal/metadata/update");
+    expect(init.method).toBe("POST");
+    expect(response).toEqual({
+      started: true,
+      already_running: false,
+      started_ms: 42,
+    });
+  });
+});
+
+describe("useMetadataStatusQuery", () => {
+  it("loads the status document", async () => {
+    installMetadataApiMock({
+      statusSequence: [{ sources: [metadataSource({ name: "faa" })] }],
+    });
+
+    const { result } = renderHook(() => useMetadataStatusQuery(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.sources[0]?.name).toBe("faa");
+  });
+
+  it("keeps polling on its own while a source is running, until it settles", async () => {
+    // A real, uncontrolled poll cycle (`MetadataSection.test.tsx`'s
+    // "polls until the run settles" covers that polling actually *stops*
+    // once settled, end to end through the component); this checks the
+    // hook drives at least one automatic refetch off `refetchInterval`
+    // without anything else re-invoking the query.
+    installMetadataApiMock({
+      statusSequence: [
+        {
+          sources: [metadataSource({ name: "mictronics", status: "running" })],
+        },
+        { sources: [metadataSource({ name: "mictronics", status: "ok" })] },
+      ],
+    });
+
+    const { result } = renderHook(() => useMetadataStatusQuery(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.data?.sources[0]?.status).toBe("running"),
+    );
+    await waitFor(
+      () => expect(result.current.data?.sources[0]?.status).toBe("ok"),
+      { timeout: 4000 },
+    );
+  });
+});
+
+describe("useTriggerMetadataUpdateMutation", () => {
+  it("invalidates the status query on success, forcing an immediate refetch", async () => {
+    const { fetchMock } = installMetadataApiMock({
+      statusSequence: [
+        {
+          sources: [
+            metadataSource({ name: "mictronics", status: "never-run" }),
+          ],
+        },
+        {
+          sources: [metadataSource({ name: "mictronics", status: "running" })],
+        },
+      ],
+      triggerResult: {
+        started: true,
+        already_running: false,
+        started_ms: 1_756_600_000_000,
+      },
+    });
+
+    function useBoth() {
+      return {
+        query: useMetadataStatusQuery(),
+        mutation: useTriggerMetadataUpdateMutation(),
+      };
+    }
+
+    const { result } = renderHook(() => useBoth(), {
+      wrapper: createQueryWrapper(),
+    });
+    await waitFor(() =>
+      expect(result.current.query.data?.sources[0]?.status).toBe("never-run"),
+    );
+
+    result.current.mutation.mutate();
+
+    await waitFor(() =>
+      expect(result.current.query.data?.sources[0]?.status).toBe("running"),
+    );
+    const statusCalls = fetchMock.mock.calls.filter(
+      ([url]) => url === "/api/internal/metadata/status",
+    );
+    expect(statusCalls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/frontend/src/lib/api/metadata.ts
+++ b/frontend/src/lib/api/metadata.ts
@@ -1,0 +1,105 @@
+/**
+ * Typed client for `POST`/`GET /api/internal/metadata/*` (docs/API.md §5,
+ * roadmap slice 025). The shapes mirror the payloads
+ * `backend/src/flightsite/api/internal.py` builds: the trigger endpoint's
+ * `{started, already_running, started_ms}` and the status endpoint's one
+ * entry per registered source (`mictronics`, `faa` as of slices 022/023).
+ */
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+
+import { apiFetch } from "@/lib/api/client";
+
+/** Mirrors the status endpoint's per-source `status` field. `"running"`
+ * overrides whatever the last completed attempt recorded — read from the
+ * importer's in-flight state, not the durable row. */
+export type MetadataSourceStatus = "ok" | "failed" | "never-run" | "running";
+
+/** One registered source's status row, merging the durable outcome with
+ * in-flight progress. `last_success_ms`, `dataset_version` and `row_count`
+ * describe the dataset actually installed — they keep describing a previous
+ * success even while a new run is `"running"` or after one has `"failed"`
+ * (SPEC §27: a failed import leaves the previous dataset intact). */
+export interface MetadataSourceStatusEntry {
+  name: string;
+  status: MetadataSourceStatus;
+  last_success_ms: number | null;
+  dataset_version: string | null;
+  row_count: number | null;
+  last_error: string | null;
+}
+
+export interface MetadataStatusResponse {
+  sources: MetadataSourceStatusEntry[];
+}
+
+/** Response to `POST /metadata/update`. `already_running` is `true` when the
+ * trigger coalesced onto a run already in flight rather than starting a new
+ * one — `started_ms` is that run's start either way. */
+export interface MetadataUpdateTriggerResponse {
+  started: boolean;
+  already_running: boolean;
+  started_ms: number;
+}
+
+const METADATA_STATUS_PATH = "/api/internal/metadata/status";
+const METADATA_UPDATE_PATH = "/api/internal/metadata/update";
+
+/** How often the Settings page polls while a source is `"running"`. Short
+ * enough that a card visibly updates soon after an import finishes, long
+ * enough not to spam the backend during a multi-second download. */
+export const METADATA_POLL_INTERVAL_MS = 1500;
+
+export function getMetadataStatus(): Promise<MetadataStatusResponse> {
+  return apiFetch<MetadataStatusResponse>(METADATA_STATUS_PATH);
+}
+
+/** Starts (or reports the state of) an "Update Aircraft Metadata" run.
+ * Resolves as soon as the backend answers 202 — the run itself keeps going
+ * in the background, tracked by polling {@link useMetadataStatusQuery}. */
+export function triggerMetadataUpdate(): Promise<MetadataUpdateTriggerResponse> {
+  return apiFetch<MetadataUpdateTriggerResponse>(METADATA_UPDATE_PATH, {
+    method: "POST",
+  });
+}
+
+/** Query key for the shared metadata status document. */
+export const metadataStatusQueryKey = ["metadata", "status"] as const;
+
+/** Loads per-source metadata status, polling every
+ * {@link METADATA_POLL_INTERVAL_MS} while any source is `"running"` and
+ * stopping the instant every source has settled into a terminal status. */
+export function useMetadataStatusQuery(): UseQueryResult<MetadataStatusResponse> {
+  return useQuery({
+    queryKey: metadataStatusQueryKey,
+    queryFn: getMetadataStatus,
+    refetchInterval: (query) => {
+      const sources = query.state.data?.sources ?? [];
+      const anyRunning = sources.some((source) => source.status === "running");
+      return anyRunning ? METADATA_POLL_INTERVAL_MS : false;
+    },
+  });
+}
+
+/** Triggers an update and refreshes {@link useMetadataStatusQuery} with an
+ * immediate refetch, so the "running" state (and the polling it drives)
+ * shows up as soon as the backend has scheduled the run rather than waiting
+ * for the next scheduled poll. */
+export function useTriggerMetadataUpdateMutation(): UseMutationResult<
+  MetadataUpdateTriggerResponse,
+  Error,
+  void
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: triggerMetadataUpdate,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: metadataStatusQueryKey });
+    },
+  });
+}

--- a/frontend/src/test/configApiMock.ts
+++ b/frontend/src/test/configApiMock.ts
@@ -2,6 +2,7 @@ import { vi } from "vitest";
 
 import type { ConfigResponse, FlightSiteConfig } from "@/lib/api/config";
 import type { ConnectionTestResult } from "@/lib/api/decoder";
+import type { MetadataStatusResponse } from "@/lib/api/metadata";
 
 /** A schema-default `FlightSiteConfig`, mirroring
  * `flightsite.config.models.Settings()` — used as the base every test
@@ -89,6 +90,12 @@ export interface MockConfigApiOptions {
    * of the request body for tests that need to vary the outcome. */
   decoderTestResult?:
     ConnectionTestResult | ((body: unknown) => ConnectionTestResult);
+  /** Result returned by `GET /api/internal/metadata/status`. Defaults to no
+   * registered sources — page-level tests that do not care about the
+   * Aircraft Metadata section's content just need this endpoint answered,
+   * not populated; `MetadataSection.test.tsx` covers its actual states with
+   * its own dedicated mock (`@/test/metadataApiMock`). */
+  metadataStatus?: MetadataStatusResponse;
 }
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -178,6 +185,9 @@ export function installConfigApiMock(options: MockConfigApiOptions = {}) {
             ? options.decoderTestResult(body)
             : (options.decoderTestResult ?? successConnectionTestResult());
         return jsonResponse(result);
+      }
+      if (url === "/api/internal/metadata/status" && method === "GET") {
+        return jsonResponse(options.metadataStatus ?? { sources: [] });
       }
 
       throw new Error(`Unhandled fetch in test: ${method} ${url}`);

--- a/frontend/src/test/metadataApiMock.ts
+++ b/frontend/src/test/metadataApiMock.ts
@@ -1,0 +1,79 @@
+import { vi } from "vitest";
+
+import type {
+  MetadataSourceStatusEntry,
+  MetadataStatusResponse,
+  MetadataUpdateTriggerResponse,
+} from "@/lib/api/metadata";
+
+/** A `MetadataSourceStatusEntry`, defaulting to a fresh, never-run source —
+ * override just the fields a test cares about. */
+export function metadataSource(
+  overrides: Partial<MetadataSourceStatusEntry> = {},
+): MetadataSourceStatusEntry {
+  return {
+    name: "mictronics",
+    status: "never-run",
+    last_success_ms: null,
+    dataset_version: null,
+    row_count: null,
+    last_error: null,
+    ...overrides,
+  };
+}
+
+export interface MockMetadataApiOptions {
+  /** Documents `GET /metadata/status` returns, in call order — the last
+   * entry repeats for every call past the end of the list. Lets a test
+   * script a run's progression (e.g. never-run → running → ok) across the
+   * mount fetch, the post-trigger refetch, and subsequent polls. */
+  statusSequence?: MetadataStatusResponse[];
+  /** Response `POST /metadata/update` returns. */
+  triggerResult?: MetadataUpdateTriggerResponse;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Installs a `global.fetch` stub serving `GET`/`POST
+ * /api/internal/metadata/*` from a scripted sequence, so `MetadataSection`
+ * tests can exercise the real `lib/api/metadata` client + TanStack Query
+ * hooks — including the trigger-then-poll flow — without a running backend.
+ * Any other URL throws, surfacing an un-mocked request as a test failure. */
+export function installMetadataApiMock(options: MockMetadataApiOptions = {}) {
+  const sequence = options.statusSequence ?? [{ sources: [] }];
+  let statusCalls = 0;
+
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url === "/api/internal/metadata/status" && method === "GET") {
+        const index = Math.min(statusCalls, sequence.length - 1);
+        statusCalls += 1;
+        return jsonResponse(sequence[index]);
+      }
+      if (url === "/api/internal/metadata/update" && method === "POST") {
+        return jsonResponse(
+          options.triggerResult ?? {
+            started: true,
+            already_running: false,
+            started_ms: 1_756_600_000_000,
+          },
+          202,
+        );
+      }
+
+      throw new Error(`Unhandled fetch in test: ${method} ${url}`);
+    },
+  );
+
+  vi.stubGlobal("fetch", fetchMock);
+
+  return { fetchMock };
+}

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -730,7 +730,7 @@ slices:
     title: "Metadata update action"
     phase: 4
     branch: "025-metadata-update-ui"
-    status: planned
+    status: merged
     depends_on: ["019", "022", "023"]
     objective: "Settings action to manually update all metadata sources with independent per-source status reporting."
     scope:


### PR DESCRIPTION
## Slice
- **Slice ID:** 025 — Metadata update action
- **Roadmap:** `planning/roadmap.yaml` slice 025 (phase 4)
- **Issue:** Closes #59

## Objective
Manual per-source metadata update with independent status reporting.

## Implementation summary
- POST /api/internal/metadata/update: 202 fire-and-return via a tracked asyncio task; race-free coalescing of concurrent triggers (no await between check and schedule); task exceptions logged via done-callback; clean shutdown cancellation
- GET /api/internal/metadata/status: durable metadata_sources rows merged with in-memory run state (ok/failed/never-run/running)
- Settings 'Aircraft Metadata' section: per-source cards (status badge, receiver-local last-update + relative age, version/rows, failure copy stating prior data is unaffected), overall metadata-age line (the slice-042 surface), update button with 1.5 s polling until settled
- Test doubles extended with hold/started events to freeze runs mid-import

## Acceptance criteria
- [x] one source failing does not affect the other; both statuses reported accurately (independent-outcome tests)
- [x] timestamps persist and display; repeat runs idempotent; concurrent triggers coalesce

## Tests added/run
Backend 1733 passed (99.04%; touched files 100%); frontend 762 passed (97.4%). Reviewer re-ran gates.

## Performance / Security / Data considerations
No migration; no secrets; background task rides existing importer transactionality.

## Documentation updates
None required (API.md §5 shapes followed).

## Known limitations
No last_attempt_ms field yet (internal surface, additive later).

## Follow-up work
042 consumes the metadata-age surface.

## Fable self-review (SPEC §104)
- [x] Full diff inspected; coalescing race reasoning verified; failure copy honest; no TODO/FIXME
- [x] Branch on current dev tip (no reconcile needed)
- [ ] CI green on this PR (gate before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)