### PR TITLE
Slice 032: Analytics page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@tanstack/react-query": "^5.102.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "echarts": "^6.0.0",
         "lucide-react": "^1.38.0",
         "maplibre-gl": "^6.6.0",
         "react": "^18.3.1",
@@ -2931,6 +2932,16 @@
       "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
       "license": "ISC"
     },
+    "node_modules/echarts": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.1.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.417",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.417.tgz",
@@ -4800,6 +4811,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5499,6 +5516,15 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zrender": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
       }
     },
     "node_modules/zustand": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@tanstack/react-query": "^5.102.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "echarts": "^6.0.0",
     "lucide-react": "^1.38.0",
     "maplibre-gl": "^6.6.0",
     "react": "^18.3.1",

--- a/frontend/src/features/analytics/AnalyticsPage.test.tsx
+++ b/frontend/src/features/analytics/AnalyticsPage.test.tsx
@@ -1,0 +1,153 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AnalyticsPage } from "@/features/analytics/AnalyticsPage";
+import type { AnalyticsAircraftRow } from "@/lib/api/analytics";
+import {
+  analyticsWindow,
+  installAnalyticsApiMock,
+} from "@/test/analyticsApiMock";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function renderAnalyticsPage(initialPath = "/analytics") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const router = createMemoryRouter(
+    [{ path: "/analytics", element: <AnalyticsPage /> }],
+    { initialEntries: [initialPath] },
+  );
+  return {
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    ),
+    router,
+  };
+}
+
+const topAircraftRow: AnalyticsAircraftRow = {
+  icao: "ae1463",
+  registration: "05-8153",
+  type: "C17",
+  model: "Boeing C-17A Globemaster III",
+  operator: "United States Air Force",
+  operator_group: "US Military",
+  classification: "military_transport",
+  military: true,
+  government: false,
+  law_enforcement: false,
+  sightings: 12,
+  first_seen_at: "2026-04-02T18:11:09.000Z",
+  last_seen_at: "2026-08-30T22:41:55.000Z",
+  max_range_nm: 141.8,
+};
+
+describe("AnalyticsPage", () => {
+  it("renders every card empty when the window has no data", async () => {
+    installAnalyticsApiMock();
+    renderAnalyticsPage();
+
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "Analytics" }),
+    ).toBeInTheDocument();
+
+    const emptyStates = await screen.findAllByText("No data for this window.");
+    // top aircraft, top types, top operators, classification, daily counts,
+    // max distance, receiver activity, never seen before — every chart card.
+    expect(emptyStates.length).toBe(8);
+    expect(
+      screen.getByText("No rare aircraft in this window."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders populated cards from mocked API data", async () => {
+    installAnalyticsApiMock({
+      topAircraft: { window: analyticsWindow(), items: [topAircraftRow] },
+    });
+    renderAnalyticsPage();
+
+    expect(
+      await screen.findByRole("img", { name: /top aircraft by sightings/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/05-8153 \(12\)/)).toBeInTheDocument();
+  });
+
+  it("defaults to the today preset and persists a change to the URL", async () => {
+    installAnalyticsApiMock();
+    const user = userEvent.setup();
+    const { router } = renderAnalyticsPage();
+
+    await screen.findByRole("heading", { level: 1, name: "Analytics" });
+    expect(router.state.location.search).toBe("");
+
+    await user.click(screen.getByRole("radio", { name: "30 days" }));
+
+    await waitFor(() => {
+      expect(router.state.location.search).toBe("?preset=30d");
+    });
+    expect(screen.getByRole("radio", { name: "30 days" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+  });
+
+  it("reads the initial preset back out of the URL", async () => {
+    installAnalyticsApiMock();
+    renderAnalyticsPage("/analytics?preset=ytd");
+
+    await screen.findByRole("heading", { level: 1, name: "Analytics" });
+    expect(screen.getByRole("radio", { name: "This year" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+  });
+
+  it("shows a per-card error message when a query fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = new URL(String(input), "http://localhost");
+        if (url.pathname === "/api/v1/analytics/top-aircraft") {
+          return new Response(
+            JSON.stringify({
+              error: { code: "internal_error", message: "boom" },
+            }),
+            { status: 500 },
+          );
+        }
+        if (url.pathname === "/api/v1/receiver") {
+          return new Response(
+            JSON.stringify({
+              site_name: "Test",
+              latitude: 0,
+              longitude: 0,
+              antenna_height_ft: 10,
+              timezone: "UTC",
+              units: "aviation",
+              display_radius_nm: 250,
+              alert_radius_nm: null,
+              demo_mode: false,
+              t0: null,
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(
+          JSON.stringify({ window: analyticsWindow(), items: [] }),
+          { status: 200 },
+        );
+      }),
+    );
+    renderAnalyticsPage();
+
+    expect(await screen.findByText("boom")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/analytics/AnalyticsPage.tsx
+++ b/frontend/src/features/analytics/AnalyticsPage.tsx
@@ -1,0 +1,185 @@
+/**
+ * The Analytics page (roadmap slice 032, SPEC §58): a preset time-range
+ * selector plus a responsive grid of cards, each rendering one of the
+ * `/api/v1/analytics/*` endpoints slice 031 shipped (`docs/API.md` §3.7).
+ * Six of the seven endpoints feed a card here; `/analytics/summary` is a
+ * separate today-at-a-glance widget (SPEC §59), out of this slice's scope.
+ *
+ * Every query is driven by the same URL-persisted preset
+ * (`useAnalyticsPresetState`), so switching presets refetches every card at
+ * once and the choice survives a reload or a shared link.
+ */
+import {
+  useAnalyticsClassificationActivityQuery,
+  useAnalyticsDailyQuery,
+  useAnalyticsRarityQuery,
+  useAnalyticsTopAircraftQuery,
+  useAnalyticsTopOperatorsQuery,
+  useAnalyticsTopTypesQuery,
+} from "@/lib/api/analytics";
+import { useReceiverQuery } from "@/lib/api/receiver";
+
+import { requireNavItem } from "@/components/shell/nav-items";
+import { ClassificationActivityCard } from "@/features/analytics/components/cards/ClassificationActivityCard";
+import { DailyCountsCard } from "@/features/analytics/components/cards/DailyCountsCard";
+import { MaxDistanceCard } from "@/features/analytics/components/cards/MaxDistanceCard";
+import { NeverSeenBeforeCard } from "@/features/analytics/components/cards/NeverSeenBeforeCard";
+import { RarityListsCard } from "@/features/analytics/components/cards/RarityListsCard";
+import { ReceiverActivityCard } from "@/features/analytics/components/cards/ReceiverActivityCard";
+import { TopAircraftCard } from "@/features/analytics/components/cards/TopAircraftCard";
+import { TopGroupCard } from "@/features/analytics/components/cards/TopGroupCard";
+import { PresetSelector } from "@/features/analytics/components/PresetSelector";
+import { useAnalyticsPresetState } from "@/features/analytics/hooks/useAnalyticsPresetState";
+
+const item = requireNavItem("/analytics");
+
+function queryErrorMessage(
+  isError: boolean,
+  error: Error | null,
+  fallback: string,
+): string | undefined {
+  if (!isError) {
+    return undefined;
+  }
+  return error?.message ?? fallback;
+}
+
+export function AnalyticsPage() {
+  const { preset, setPreset } = useAnalyticsPresetState();
+  const receiverQuery = useReceiverQuery();
+  const units = receiverQuery.data?.units ?? "aviation";
+
+  const dailyQuery = useAnalyticsDailyQuery({ preset });
+  const classificationQuery = useAnalyticsClassificationActivityQuery({
+    preset,
+  });
+  const topAircraftQuery = useAnalyticsTopAircraftQuery({ preset });
+  const topTypesQuery = useAnalyticsTopTypesQuery({ preset });
+  const topOperatorsQuery = useAnalyticsTopOperatorsQuery({ preset });
+  const rarityQuery = useAnalyticsRarityQuery({ preset });
+
+  return (
+    <div className="flex h-full flex-col gap-4 px-4 py-6 md:px-8">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            {item.label}
+          </h1>
+          <p className="text-sm text-muted-foreground">{item.description}</p>
+        </div>
+        <PresetSelector preset={preset} onChange={setPreset} />
+      </header>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
+        <TopAircraftCard
+          window={topAircraftQuery.data?.window}
+          rows={topAircraftQuery.data?.items ?? []}
+          isLoading={topAircraftQuery.isPending}
+          error={queryErrorMessage(
+            topAircraftQuery.isError,
+            topAircraftQuery.error,
+            "Could not load top aircraft.",
+          )}
+        />
+
+        <TopGroupCard
+          title="Top types"
+          ariaLabel="Top types by sightings, horizontal bar chart"
+          emptyLabel="No types sighted in this window."
+          window={topTypesQuery.data?.window}
+          rows={topTypesQuery.data?.items ?? []}
+          isLoading={topTypesQuery.isPending}
+          error={queryErrorMessage(
+            topTypesQuery.isError,
+            topTypesQuery.error,
+            "Could not load top types.",
+          )}
+        />
+
+        <TopGroupCard
+          title="Top operators"
+          ariaLabel="Top operators by sightings, horizontal bar chart"
+          emptyLabel="No operators sighted in this window."
+          window={topOperatorsQuery.data?.window}
+          rows={topOperatorsQuery.data?.items ?? []}
+          isLoading={topOperatorsQuery.isPending}
+          error={queryErrorMessage(
+            topOperatorsQuery.isError,
+            topOperatorsQuery.error,
+            "Could not load top operators.",
+          )}
+        />
+
+        <ClassificationActivityCard
+          window={classificationQuery.data?.window}
+          series={classificationQuery.data?.series ?? []}
+          isLoading={classificationQuery.isPending}
+          error={queryErrorMessage(
+            classificationQuery.isError,
+            classificationQuery.error,
+            "Could not load classification activity.",
+          )}
+        />
+
+        <DailyCountsCard
+          window={dailyQuery.data?.window}
+          items={dailyQuery.data?.items ?? []}
+          isLoading={dailyQuery.isPending}
+          error={queryErrorMessage(
+            dailyQuery.isError,
+            dailyQuery.error,
+            "Could not load daily counts.",
+          )}
+        />
+
+        <MaxDistanceCard
+          window={dailyQuery.data?.window}
+          items={dailyQuery.data?.items ?? []}
+          units={units}
+          isLoading={dailyQuery.isPending}
+          error={queryErrorMessage(
+            dailyQuery.isError,
+            dailyQuery.error,
+            "Could not load maximum detection distance.",
+          )}
+        />
+
+        <ReceiverActivityCard
+          window={dailyQuery.data?.window}
+          items={dailyQuery.data?.items ?? []}
+          isLoading={dailyQuery.isPending}
+          error={queryErrorMessage(
+            dailyQuery.isError,
+            dailyQuery.error,
+            "Could not load receiver activity.",
+          )}
+        />
+
+        <NeverSeenBeforeCard
+          window={dailyQuery.data?.window}
+          items={dailyQuery.data?.items ?? []}
+          isLoading={dailyQuery.isPending}
+          error={queryErrorMessage(
+            dailyQuery.isError,
+            dailyQuery.error,
+            "Could not load new-aircraft counts.",
+          )}
+        />
+
+        <RarityListsCard
+          window={rarityQuery.data?.window}
+          neverSeenBefore={rarityQuery.data?.never_seen_before ?? 0}
+          rareMaxSightings={rarityQuery.data?.rare_max_sightings ?? 0}
+          rareAircraft={rarityQuery.data?.rare_aircraft ?? []}
+          rareTypes={rarityQuery.data?.rare_types ?? []}
+          isLoading={rarityQuery.isPending}
+          error={queryErrorMessage(
+            rarityQuery.isError,
+            rarityQuery.error,
+            "Could not load rarity data.",
+          )}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/analytics/components/AnalyticsCard.test.tsx
+++ b/frontend/src/features/analytics/components/AnalyticsCard.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AnalyticsCard } from "@/features/analytics/components/AnalyticsCard";
+
+const WINDOW = {
+  preset: "today" as const,
+  from: "2026-08-31T00:00:00.000Z",
+  to: "2026-09-01T00:00:00.000Z",
+  first_day: "2026-08-31",
+  last_day: "2026-08-31",
+  timezone: "UTC",
+};
+
+describe("AnalyticsCard", () => {
+  it("shows a loading state and no window caption while pending", () => {
+    render(
+      <AnalyticsCard title="Top aircraft" isLoading>
+        <p>content</p>
+      </AnalyticsCard>,
+    );
+
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    expect(screen.queryByText(/UTC/)).not.toBeInTheDocument();
+  });
+
+  it("shows an error message in place of children", () => {
+    render(
+      <AnalyticsCard
+        title="Top aircraft"
+        isLoading={false}
+        error="Could not load top aircraft."
+      >
+        <p>content</p>
+      </AnalyticsCard>,
+    );
+
+    expect(
+      screen.getByText("Could not load top aircraft."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("content")).not.toBeInTheDocument();
+  });
+
+  it("renders children and the echoed window once loaded", () => {
+    render(
+      <AnalyticsCard title="Top aircraft" isLoading={false} window={WINDOW}>
+        <p>content</p>
+      </AnalyticsCard>,
+    );
+
+    expect(screen.getByText("content")).toBeInTheDocument();
+    expect(screen.getByText("Top aircraft")).toBeInTheDocument();
+    expect(screen.getByText(/UTC/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/analytics/components/AnalyticsCard.tsx
+++ b/frontend/src/features/analytics/components/AnalyticsCard.tsx
@@ -1,0 +1,53 @@
+/**
+ * The card shell every Analytics tile renders through: a title, the echoed
+ * window shown subtly beneath it (`docs/API.md` §3.7 — every response
+ * carries the window it actually resolved, so it never goes unshown), and a
+ * loading/error/content body. Kept separate from `EChart` because two of the
+ * eight tiles (rarity lists) render a table, not a chart.
+ */
+import type { ReactNode } from "react";
+
+import type { AnalyticsWindow } from "@/lib/api/analytics";
+
+import { formatWindowLabel } from "@/features/analytics/lib/format";
+
+export interface AnalyticsCardProps {
+  title: string;
+  /** `undefined` while the query is still pending — the window caption is
+   * simply omitted until it arrives, rather than showing a stale one. */
+  window?: AnalyticsWindow;
+  isLoading: boolean;
+  /** The query's error message, if any — shown in place of `children`. */
+  error?: string;
+  children: ReactNode;
+}
+
+export function AnalyticsCard({
+  title,
+  window,
+  isLoading,
+  error,
+  children,
+}: AnalyticsCardProps) {
+  return (
+    <section className="flex flex-col gap-2 rounded-lg border border-border bg-card p-4">
+      <header>
+        <h2 className="text-sm font-semibold text-foreground">{title}</h2>
+        {window !== undefined && (
+          <p className="text-xs text-muted-foreground">
+            {formatWindowLabel(window)}
+          </p>
+        )}
+      </header>
+      {isLoading ? (
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          Loading…
+        </p>
+      ) : error !== undefined ? (
+        <p className="py-8 text-center text-sm text-destructive">{error}</p>
+      ) : (
+        children
+      )}
+    </section>
+  );
+}

--- a/frontend/src/features/analytics/components/EChart.test.tsx
+++ b/frontend/src/features/analytics/components/EChart.test.tsx
@@ -1,0 +1,127 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { EChart } from "@/features/analytics/components/EChart";
+import type { ChartTheme } from "@/features/analytics/lib/chartTheme";
+import { useUiStore } from "@/store/useUiStore";
+import { getLastMockChart } from "@/test/echartsMock";
+
+afterEach(() => {
+  useUiStore.setState({ theme: "dark" });
+});
+
+function themedBarOption(theme: ChartTheme) {
+  return {
+    color: [theme.series[0]],
+    xAxis: { type: "category", data: ["a", "b"] },
+    yAxis: { type: "value" },
+    series: [{ type: "bar", data: [1, 2] }],
+  };
+}
+
+describe("EChart", () => {
+  it("renders the chart container with an aria-label and a visually-hidden summary", () => {
+    render(
+      <EChart
+        buildOption={themedBarOption}
+        ariaLabel="Widgets by count, bar chart"
+        summary="a: 1, b: 2"
+      />,
+    );
+
+    const chart = screen.getByRole("img", {
+      name: "Widgets by count, bar chart",
+    });
+    expect(chart).toBeInTheDocument();
+    expect(screen.getByText("a: 1, b: 2")).toBeInTheDocument();
+  });
+
+  it("initializes ECharts once and calls setOption with the built option", () => {
+    render(
+      <EChart
+        buildOption={themedBarOption}
+        ariaLabel="Widgets"
+        summary="summary"
+      />,
+    );
+
+    const instance = getLastMockChart();
+    expect(instance.setOption).toHaveBeenCalledTimes(1);
+    const applied = instance.optionCalls[0] as { color: string[] };
+    expect(applied.color).toEqual(["#3987e5"]); // dark-mode default fallback
+  });
+
+  it("renders the empty state and never initializes a chart when buildOption returns null", () => {
+    render(
+      <EChart buildOption={() => null} ariaLabel="Widgets" summary="summary" />,
+    );
+
+    expect(screen.getByText("No data for this window.")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("rebuilds the option (without re-initializing) when the theme toggles", () => {
+    render(
+      <EChart
+        buildOption={themedBarOption}
+        ariaLabel="Widgets"
+        summary="summary"
+      />,
+    );
+
+    const instance = getLastMockChart();
+    expect(instance.optionCalls).toHaveLength(1);
+    expect((instance.optionCalls[0] as { color: string[] }).color).toEqual([
+      "#3987e5",
+    ]);
+
+    act(() => {
+      useUiStore.getState().setTheme("light");
+    });
+
+    // Same instance — a theme toggle rebuilds the option, it does not tear
+    // down and recreate the chart.
+    expect(getLastMockChart()).toBe(instance);
+    expect(instance.optionCalls).toHaveLength(2);
+    expect((instance.optionCalls[1] as { color: string[] }).color).toEqual([
+      "#2a78d6",
+    ]);
+  });
+
+  it("disposes the chart instance on unmount", () => {
+    const { unmount } = render(
+      <EChart
+        buildOption={themedBarOption}
+        ariaLabel="Widgets"
+        summary="summary"
+      />,
+    );
+    const instance = getLastMockChart();
+    expect(instance.disposed).toBe(false);
+
+    unmount();
+
+    expect(instance.disposed).toBe(true);
+  });
+
+  it("forwards a mark click to onMarkClick", () => {
+    const onMarkClick = vi.fn();
+    render(
+      <EChart
+        buildOption={themedBarOption}
+        ariaLabel="Widgets"
+        summary="summary"
+        onMarkClick={onMarkClick}
+      />,
+    );
+
+    const instance = getLastMockChart();
+    instance.emit("click", { dataIndex: 1, name: "b", value: 2 });
+
+    expect(onMarkClick).toHaveBeenCalledWith({
+      dataIndex: 1,
+      name: "b",
+      value: 2,
+    });
+  });
+});

--- a/frontend/src/features/analytics/components/EChart.tsx
+++ b/frontend/src/features/analytics/components/EChart.tsx
@@ -1,0 +1,153 @@
+/**
+ * The shared chart wrapper every Analytics card renders through (roadmap
+ * slice 032). Owns everything a raw ECharts instance needs that a React
+ * component should not repeat per card:
+ *
+ * - **Theme-aware**: rebuilds the option from {@link ChartTheme} whenever the
+ *   app theme toggles, via `buildOption` — a pure function of the theme
+ *   rather than a static object, so a card never hand-rolls its own
+ *   light/dark branching.
+ * - **Resize-observing**: keeps the chart sized to its container (the card
+ *   grid is responsive) without a page-level resize listener.
+ * - **Disposes on unmount**: an ECharts instance holds a canvas and internal
+ *   render state that a card unmounting (preset switch, navigation away)
+ *   must not leak.
+ * - **Accessible**: `role="img"` plus `aria-label` names the chart for
+ *   assistive tech that announces the container, and a visually-hidden
+ *   `summary` paragraph is the real text alternative (`docs/TEST_STRATEGY.md`
+ *   §2's chart-a11y expectation) — a screen reader user gets the data, not
+ *   just a label saying a chart exists.
+ * - **Empty state**: `buildOption` returning `null` (no rows in the window)
+ *   renders "No data" instead of an empty canvas.
+ *
+ * ECharts itself is registered modularly by `lib/echartsSetup` (imported
+ * here for its side effect) rather than pulled in whole — see that module's
+ * comment.
+ */
+import "@/features/analytics/lib/echartsSetup";
+
+import * as echarts from "echarts/core";
+import { useEffect, useMemo, useRef } from "react";
+
+import type { ChartTheme } from "@/features/analytics/lib/chartTheme";
+import { resolveChartTheme } from "@/features/analytics/lib/chartTheme";
+import { useUiStore } from "@/store/useUiStore";
+
+export interface EChartClickParams {
+  /** The clicked mark's `dataIndex`/`name`/`value` etc. — echarts' own
+   * `ECElementEvent`, kept loose here so callers narrow what they need. */
+  dataIndex: number;
+  name: string;
+  value: unknown;
+}
+
+export interface EChartProps {
+  /** Builds the option from the resolved theme. Returning `null` renders the
+   * empty state instead of an (empty) chart — the card's call, based on
+   * whether its query actually has rows to plot. */
+  buildOption: (theme: ChartTheme) => echarts.EChartsCoreOption | null;
+  /** Announces what the chart shows to assistive tech (`role="img"`'s
+   * label) — e.g. `"Top aircraft by sightings, bar chart"`. */
+  ariaLabel: string;
+  /** The visually-hidden text alternative: a plain-language description of
+   * the data the chart renders (not just its title), so a screen reader
+   * user gets the figures. */
+  summary: string;
+  /** Fixed pixel height; the chart always fills its container's width. */
+  height?: number;
+  className?: string;
+  /** Fired on a mark click (e.g. a top-aircraft bar), for row-level
+   * navigation. */
+  onMarkClick?: (params: EChartClickParams) => void;
+}
+
+const DEFAULT_HEIGHT = 280;
+
+export function EChart({
+  buildOption,
+  ariaLabel,
+  summary,
+  height = DEFAULT_HEIGHT,
+  className,
+  onMarkClick,
+}: EChartProps) {
+  const theme = useUiStore((state) => state.theme);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<echarts.ECharts | null>(null);
+  const onMarkClickRef = useRef(onMarkClick);
+  useEffect(() => {
+    onMarkClickRef.current = onMarkClick;
+  }, [onMarkClick]);
+
+  const option = useMemo(
+    () => buildOption(resolveChartTheme(theme)),
+    [buildOption, theme],
+  );
+  const isEmpty = option === null;
+
+  // Mounts (and disposes) the ECharts instance itself, exactly once per
+  // container mount — a chart transitioning to/from the empty state
+  // unmounts/remounts the container div, which this depends on.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (el === null) {
+      return;
+    }
+    const instance = echarts.init(el);
+    chartRef.current = instance;
+
+    instance.on("click", (params: unknown) => {
+      const clicked = params as EChartClickParams;
+      onMarkClickRef.current?.(clicked);
+    });
+
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(() => instance.resize())
+        : null;
+    resizeObserver?.observe(el);
+
+    return () => {
+      resizeObserver?.disconnect();
+      instance.dispose();
+      chartRef.current = null;
+    };
+    // `isEmpty` is the real dependency (it decides whether the container
+    // exists) — `buildOption`/`theme` changes are handled by the setOption
+    // effect below without tearing the instance down.
+  }, [isEmpty]);
+
+  // Applies a freshly-built (possibly re-themed) option to the live
+  // instance, without re-creating it — this is what makes a theme toggle
+  // "rebuild options" rather than flicker the whole chart.
+  useEffect(() => {
+    if (chartRef.current !== null && option !== null) {
+      chartRef.current.setOption(option, true);
+    }
+  }, [option]);
+
+  if (isEmpty) {
+    return (
+      <div className={className} style={{ minHeight: height }}>
+        <p
+          role="status"
+          className="flex h-full min-h-[inherit] items-center justify-center text-sm text-muted-foreground"
+        >
+          No data for this window.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      <div
+        ref={containerRef}
+        role="img"
+        aria-label={ariaLabel}
+        style={{ height, width: "100%" }}
+      />
+      <p className="sr-only">{summary}</p>
+    </div>
+  );
+}

--- a/frontend/src/features/analytics/components/PresetSelector.test.tsx
+++ b/frontend/src/features/analytics/components/PresetSelector.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { PresetSelector } from "@/features/analytics/components/PresetSelector";
+
+describe("PresetSelector", () => {
+  it("renders all five presets with the active one checked", () => {
+    render(<PresetSelector preset="30d" onChange={vi.fn()} />);
+
+    expect(screen.getByRole("radio", { name: "30 days" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(screen.getByRole("radio", { name: "Today" })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+    expect(screen.getByRole("radio", { name: "7 days" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: "This year" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Since T0" })).toBeInTheDocument();
+  });
+
+  it("calls onChange with the clicked preset", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<PresetSelector preset="today" onChange={onChange} />);
+
+    await user.click(screen.getByRole("radio", { name: "Since T0" }));
+
+    expect(onChange).toHaveBeenCalledWith("t0");
+  });
+});

--- a/frontend/src/features/analytics/components/PresetSelector.tsx
+++ b/frontend/src/features/analytics/components/PresetSelector.tsx
@@ -1,0 +1,50 @@
+/**
+ * The Analytics page's time-preset selector (SPEC §58: Today / 7 days /
+ * 30 days / This year / Since T0), URL-persisted via
+ * `useAnalyticsPresetState`. A `role="radiogroup"` of toggle buttons rather
+ * than a `<select>` — five short, mutually-exclusive options read faster as
+ * always-visible buttons than behind a dropdown, and the roving `aria-checked`
+ * state keeps this understandable to assistive tech as one choice, not five
+ * independent toggles.
+ */
+import { ANALYTICS_PRESETS, type AnalyticsPreset } from "@/lib/api/analytics";
+
+import { PRESET_LABELS } from "@/features/analytics/lib/urlState";
+import { cn } from "@/lib/utils";
+
+export interface PresetSelectorProps {
+  preset: AnalyticsPreset;
+  onChange: (preset: AnalyticsPreset) => void;
+}
+
+export function PresetSelector({ preset, onChange }: PresetSelectorProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Time range"
+      className="inline-flex flex-wrap gap-1 rounded-lg border border-border bg-card p-1"
+    >
+      {ANALYTICS_PRESETS.map((option) => {
+        const active = option === preset;
+        return (
+          <button
+            key={option}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(option)}
+            className={cn(
+              "rounded-md px-3 py-1.5 text-sm font-medium outline-none transition-colors",
+              "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring",
+              active
+                ? "bg-accent text-accent-foreground"
+                : "text-muted-foreground hover:bg-secondary hover:text-foreground",
+            )}
+          >
+            {PRESET_LABELS[option]}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/features/analytics/components/cards/ClassificationActivityCard.test.tsx
+++ b/frontend/src/features/analytics/components/cards/ClassificationActivityCard.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ClassificationActivityCard } from "@/features/analytics/components/cards/ClassificationActivityCard";
+import type { AnalyticsDailyRow } from "@/lib/api/analytics";
+
+function dailyRow(
+  overrides: Partial<AnalyticsDailyRow> = {},
+): AnalyticsDailyRow {
+  return {
+    day: "2026-08-31",
+    unique_aircraft: 10,
+    new_aircraft: 1,
+    sightings: 15,
+    interesting: 2,
+    military: 2,
+    government: 1,
+    law_enforcement: 0,
+    max_range_nm: 141.8,
+    busiest_hour: 14,
+    receiver_messages: 100000,
+    receiver_positions: 5000,
+    receiver_aircraft_max: 12,
+    receiver_max_range_nm: 150.2,
+    ...overrides,
+  };
+}
+
+describe("ClassificationActivityCard", () => {
+  it("renders the empty state with no days", () => {
+    render(<ClassificationActivityCard series={[]} isLoading={false} />);
+    expect(screen.getByText("No data for this window.")).toBeInTheDocument();
+  });
+
+  it("renders a summary with totals across the series", () => {
+    const series = [
+      dailyRow({
+        day: "2026-08-30",
+        military: 1,
+        government: 0,
+        law_enforcement: 0,
+      }),
+      dailyRow({
+        day: "2026-08-31",
+        military: 2,
+        government: 1,
+        law_enforcement: 1,
+      }),
+    ];
+    render(<ClassificationActivityCard series={series} isLoading={false} />);
+
+    expect(
+      screen.getByRole("img", {
+        name: /military, government and law-enforcement activity over time/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/3 military/)).toBeInTheDocument();
+    expect(screen.getByText(/1 government/)).toBeInTheDocument();
+    expect(screen.getByText(/1 law-enforcement/)).toBeInTheDocument();
+  });
+
+  it("shows a loading state", () => {
+    render(<ClassificationActivityCard series={[]} isLoading />);
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/analytics/components/cards/ClassificationActivityCard.tsx
+++ b/frontend/src/features/analytics/components/cards/ClassificationActivityCard.tsx
@@ -1,0 +1,108 @@
+/**
+ * "Military/government/police activity over time" (SPEC §58) —
+ * `GET /api/v1/analytics/classification-activity`'s per-day series as a
+ * stacked bar: three fixed-order categorical series (never reassigned by
+ * which classification happens to be busiest), legend always shown for
+ * three series so identity never rides on color alone.
+ */
+import { useCallback } from "react";
+
+import type { AnalyticsDailyRow, AnalyticsWindow } from "@/lib/api/analytics";
+
+import { AnalyticsCard } from "@/features/analytics/components/AnalyticsCard";
+import { EChart } from "@/features/analytics/components/EChart";
+import type { ChartTheme } from "@/features/analytics/lib/chartTheme";
+
+export interface ClassificationActivityCardProps {
+  window?: AnalyticsWindow;
+  series: AnalyticsDailyRow[];
+  isLoading: boolean;
+  error?: string;
+}
+
+export function ClassificationActivityCard({
+  window,
+  series,
+  isLoading,
+  error,
+}: ClassificationActivityCardProps) {
+  const buildOption = useCallback(
+    (theme: ChartTheme) => {
+      if (series.length === 0) {
+        return null;
+      }
+      const axisStyle = {
+        axisLabel: { color: theme.mutedInk },
+        axisLine: { lineStyle: { color: theme.grid } },
+        splitLine: { lineStyle: { color: theme.grid } },
+      };
+      return {
+        color: [...theme.series],
+        legend: {
+          data: ["Military", "Government", "Law enforcement"],
+          top: 0,
+          textStyle: { color: theme.mutedInk },
+        },
+        grid: { left: 8, right: 16, top: 32, bottom: 24, containLabel: true },
+        tooltip: { trigger: "axis" as const },
+        xAxis: {
+          type: "category" as const,
+          data: series.map((row) => row.day),
+          ...axisStyle,
+        },
+        yAxis: { type: "value" as const, ...axisStyle },
+        series: [
+          {
+            name: "Military",
+            type: "bar" as const,
+            stack: "classification",
+            data: series.map((row) => row.military),
+          },
+          {
+            name: "Government",
+            type: "bar" as const,
+            stack: "classification",
+            data: series.map((row) => row.government),
+          },
+          {
+            name: "Law enforcement",
+            type: "bar" as const,
+            stack: "classification",
+            data: series.map((row) => row.law_enforcement),
+          },
+        ],
+      };
+    },
+    [series],
+  );
+
+  const totals = series.reduce(
+    (acc, row) => ({
+      military: acc.military + row.military,
+      government: acc.government + row.government,
+      lawEnforcement: acc.lawEnforcement + row.law_enforcement,
+    }),
+    { military: 0, government: 0, lawEnforcement: 0 },
+  );
+  const summary =
+    series.length === 0
+      ? "No military, government or law-enforcement activity in this window."
+      : `Military, government and law-enforcement activity by day: ` +
+        `${totals.military} military, ${totals.government} government, ` +
+        `${totals.lawEnforcement} law-enforcement sightings across ${series.length} days.`;
+
+  return (
+    <AnalyticsCard
+      title="Military / government / police activity"
+      window={window}
+      isLoading={isLoading}
+      error={error}
+    >
+      <EChart
+        buildOption={buildOption}
+        ariaLabel="Military, government and law-enforcement activity over time, stacked bar chart"
+        summary={summary}
+      />
+    </AnalyticsCard>
+  );
+}

--- a/frontend/src/features/analytics/components/cards/DailyCountsCard.test.tsx
+++ b/frontend/src/features/analytics/components/cards/DailyCountsCard.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DailyCountsCard } from "@/features/analytics/components/cards/DailyCountsCard";
+import type { AnalyticsDailyRow } from "@/lib/api/analytics";
+
+function dailyRow(
+  overrides: Partial<AnalyticsDailyRow> = {},
+): AnalyticsDailyRow {
+  return {
+    day: "2026-08-31",
+    unique_aircraft: 10,
+    new_aircraft: 1,
+    sightings: 15,
+    interesting: 2,
+    military: 0,
+    government: 0,
+    law_enforcement: 0,
+    max_range_nm: 141.8,
+    busiest_hour: 14,
+    receiver_messages: 100000,
+    receiver_positions: 5000,
+    receiver_aircraft_max: 12,
+    receiver_max_range_nm: 150.2,
+    ...overrides,
+  };
+}
+
+describe("DailyCountsCard", () => {
+  it("renders the empty state with no days", () => {
+    render(<DailyCountsCard items={[]} isLoading={false} />);
+    expect(screen.getByText("No data for this window.")).toBeInTheDocument();
+  });
+
+  it("renders a chart with a per-day accessible summary", () => {
+    const items = [
+      dailyRow({ day: "2026-08-30", unique_aircraft: 8, sightings: 11 }),
+      dailyRow({ day: "2026-08-31", unique_aircraft: 10, sightings: 15 }),
+    ];
+    render(<DailyCountsCard items={items} isLoading={false} />);
+
+    expect(
+      screen.getByRole("img", { name: /daily aircraft and sighting counts/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/2026-08-30 — 8 aircraft, 11 sightings/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/2026-08-31 — 10 aircraft, 15 sightings/),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/analytics/components/cards/DailyCountsCard.tsx
+++ b/frontend/src/features/analytics/components/cards/DailyCountsCard.tsx
@@ -1,0 +1,107 @@
+/**
+ * "Daily aircraft count" and "daily sighting count" (SPEC §58) — two
+ * distinct metrics, so two categorical series (not a magnitude gradient) as
+ * lines/areas over the window's days.
+ */
+import { useCallback } from "react";
+
+import type { AnalyticsDailyRow, AnalyticsWindow } from "@/lib/api/analytics";
+
+import { AnalyticsCard } from "@/features/analytics/components/AnalyticsCard";
+import { EChart } from "@/features/analytics/components/EChart";
+import type { ChartTheme } from "@/features/analytics/lib/chartTheme";
+import { formatCompactNumber } from "@/features/analytics/lib/format";
+
+export interface DailyCountsCardProps {
+  window?: AnalyticsWindow;
+  items: AnalyticsDailyRow[];
+  isLoading: boolean;
+  error?: string;
+}
+
+export function DailyCountsCard({
+  window,
+  items,
+  isLoading,
+  error,
+}: DailyCountsCardProps) {
+  const buildOption = useCallback(
+    (theme: ChartTheme) => {
+      if (items.length === 0) {
+        return null;
+      }
+      const axisStyle = {
+        axisLabel: { color: theme.mutedInk },
+        axisLine: { lineStyle: { color: theme.grid } },
+        splitLine: { lineStyle: { color: theme.grid } },
+      };
+      return {
+        color: [theme.series[0], theme.series[1]],
+        legend: {
+          data: ["Aircraft", "Sightings"],
+          top: 0,
+          textStyle: { color: theme.mutedInk },
+        },
+        grid: { left: 8, right: 16, top: 32, bottom: 24, containLabel: true },
+        tooltip: { trigger: "axis" as const },
+        xAxis: {
+          type: "category" as const,
+          data: items.map((row) => row.day),
+          ...axisStyle,
+        },
+        yAxis: {
+          type: "value" as const,
+          axisLabel: {
+            ...axisStyle.axisLabel,
+            formatter: (value: number) => formatCompactNumber(value),
+          },
+          axisLine: axisStyle.axisLine,
+          splitLine: axisStyle.splitLine,
+        },
+        series: [
+          {
+            name: "Aircraft",
+            type: "line" as const,
+            data: items.map((row) => row.unique_aircraft),
+            smooth: true,
+            showSymbol: false,
+          },
+          {
+            name: "Sightings",
+            type: "line" as const,
+            data: items.map((row) => row.sightings),
+            smooth: true,
+            showSymbol: false,
+          },
+        ],
+      };
+    },
+    [items],
+  );
+
+  const summary =
+    items.length === 0
+      ? "No traffic recorded in this window."
+      : `Daily aircraft and sighting counts across ${items.length} days: ` +
+        `${items
+          .map(
+            (row) =>
+              `${row.day} — ${row.unique_aircraft} aircraft, ${row.sightings} sightings`,
+          )
+          .join("; ")}.`;
+
+  return (
+    <AnalyticsCard
+      title="Daily aircraft & sighting counts"
+      window={window}
+      isLoading={isLoading}
+      error={error}
+    >
+      <EChart
+        buildOption={buildOption}
+        ariaLabel="Daily aircraft and sighting counts, line chart"
+        summary={summary}
+      />
+    </AnalyticsCard>
+  );
+}

--- a/frontend/src/features/analytics/components/cards/MaxDistanceCard.test.tsx
+++ b/frontend/src/features/analytics/components/cards/MaxDistanceCard.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MaxDistanceCard } from "@/features/analytics/components/cards/MaxDistanceCard";
+import type { AnalyticsDailyRow } from "@/lib/api/analytics";
+
+function dailyRow(
+  overrides: Partial<AnalyticsDailyRow> = {},
+): AnalyticsDailyRow {
+  return {
+    day: "2026-08-31",
+    unique_aircraft: 10,
+    new_aircraft: 1,
+    sightings: 15,
+    interesting: 2,
+    military: 0,
+    government: 0,
+    law_enforcement: 0,
+    max_range_nm: 100,
+    busiest_hour: 14,
+    receiver_messages: 100000,
+    receiver_positions: 5000,
+    receiver_aircraft_max: 12,
+    receiver_max_range_nm: 150.2,
+    ...overrides,
+  };
+}
+
+describe("MaxDistanceCard", () => {
+  it("renders the empty state when every day has no distance", () => {
+    render(
+      <MaxDistanceCard
+        items={[dailyRow({ max_range_nm: null })]}
+        units="aviation"
+        isLoading={false}
+      />,
+    );
+    expect(screen.getByText("No data for this window.")).toBeInTheDocument();
+  });
+
+  it("renders in nautical miles for aviation units", () => {
+    render(
+      <MaxDistanceCard
+        items={[dailyRow({ day: "2026-08-31", max_range_nm: 100 })]}
+        units="aviation"
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByText(/2026-08-31 — 100 nm/)).toBeInTheDocument();
+  });
+
+  it("converts to kilometers for metric units", () => {
+    render(
+      <MaxDistanceCard
+        items={[dailyRow({ day: "2026-08-31", max_range_nm: 100 })]}
+        units="metric"
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByText(/2026-08-31 — 185.2 km/)).toBeInTheDocument();
+  });
+
+  it("skips days with no distance in the summary", () => {
+    const items = [
+      dailyRow({ day: "2026-08-30", max_range_nm: null }),
+      dailyRow({ day: "2026-08-31", max_range_nm: 50 }),
+    ];
+    render(
+      <MaxDistanceCard items={items} units="aviation" isLoading={false} />,
+    );
+
+    expect(screen.queryByText(/2026-08-30/)).not.toBeInTheDocument();
+    expect(screen.getByText(/2026-08-31 — 50 nm/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/analytics/components/cards/MaxDistanceCard.tsx
+++ b/frontend/src/features/analytics/components/cards/MaxDistanceCard.tsx
@@ -1,0 +1,111 @@
+/**
+ * "Maximum detection distance" over time (SPEC §58) — a single-series line
+ * of the window's per-day farthest detection, converted to the receiver's
+ * display unit (`docs/API.md` §3.2 `units`; storage/wire stays nm — only the
+ * chart's plotted numbers and axis label convert). A day with no usable
+ * position (`max_range_nm: null`) is a gap in the line, not a false zero.
+ */
+import { useCallback } from "react";
+
+import type { AnalyticsDailyRow, AnalyticsWindow } from "@/lib/api/analytics";
+import type { UnitSystem } from "@/lib/api/config";
+
+import { AnalyticsCard } from "@/features/analytics/components/AnalyticsCard";
+import { EChart } from "@/features/analytics/components/EChart";
+import type { ChartTheme } from "@/features/analytics/lib/chartTheme";
+import {
+  convertDistance,
+  distanceUnitLabel,
+} from "@/features/analytics/lib/format";
+
+export interface MaxDistanceCardProps {
+  window?: AnalyticsWindow;
+  items: AnalyticsDailyRow[];
+  units: UnitSystem;
+  isLoading: boolean;
+  error?: string;
+}
+
+export function MaxDistanceCard({
+  window,
+  items,
+  units,
+  isLoading,
+  error,
+}: MaxDistanceCardProps) {
+  const hasData = items.some((row) => row.max_range_nm !== null);
+
+  const buildOption = useCallback(
+    (theme: ChartTheme) => {
+      if (!hasData) {
+        return null;
+      }
+      const unitLabel = distanceUnitLabel(units);
+      const axisStyle = {
+        axisLabel: { color: theme.mutedInk },
+        axisLine: { lineStyle: { color: theme.grid } },
+        splitLine: { lineStyle: { color: theme.grid } },
+      };
+      return {
+        color: [theme.series[0]],
+        grid: { left: 8, right: 16, top: 16, bottom: 24, containLabel: true },
+        tooltip: {
+          trigger: "axis" as const,
+          valueFormatter: (value: unknown) =>
+            typeof value === "number" ? `${value} ${unitLabel}` : "—",
+        },
+        xAxis: {
+          type: "category" as const,
+          data: items.map((row) => row.day),
+          ...axisStyle,
+        },
+        yAxis: {
+          type: "value" as const,
+          name: unitLabel,
+          nameTextStyle: { color: theme.mutedInk },
+          ...axisStyle,
+        },
+        series: [
+          {
+            type: "line" as const,
+            data: items.map((row) =>
+              row.max_range_nm === null
+                ? null
+                : convertDistance(row.max_range_nm, units),
+            ),
+            connectNulls: false,
+            smooth: true,
+            showSymbol: false,
+          },
+        ],
+      };
+    },
+    [hasData, items, units],
+  );
+
+  const unitLabel = distanceUnitLabel(units);
+  const summary = !hasData
+    ? "No detection distance recorded in this window."
+    : `Maximum detection distance by day, in ${unitLabel}: ${items
+        .filter((row) => row.max_range_nm !== null)
+        .map(
+          (row) =>
+            `${row.day} — ${convertDistance(row.max_range_nm as number, units)} ${unitLabel}`,
+        )
+        .join("; ")}.`;
+
+  return (
+    <AnalyticsCard
+      title="Maximum detection distance"
+      window={window}
+      isLoading={isLoading}
+      error={error}
+    >
+      <EChart
+        buildOption={buildOption}
+        ariaLabel="Maximum detection distance over time, line chart"
+        summary={summary}
+      />
+    </AnalyticsCard>
+  );
+}

--- a/frontend/src/features/analytics/components/cards/NeverSeenBeforeCard.test.tsx
+++ b/frontend/src/features/analytics/components/cards/NeverSeenBeforeCard.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { NeverSeenBeforeCard } from "@/features/analytics/components/cards/NeverSeenBeforeCard";
+import type { AnalyticsDailyRow } from "@/lib/api/analytics";
+
+function dailyRow(
+  overrides: Partial<AnalyticsDailyRow> = {},
+): AnalyticsDailyRow {
+  return {
+    day: "2026-08-31",
+    unique_aircraft: 10,
+    new_aircraft: 2,
+    sightings: 15,
+    interesting: 2,
+    military: 0,
+    government: 0,
+    law_enforcement: 0,
+    max_range_nm: 141.8,
+    busiest_hour: 14,
+    receiver_messages: 100000,
+    receiver_positions: 5000,
+    receiver_aircraft_max: 12,
+    receiver_max_range_nm: 150.2,
+    ...overrides,
+  };
+}
+
+describe("NeverSeenBeforeCard", () => {
+  it("renders the empty state with no days", () => {
+    render(<NeverSeenBeforeCard items={[]} isLoading={false} />);
+    expect(screen.getByText("No data for this window.")).toBeInTheDocument();
+  });
+
+  it("sums the daily new-aircraft counts in the summary", () => {
+    const items = [
+      dailyRow({ day: "2026-08-30", new_aircraft: 1 }),
+      dailyRow({ day: "2026-08-31", new_aircraft: 2 }),
+    ];
+    render(<NeverSeenBeforeCard items={items} isLoading={false} />);
+
+    expect(
+      screen.getByRole("img", { name: /new aircraft never seen before/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/3 total/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/analytics/components/cards/NeverSeenBeforeCard.tsx
+++ b/frontend/src/features/analytics/components/cards/NeverSeenBeforeCard.tsx
@@ -1,0 +1,87 @@
+/**
+ * "Count of aircraft never previously seen" (SPEC §58) — the daily trend, a
+ * single-series bar of `AnalyticsDailyRow.new_aircraft`. The window's
+ * aggregate total lives on {@link RarityListsCard} alongside the locally
+ * rare lists (`/api/v1/analytics/rarity`'s `never_seen_before`), so this
+ * card is the "over time" half of the same SPEC bullet.
+ */
+import { useCallback } from "react";
+
+import type { AnalyticsDailyRow, AnalyticsWindow } from "@/lib/api/analytics";
+
+import { AnalyticsCard } from "@/features/analytics/components/AnalyticsCard";
+import { EChart } from "@/features/analytics/components/EChart";
+import type { ChartTheme } from "@/features/analytics/lib/chartTheme";
+
+export interface NeverSeenBeforeCardProps {
+  window?: AnalyticsWindow;
+  items: AnalyticsDailyRow[];
+  isLoading: boolean;
+  error?: string;
+}
+
+export function NeverSeenBeforeCard({
+  window,
+  items,
+  isLoading,
+  error,
+}: NeverSeenBeforeCardProps) {
+  const total = items.reduce((sum, row) => sum + row.new_aircraft, 0);
+
+  const buildOption = useCallback(
+    (theme: ChartTheme) => {
+      if (items.length === 0) {
+        return null;
+      }
+      const axisStyle = {
+        axisLabel: { color: theme.mutedInk },
+        axisLine: { lineStyle: { color: theme.grid } },
+        splitLine: { lineStyle: { color: theme.grid } },
+      };
+      return {
+        color: [theme.series[0]],
+        grid: { left: 8, right: 16, top: 16, bottom: 24, containLabel: true },
+        tooltip: {
+          trigger: "axis" as const,
+          axisPointer: { type: "shadow" as const },
+        },
+        xAxis: {
+          type: "category" as const,
+          data: items.map((row) => row.day),
+          ...axisStyle,
+        },
+        yAxis: { type: "value" as const, ...axisStyle },
+        series: [
+          {
+            type: "bar" as const,
+            data: items.map((row) => row.new_aircraft),
+            barMaxWidth: 24,
+          },
+        ],
+      };
+    },
+    [items],
+  );
+
+  const summary =
+    items.length === 0
+      ? "No new aircraft in this window."
+      : `New (never-seen-before) aircraft by day, ${total} total: ${items
+          .map((row) => `${row.day} — ${row.new_aircraft}`)
+          .join("; ")}.`;
+
+  return (
+    <AnalyticsCard
+      title="Never seen before"
+      window={window}
+      isLoading={isLoading}
+      error={error}
+    >
+      <EChart
+        buildOption={buildOption}
+        ariaLabel="New aircraft never seen before, by day, bar chart"
+        summary={summary}
+      />
+    </AnalyticsCard>
+  );
+}

--- a/frontend/src/features/analytics/components/cards/RarityListsCard.test.tsx
+++ b/frontend/src/features/analytics/components/cards/RarityListsCard.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { RarityListsCard } from "@/features/analytics/components/cards/RarityListsCard";
+import type {
+  AnalyticsAircraftRow,
+  AnalyticsRareType,
+} from "@/lib/api/analytics";
+
+function aircraftRow(
+  overrides: Partial<AnalyticsAircraftRow> = {},
+): AnalyticsAircraftRow {
+  return {
+    icao: "ae1463",
+    registration: "05-8153",
+    type: "C17",
+    model: "Boeing C-17A Globemaster III",
+    operator: "United States Air Force",
+    operator_group: "US Military",
+    classification: "military_transport",
+    military: true,
+    government: false,
+    law_enforcement: false,
+    sightings: 1,
+    first_seen_at: "2026-08-30T22:02:10.000Z",
+    last_seen_at: "2026-08-30T22:41:55.000Z",
+    max_range_nm: 96,
+    ...overrides,
+  };
+}
+
+function rareType(
+  overrides: Partial<AnalyticsRareType> = {},
+): AnalyticsRareType {
+  return {
+    type: "military_transport",
+    unique_aircraft: 1,
+    total_sightings: 1,
+    first_seen_at: "2026-08-30T22:02:10.000Z",
+    last_seen_at: "2026-08-30T22:41:55.000Z",
+    ...overrides,
+  };
+}
+
+describe("RarityListsCard", () => {
+  it("shows the never-seen-before total and empty-list messages when both lists are empty", () => {
+    render(
+      <MemoryRouter>
+        <RarityListsCard
+          neverSeenBefore={3}
+          rareMaxSightings={2}
+          rareAircraft={[]}
+          rareTypes={[]}
+          isLoading={false}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(
+      screen.getByText(/never seen before this window/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("No rare aircraft in this window."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("No rare types in this window."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders rare aircraft rows linking to the aircraft detail route", () => {
+    render(
+      <MemoryRouter>
+        <RarityListsCard
+          neverSeenBefore={1}
+          rareMaxSightings={2}
+          rareAircraft={[aircraftRow()]}
+          rareTypes={[]}
+          isLoading={false}
+        />
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole("link", { name: "05-8153" });
+    expect(link).toHaveAttribute("href", "/aircraft/ae1463");
+  });
+
+  it("renders rare type rows with a humanized label, no link", () => {
+    render(
+      <MemoryRouter>
+        <RarityListsCard
+          neverSeenBefore={0}
+          rareMaxSightings={2}
+          rareAircraft={[]}
+          rareTypes={[rareType({ type: "military_transport" })]}
+          isLoading={false}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Military transport")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("shows an error message in place of the lists", () => {
+    render(
+      <MemoryRouter>
+        <RarityListsCard
+          neverSeenBefore={0}
+          rareMaxSightings={2}
+          rareAircraft={[]}
+          rareTypes={[]}
+          isLoading={false}
+          error="Could not load rarity data."
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Could not load rarity data.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/analytics/components/cards/RarityListsCard.tsx
+++ b/frontend/src/features/analytics/components/cards/RarityListsCard.tsx
@@ -1,0 +1,144 @@
+/**
+ * "Locally rare aircraft/type information" plus the window's never-seen-
+ * before total (SPEC §58, `GET /api/v1/analytics/rarity`) — two compact
+ * tables rather than a chart: rarity is a short, specific list of airframes
+ * and types, exactly the case where a table reads faster than a plot.
+ * Rare-aircraft rows link to the aircraft detail route (roadmap slice 029);
+ * type designators have no detail route in this app, so rare-type rows stay
+ * plain text.
+ */
+import { Link } from "react-router-dom";
+
+import type {
+  AnalyticsAircraftRow,
+  AnalyticsRareType,
+  AnalyticsWindow,
+} from "@/lib/api/analytics";
+
+import { AnalyticsCard } from "@/features/analytics/components/AnalyticsCard";
+import { humanizeSlug } from "@/features/analytics/lib/format";
+
+export interface RarityListsCardProps {
+  window?: AnalyticsWindow;
+  neverSeenBefore: number;
+  rareMaxSightings: number;
+  rareAircraft: AnalyticsAircraftRow[];
+  rareTypes: AnalyticsRareType[];
+  isLoading: boolean;
+  error?: string;
+}
+
+export function RarityListsCard({
+  window,
+  neverSeenBefore,
+  rareMaxSightings,
+  rareAircraft,
+  rareTypes,
+  isLoading,
+  error,
+}: RarityListsCardProps) {
+  return (
+    <AnalyticsCard
+      title="Locally rare"
+      window={window}
+      isLoading={isLoading}
+      error={error}
+    >
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-foreground">
+          <span className="font-semibold">{neverSeenBefore}</span> aircraft
+          never seen before this window.
+        </p>
+
+        <div>
+          <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Rare aircraft{" "}
+            <span className="normal-case">
+              (lifetime sightings ≤ {rareMaxSightings})
+            </span>
+          </h3>
+          {rareAircraft.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No rare aircraft in this window.
+            </p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+                  <th scope="col" className="py-1 pr-2 font-semibold">
+                    Aircraft
+                  </th>
+                  <th scope="col" className="py-1 pr-2 font-semibold">
+                    Type
+                  </th>
+                  <th scope="col" className="py-1 text-right font-semibold">
+                    Sightings
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {rareAircraft.map((row) => (
+                  <tr key={row.icao} className="border-t border-border/60">
+                    <td className="py-1 pr-2">
+                      <Link
+                        to={`/aircraft/${row.icao}`}
+                        className="font-medium text-accent hover:underline"
+                      >
+                        {row.registration ?? row.icao.toUpperCase()}
+                      </Link>
+                    </td>
+                    <td className="py-1 pr-2 text-muted-foreground">
+                      {row.type ?? "Unknown"}
+                    </td>
+                    <td className="py-1 text-right">{row.sightings}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        <div>
+          <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Rare types
+          </h3>
+          {rareTypes.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No rare types in this window.
+            </p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+                  <th scope="col" className="py-1 pr-2 font-semibold">
+                    Type
+                  </th>
+                  <th
+                    scope="col"
+                    className="py-1 pr-2 text-right font-semibold"
+                  >
+                    Aircraft
+                  </th>
+                  <th scope="col" className="py-1 text-right font-semibold">
+                    Sightings
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {rareTypes.map((row) => (
+                  <tr key={row.type} className="border-t border-border/60">
+                    <td className="py-1 pr-2">{humanizeSlug(row.type)}</td>
+                    <td className="py-1 pr-2 text-right">
+                      {row.unique_aircraft}
+                    </td>
+                    <td className="py-1 text-right">{row.total_sightings}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </AnalyticsCard>
+  );
+}

--- a/frontend/src/features/analytics/components/cards/ReceiverActivityCard.test.tsx
+++ b/frontend/src/features/analytics/components/cards/ReceiverActivityCard.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ReceiverActivityCard } from "@/features/analytics/components/cards/ReceiverActivityCard";
+import type { AnalyticsDailyRow } from "@/lib/api/analytics";
+
+function dailyRow(
+  overrides: Partial<AnalyticsDailyRow> = {},
+): AnalyticsDailyRow {
+  return {
+    day: "2026-08-31",
+    unique_aircraft: 10,
+    new_aircraft: 1,
+    sightings: 15,
+    interesting: 2,
+    military: 0,
+    government: 0,
+    law_enforcement: 0,
+    max_range_nm: 141.8,
+    busiest_hour: 14,
+    receiver_messages: 120000,
+    receiver_positions: 6000,
+    receiver_aircraft_max: 12,
+    receiver_max_range_nm: 150.2,
+    ...overrides,
+  };
+}
+
+describe("ReceiverActivityCard", () => {
+  it("renders the empty state when no day has receiver activity", () => {
+    render(
+      <ReceiverActivityCard
+        items={[
+          dailyRow({ receiver_messages: null, receiver_positions: null }),
+        ]}
+        isLoading={false}
+      />,
+    );
+    expect(screen.getByText("No data for this window.")).toBeInTheDocument();
+  });
+
+  it("renders a summary with compact message/position counts", () => {
+    render(
+      <ReceiverActivityCard
+        items={[
+          dailyRow({
+            day: "2026-08-31",
+            receiver_messages: 120000,
+            receiver_positions: 6000,
+          }),
+        ]}
+        isLoading={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole("img", { name: /receiver messages and positions/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/2026-08-31 — 120K messages, 6K positions/),
+    ).toBeInTheDocument();
+  });
+
+  it("treats a partially-recorded window (some days null) as having data", () => {
+    const items = [
+      dailyRow({
+        day: "2026-08-30",
+        receiver_messages: null,
+        receiver_positions: null,
+      }),
+      dailyRow({
+        day: "2026-08-31",
+        receiver_messages: 500,
+        receiver_positions: 50,
+      }),
+    ];
+    render(<ReceiverActivityCard items={items} isLoading={false} />);
+
+    expect(
+      screen.queryByText("No data for this window."),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/2026-08-30/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/analytics/components/cards/ReceiverActivityCard.tsx
+++ b/frontend/src/features/analytics/components/cards/ReceiverActivityCard.tsx
@@ -1,0 +1,117 @@
+/**
+ * "Receiver activity over time" (SPEC §58) — messages and positions per day,
+ * joined onto the `daily` response by slice 033's receiver metrics
+ * (`docs/API.md` §3.7's `AnalyticsDailyRow.receiver_*` fields). `null` for a
+ * day before receiver-metrics recording started, rendered as a gap rather
+ * than a false zero, the same convention {@link MaxDistanceCard} uses.
+ */
+import { useCallback } from "react";
+
+import type { AnalyticsDailyRow, AnalyticsWindow } from "@/lib/api/analytics";
+
+import { AnalyticsCard } from "@/features/analytics/components/AnalyticsCard";
+import { EChart } from "@/features/analytics/components/EChart";
+import type { ChartTheme } from "@/features/analytics/lib/chartTheme";
+import { formatCompactNumber } from "@/features/analytics/lib/format";
+
+export interface ReceiverActivityCardProps {
+  window?: AnalyticsWindow;
+  items: AnalyticsDailyRow[];
+  isLoading: boolean;
+  error?: string;
+}
+
+export function ReceiverActivityCard({
+  window,
+  items,
+  isLoading,
+  error,
+}: ReceiverActivityCardProps) {
+  const hasData = items.some(
+    (row) => row.receiver_messages !== null || row.receiver_positions !== null,
+  );
+
+  const buildOption = useCallback(
+    (theme: ChartTheme) => {
+      if (!hasData) {
+        return null;
+      }
+      const axisStyle = {
+        axisLabel: { color: theme.mutedInk },
+        axisLine: { lineStyle: { color: theme.grid } },
+        splitLine: { lineStyle: { color: theme.grid } },
+      };
+      return {
+        color: [theme.series[0], theme.series[1]],
+        legend: {
+          data: ["Messages", "Positions"],
+          top: 0,
+          textStyle: { color: theme.mutedInk },
+        },
+        grid: { left: 8, right: 16, top: 32, bottom: 24, containLabel: true },
+        tooltip: { trigger: "axis" as const },
+        xAxis: {
+          type: "category" as const,
+          data: items.map((row) => row.day),
+          ...axisStyle,
+        },
+        yAxis: {
+          type: "value" as const,
+          axisLabel: {
+            ...axisStyle.axisLabel,
+            formatter: (value: number) => formatCompactNumber(value),
+          },
+          axisLine: axisStyle.axisLine,
+          splitLine: axisStyle.splitLine,
+        },
+        series: [
+          {
+            name: "Messages",
+            type: "line" as const,
+            data: items.map((row) => row.receiver_messages),
+            connectNulls: false,
+            smooth: true,
+            showSymbol: false,
+          },
+          {
+            name: "Positions",
+            type: "line" as const,
+            data: items.map((row) => row.receiver_positions),
+            connectNulls: false,
+            smooth: true,
+            showSymbol: false,
+          },
+        ],
+      };
+    },
+    [hasData, items],
+  );
+
+  const summary = !hasData
+    ? "No receiver activity recorded in this window."
+    : `Daily receiver messages and positions: ${items
+        .filter(
+          (row) =>
+            row.receiver_messages !== null || row.receiver_positions !== null,
+        )
+        .map(
+          (row) =>
+            `${row.day} — ${formatCompactNumber(row.receiver_messages ?? 0)} messages, ${formatCompactNumber(row.receiver_positions ?? 0)} positions`,
+        )
+        .join("; ")}.`;
+
+  return (
+    <AnalyticsCard
+      title="Receiver activity"
+      window={window}
+      isLoading={isLoading}
+      error={error}
+    >
+      <EChart
+        buildOption={buildOption}
+        ariaLabel="Receiver messages and positions over time, line chart"
+        summary={summary}
+      />
+    </AnalyticsCard>
+  );
+}

--- a/frontend/src/features/analytics/components/cards/TopAircraftCard.test.tsx
+++ b/frontend/src/features/analytics/components/cards/TopAircraftCard.test.tsx
@@ -1,0 +1,108 @@
+import { act, render, screen } from "@testing-library/react";
+import {
+  createMemoryRouter,
+  MemoryRouter,
+  RouterProvider,
+  useParams,
+} from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { TopAircraftCard } from "@/features/analytics/components/cards/TopAircraftCard";
+import type { AnalyticsAircraftRow } from "@/lib/api/analytics";
+import { getLastMockChart } from "@/test/echartsMock";
+
+function aircraftRow(
+  overrides: Partial<AnalyticsAircraftRow> = {},
+): AnalyticsAircraftRow {
+  return {
+    icao: "ae1463",
+    registration: "05-8153",
+    type: "C17",
+    model: "Boeing C-17A Globemaster III",
+    operator: "United States Air Force",
+    operator_group: "US Military",
+    classification: "military_transport",
+    military: true,
+    government: false,
+    law_enforcement: false,
+    sightings: 12,
+    first_seen_at: "2026-04-02T18:11:09.000Z",
+    last_seen_at: "2026-08-30T22:41:55.000Z",
+    max_range_nm: 141.8,
+    ...overrides,
+  };
+}
+
+describe("TopAircraftCard", () => {
+  it("renders a loading state", () => {
+    render(
+      <MemoryRouter>
+        <TopAircraftCard rows={[]} isLoading />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+  });
+
+  it("renders an error state", () => {
+    render(
+      <MemoryRouter>
+        <TopAircraftCard rows={[]} isLoading={false} error="Could not load." />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Could not load.")).toBeInTheDocument();
+  });
+
+  it("renders the empty state when there are no rows", () => {
+    render(
+      <MemoryRouter>
+        <TopAircraftCard rows={[]} isLoading={false} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("No data for this window.")).toBeInTheDocument();
+  });
+
+  it("renders a chart with an accessible summary listing every row", () => {
+    const rows = [
+      aircraftRow({ sightings: 12 }),
+      aircraftRow({ icao: "a9c2f0", registration: "N302DN", sightings: 8 }),
+    ];
+    render(
+      <MemoryRouter>
+        <TopAircraftCard rows={rows} isLoading={false} />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("img", { name: /top aircraft by sightings/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/05-8153 \(12\)/)).toBeInTheDocument();
+    expect(screen.getByText(/N302DN \(8\)/)).toBeInTheDocument();
+  });
+
+  it("navigates to the aircraft detail route on a bar click", () => {
+    function AircraftDetailStub() {
+      const { icao } = useParams();
+      return <p>Detail for {icao}</p>;
+    }
+
+    const rows = [aircraftRow({ icao: "ae1463", registration: "05-8153" })];
+    const router = createMemoryRouter(
+      [
+        {
+          path: "/analytics",
+          element: <TopAircraftCard rows={rows} isLoading={false} />,
+        },
+        { path: "/aircraft/:icao", element: <AircraftDetailStub /> },
+      ],
+      { initialEntries: ["/analytics"] },
+    );
+    render(<RouterProvider router={router} />);
+
+    const instance = getLastMockChart();
+    act(() => {
+      instance.emit("click", { dataIndex: 0, name: "05-8153", value: 12 });
+    });
+
+    expect(screen.getByText("Detail for ae1463")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/analytics/components/cards/TopAircraftCard.tsx
+++ b/frontend/src/features/analytics/components/cards/TopAircraftCard.tsx
@@ -1,0 +1,114 @@
+/**
+ * "Most frequently seen aircraft" (SPEC §58) — a horizontal bar of the
+ * window's top airframes by sighting count. Clicking a bar (or its label)
+ * opens the aircraft's history detail (roadmap slice 029), the same
+ * destination the Aircraft page's table rows use.
+ */
+import { useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+
+import type {
+  AnalyticsAircraftRow,
+  AnalyticsWindow,
+} from "@/lib/api/analytics";
+
+import { AnalyticsCard } from "@/features/analytics/components/AnalyticsCard";
+import {
+  EChart,
+  type EChartClickParams,
+} from "@/features/analytics/components/EChart";
+import type { ChartTheme } from "@/features/analytics/lib/chartTheme";
+
+export interface TopAircraftCardProps {
+  window?: AnalyticsWindow;
+  rows: AnalyticsAircraftRow[];
+  isLoading: boolean;
+  error?: string;
+}
+
+function aircraftLabel(row: AnalyticsAircraftRow): string {
+  return row.registration ?? row.icao.toUpperCase();
+}
+
+export function TopAircraftCard({
+  window,
+  rows,
+  isLoading,
+  error,
+}: TopAircraftCardProps) {
+  const navigate = useNavigate();
+
+  // Reversed so the highest-ranked row (rows[0], the backend's own sort)
+  // ends up at the top of the horizontal bar rather than the bottom —
+  // ECharts draws a category axis's first entry lowest.
+  const ordered = useMemo(() => [...rows].reverse(), [rows]);
+
+  const buildOption = useCallback(
+    (theme: ChartTheme) => {
+      if (ordered.length === 0) {
+        return null;
+      }
+      return {
+        color: [theme.series[0]],
+        grid: { left: 8, right: 24, top: 8, bottom: 24, containLabel: true },
+        tooltip: {
+          trigger: "axis" as const,
+          axisPointer: { type: "shadow" as const },
+        },
+        xAxis: {
+          type: "value" as const,
+          axisLabel: { color: theme.mutedInk },
+          axisLine: { lineStyle: { color: theme.grid } },
+          splitLine: { lineStyle: { color: theme.grid } },
+        },
+        yAxis: {
+          type: "category" as const,
+          data: ordered.map(aircraftLabel),
+          axisLabel: { color: theme.ink },
+          axisLine: { lineStyle: { color: theme.grid } },
+        },
+        series: [
+          {
+            type: "bar" as const,
+            data: ordered.map((row) => row.sightings),
+            barMaxWidth: 18,
+          },
+        ],
+      };
+    },
+    [ordered],
+  );
+
+  const handleMarkClick = useCallback(
+    (params: EChartClickParams) => {
+      const row = ordered[params.dataIndex];
+      if (row) {
+        navigate(`/aircraft/${row.icao}`);
+      }
+    },
+    [navigate, ordered],
+  );
+
+  const summary =
+    rows.length === 0
+      ? "No aircraft sighted in this window."
+      : `Top aircraft by sightings: ${rows
+          .map((row) => `${aircraftLabel(row)} (${row.sightings})`)
+          .join(", ")}.`;
+
+  return (
+    <AnalyticsCard
+      title="Top aircraft"
+      window={window}
+      isLoading={isLoading}
+      error={error}
+    >
+      <EChart
+        buildOption={buildOption}
+        ariaLabel="Top aircraft by sightings, horizontal bar chart"
+        summary={summary}
+        onMarkClick={handleMarkClick}
+      />
+    </AnalyticsCard>
+  );
+}

--- a/frontend/src/features/analytics/components/cards/TopGroupCard.test.tsx
+++ b/frontend/src/features/analytics/components/cards/TopGroupCard.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TopGroupCard } from "@/features/analytics/components/cards/TopGroupCard";
+import type { AnalyticsGroupRow } from "@/lib/api/analytics";
+
+function groupRow(
+  overrides: Partial<AnalyticsGroupRow> = {},
+): AnalyticsGroupRow {
+  return {
+    key: "C17",
+    label: "C-17 Globemaster III",
+    sightings: 9,
+    unique_aircraft: 3,
+    days_seen: 5,
+    first_seen_at: "2026-04-02T18:11:09.000Z",
+    last_seen_at: "2026-08-30T22:41:55.000Z",
+    ...overrides,
+  };
+}
+
+describe("TopGroupCard", () => {
+  it("renders the empty state with the given empty label", () => {
+    render(
+      <TopGroupCard
+        title="Top types"
+        ariaLabel="Top types by sightings"
+        emptyLabel="No types sighted in this window."
+        rows={[]}
+        isLoading={false}
+      />,
+    );
+    expect(screen.getByText("No data for this window.")).toBeInTheDocument();
+  });
+
+  it("renders a chart with an accessible summary, falling back to key when label is null", () => {
+    const rows = [
+      groupRow({ label: "C-17 Globemaster III", sightings: 9 }),
+      groupRow({ key: "B738", label: null, sightings: 4 }),
+    ];
+    render(
+      <TopGroupCard
+        title="Top types"
+        ariaLabel="Top types by sightings"
+        emptyLabel="No types sighted in this window."
+        rows={rows}
+        isLoading={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole("img", { name: "Top types by sightings" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/C-17 Globemaster III \(9\)/)).toBeInTheDocument();
+    expect(screen.getByText(/B738 \(4\)/)).toBeInTheDocument();
+  });
+
+  it("reuses the same component for operators via title/ariaLabel props", () => {
+    render(
+      <TopGroupCard
+        title="Top operators"
+        ariaLabel="Top operators by sightings"
+        emptyLabel="No operators sighted in this window."
+        rows={[groupRow({ key: "1", label: "Delta Air Lines", sightings: 6 })]}
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByText("Top operators")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "Top operators by sightings" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/analytics/components/cards/TopGroupCard.tsx
+++ b/frontend/src/features/analytics/components/cards/TopGroupCard.tsx
@@ -1,0 +1,104 @@
+/**
+ * "Most frequently seen types/models" and "most common operators" (SPEC
+ * §58) — both `/api/v1/analytics/top-types` and `/top-operators` return the
+ * identical `AnalyticsGroupRow` shape (`docs/API.md` §3.7: "key"/"label"
+ * over a type designator or an operator group), so one horizontal-bar card
+ * renders either, parameterized by title and which rows it was given —
+ * SightingsPage-style reuse rather than two near-duplicate components.
+ * Neither a type designator nor an operator group has its own detail route
+ * in this app, so bars are not clickable (unlike {@link TopAircraftCard}).
+ */
+import { useCallback, useMemo } from "react";
+
+import type { AnalyticsGroupRow, AnalyticsWindow } from "@/lib/api/analytics";
+
+import { AnalyticsCard } from "@/features/analytics/components/AnalyticsCard";
+import { EChart } from "@/features/analytics/components/EChart";
+import type { ChartTheme } from "@/features/analytics/lib/chartTheme";
+
+export interface TopGroupCardProps {
+  title: string;
+  ariaLabel: string;
+  emptyLabel: string;
+  window?: AnalyticsWindow;
+  rows: AnalyticsGroupRow[];
+  isLoading: boolean;
+  error?: string;
+}
+
+function groupLabel(row: AnalyticsGroupRow): string {
+  return row.label ?? row.key;
+}
+
+export function TopGroupCard({
+  title,
+  ariaLabel,
+  emptyLabel,
+  window,
+  rows,
+  isLoading,
+  error,
+}: TopGroupCardProps) {
+  // Reversed so the highest-ranked row (the backend's own sort) ends up at
+  // the top of the horizontal bar — ECharts draws a category axis's first
+  // entry lowest.
+  const ordered = useMemo(() => [...rows].reverse(), [rows]);
+
+  const buildOption = useCallback(
+    (theme: ChartTheme) => {
+      if (ordered.length === 0) {
+        return null;
+      }
+      return {
+        color: [theme.series[0]],
+        grid: { left: 8, right: 24, top: 8, bottom: 24, containLabel: true },
+        tooltip: {
+          trigger: "axis" as const,
+          axisPointer: { type: "shadow" as const },
+        },
+        xAxis: {
+          type: "value" as const,
+          axisLabel: { color: theme.mutedInk },
+          axisLine: { lineStyle: { color: theme.grid } },
+          splitLine: { lineStyle: { color: theme.grid } },
+        },
+        yAxis: {
+          type: "category" as const,
+          data: ordered.map(groupLabel),
+          axisLabel: { color: theme.ink },
+          axisLine: { lineStyle: { color: theme.grid } },
+        },
+        series: [
+          {
+            type: "bar" as const,
+            data: ordered.map((row) => row.sightings),
+            barMaxWidth: 18,
+          },
+        ],
+      };
+    },
+    [ordered],
+  );
+
+  const summary =
+    rows.length === 0
+      ? emptyLabel
+      : `${title}: ${rows
+          .map((row) => `${groupLabel(row)} (${row.sightings})`)
+          .join(", ")}.`;
+
+  return (
+    <AnalyticsCard
+      title={title}
+      window={window}
+      isLoading={isLoading}
+      error={error}
+    >
+      <EChart
+        buildOption={buildOption}
+        ariaLabel={ariaLabel}
+        summary={summary}
+      />
+    </AnalyticsCard>
+  );
+}

--- a/frontend/src/features/analytics/hooks/useAnalyticsPresetState.ts
+++ b/frontend/src/features/analytics/hooks/useAnalyticsPresetState.ts
@@ -1,0 +1,40 @@
+/**
+ * The Analytics page's preset state, backed directly by the URL (roadmap
+ * slice 032: "preset selector... URL-persisted"). Mirrors
+ * `features/aircraft-page/hooks/useAircraftTableState.ts` — the URL *is*
+ * the state, read fresh on every render and written with `replace` so
+ * switching presets never grows the browser history stack.
+ */
+
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import type { AnalyticsPreset } from "@/lib/api/analytics";
+
+import {
+  parseAnalyticsPreset,
+  serializeAnalyticsPreset,
+} from "@/features/analytics/lib/urlState";
+
+export interface UseAnalyticsPresetStateResult {
+  preset: AnalyticsPreset;
+  setPreset: (preset: AnalyticsPreset) => void;
+}
+
+export function useAnalyticsPresetState(): UseAnalyticsPresetStateResult {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const preset = useMemo(
+    () => parseAnalyticsPreset(searchParams),
+    [searchParams],
+  );
+
+  const setPreset = useCallback(
+    (next: AnalyticsPreset) => {
+      setSearchParams(serializeAnalyticsPreset(next), { replace: true });
+    },
+    [setSearchParams],
+  );
+
+  return { preset, setPreset };
+}

--- a/frontend/src/features/analytics/lib/chartTheme.test.ts
+++ b/frontend/src/features/analytics/lib/chartTheme.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveChartTheme } from "@/features/analytics/lib/chartTheme";
+
+afterEach(() => {
+  document.documentElement.removeAttribute("style");
+});
+
+describe("resolveChartTheme", () => {
+  it("falls back to a plausible default when no CSS custom properties are set", () => {
+    const theme = resolveChartTheme("dark");
+    expect(theme.mode).toBe("dark");
+    expect(theme.ink).toBeTruthy();
+    expect(theme.mutedInk).toBeTruthy();
+    expect(theme.grid).toBeTruthy();
+    expect(theme.series).toHaveLength(3);
+  });
+
+  it("reads live CSS custom properties when set", () => {
+    document.documentElement.style.setProperty("--foreground", "rgb(1, 2, 3)");
+    document.documentElement.style.setProperty(
+      "--muted-foreground",
+      "rgb(4, 5, 6)",
+    );
+    document.documentElement.style.setProperty("--border", "rgb(7, 8, 9)");
+    document.documentElement.style.setProperty(
+      "--chart-series-1",
+      "rgb(10, 11, 12)",
+    );
+
+    const theme = resolveChartTheme("light");
+
+    expect(theme.ink).toBe("rgb(1, 2, 3)");
+    expect(theme.mutedInk).toBe("rgb(4, 5, 6)");
+    expect(theme.grid).toBe("rgb(7, 8, 9)");
+    expect(theme.series[0]).toBe("rgb(10, 11, 12)");
+  });
+
+  it("returns different fallback colors for light and dark modes", () => {
+    const light = resolveChartTheme("light");
+    const dark = resolveChartTheme("dark");
+    expect(light.ink).not.toBe(dark.ink);
+    expect(light.series).not.toEqual(dark.series);
+  });
+});

--- a/frontend/src/features/analytics/lib/chartTheme.ts
+++ b/frontend/src/features/analytics/lib/chartTheme.ts
@@ -1,0 +1,75 @@
+/**
+ * Resolves the app's design tokens into the colors an ECharts option needs
+ * (`EChart.tsx` calls this on every render, so a theme toggle always rebuilds
+ * with fresh colors — roadmap slice 032).
+ *
+ * Reads the live CSS custom properties `index.css` defines on `:root`/`.dark`
+ * — `--foreground`, `--muted-foreground`, `--border` for ink/grid, and the
+ * three fixed categorical `--chart-series-*` hues (data-viz method: fixed
+ * hue order, never cycled; the first slot doubles as the single-hue color
+ * for a one-series chart) — so a chart always matches the app's live theme
+ * rather than a value baked in at build time. Falls back to a value drawn
+ * from the same tokens when a property is unset (jsdom under test, or a
+ * runtime that has not applied `index.css` yet), so the resolver never
+ * fails — it degrades to a plausible default instead.
+ */
+
+import type { Theme } from "@/lib/theme";
+
+export interface ChartTheme {
+  mode: Theme;
+  /** Primary text/axis-label ink (`--foreground`). */
+  ink: string;
+  /** Secondary ink for axis ticks and captions (`--muted-foreground`). */
+  mutedInk: string;
+  /** Recessive gridline/axis-line color (`--border`). */
+  grid: string;
+  /** Three fixed categorical hues, in order — never reassigned by data. */
+  series: readonly [string, string, string];
+}
+
+const FALLBACK: Record<Theme, ChartTheme> = {
+  light: {
+    mode: "light",
+    ink: "#20242d",
+    mutedInk: "#6b7280",
+    grid: "#dfe1e6",
+    series: ["#2a78d6", "#eb6834", "#1baf7a"],
+  },
+  dark: {
+    mode: "dark",
+    ink: "#e8ecf1",
+    mutedInk: "#9aa3ad",
+    grid: "#33394a",
+    series: ["#3987e5", "#d95926", "#199e70"],
+  },
+};
+
+function cssVar(name: string, fallback: string): string {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return fallback;
+  }
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+  return value.length > 0 ? value : fallback;
+}
+
+/** Resolves the current chart theme for `mode`. The categorical hue *order*
+ * is the CVD-safety mechanism (data-viz method) and never changes, but each
+ * slot's exact step is still read live so it stays in sync with a token
+ * edit in `index.css` without a code change here. */
+export function resolveChartTheme(mode: Theme): ChartTheme {
+  const base = FALLBACK[mode];
+  return {
+    mode,
+    ink: cssVar("--foreground", base.ink),
+    mutedInk: cssVar("--muted-foreground", base.mutedInk),
+    grid: cssVar("--border", base.grid),
+    series: [
+      cssVar("--chart-series-1", base.series[0]),
+      cssVar("--chart-series-2", base.series[1]),
+      cssVar("--chart-series-3", base.series[2]),
+    ],
+  };
+}

--- a/frontend/src/features/analytics/lib/echartsSetup.ts
+++ b/frontend/src/features/analytics/lib/echartsSetup.ts
@@ -1,0 +1,28 @@
+/**
+ * Registers the modular ECharts pieces the Analytics page's charts actually
+ * use — `import * as echarts from "echarts"` would pull in every chart type,
+ * every component and the SVG renderer none of these cards need, which is
+ * exactly what roadmap slice 032 asks this module to avoid (route-level lazy
+ * loading keeps it out of the Live Map bundle in the first place; this keeps
+ * the Analytics chunk itself lean once loaded).
+ *
+ * `EChart.tsx` imports this module once for its side effect (`echarts.use`)
+ * before the first `echarts.init` call.
+ */
+import { BarChart, LineChart } from "echarts/charts";
+import {
+  GridComponent,
+  LegendComponent,
+  TooltipComponent,
+} from "echarts/components";
+import * as echarts from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
+
+echarts.use([
+  BarChart,
+  LineChart,
+  GridComponent,
+  LegendComponent,
+  TooltipComponent,
+  CanvasRenderer,
+]);

--- a/frontend/src/features/analytics/lib/format.test.ts
+++ b/frontend/src/features/analytics/lib/format.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  convertDistance,
+  distanceUnitLabel,
+  formatCompactNumber,
+  formatWindowLabel,
+  humanizeSlug,
+} from "@/features/analytics/lib/format";
+
+describe("distanceUnitLabel", () => {
+  it("returns nm for aviation and km for metric", () => {
+    expect(distanceUnitLabel("aviation")).toBe("nm");
+    expect(distanceUnitLabel("metric")).toBe("km");
+  });
+});
+
+describe("convertDistance", () => {
+  it("passes nm through unchanged for aviation units", () => {
+    expect(convertDistance(141.8, "aviation")).toBe(141.8);
+  });
+
+  it("converts nm to km for metric units", () => {
+    expect(convertDistance(100, "metric")).toBeCloseTo(185.2, 1);
+  });
+});
+
+describe("formatCompactNumber", () => {
+  it("compacts large numbers", () => {
+    expect(formatCompactNumber(1200)).toMatch(/1\.2K/i);
+  });
+
+  it("leaves small numbers as-is", () => {
+    expect(formatCompactNumber(48)).toBe("48");
+  });
+});
+
+describe("formatWindowLabel", () => {
+  it("renders a single date when the window is one day", () => {
+    const label = formatWindowLabel({
+      preset: "today",
+      from: "2026-08-31T00:00:00.000Z",
+      to: "2026-09-01T00:00:00.000Z",
+      first_day: "2026-08-31",
+      last_day: "2026-08-31",
+      timezone: "America/Los_Angeles",
+    });
+    expect(label).toContain("Aug 31, 2026");
+    expect(label).toContain("America/Los_Angeles");
+    expect(label).not.toContain("–");
+  });
+
+  it("renders a range when the window spans multiple days", () => {
+    const label = formatWindowLabel({
+      preset: "7d",
+      from: "2026-08-25T00:00:00.000Z",
+      to: "2026-09-01T00:00:00.000Z",
+      first_day: "2026-08-25",
+      last_day: "2026-08-31",
+      timezone: "UTC",
+    });
+    expect(label).toContain("Aug 25, 2026");
+    expect(label).toContain("Aug 31, 2026");
+    expect(label).toContain("–");
+  });
+
+  it("falls back to the raw string for an unparseable day", () => {
+    const label = formatWindowLabel({
+      preset: null,
+      from: "x",
+      to: "y",
+      first_day: "not-a-date",
+      last_day: "not-a-date",
+      timezone: "UTC",
+    });
+    expect(label).toContain("not-a-date");
+  });
+});
+
+describe("humanizeSlug", () => {
+  it("replaces underscores and capitalizes the first letter", () => {
+    expect(humanizeSlug("military_transport")).toBe("Military transport");
+  });
+
+  it("passes a single word through with capitalization", () => {
+    expect(humanizeSlug("civilian")).toBe("Civilian");
+  });
+});

--- a/frontend/src/features/analytics/lib/format.ts
+++ b/frontend/src/features/analytics/lib/format.ts
@@ -1,0 +1,76 @@
+/**
+ * Analytics-specific formatting: the echoed window's subtle date range,
+ * compact counts for chart tooltips/axis labels, and unit-aware distance
+ * conversion for chart values (as opposed to
+ * `features/aircraft-detail/lib/format.ts`'s `formatDistance`, which returns
+ * a display string — charts need the bare converted number for the axis
+ * scale, and only format it to a string in the tooltip).
+ */
+
+import type { AnalyticsWindow } from "@/lib/api/analytics";
+import type { UnitSystem } from "@/lib/api/config";
+
+const NM_PER_KM = 1 / 1.852;
+
+/** `"nm"` or `"km"` — the axis/tooltip suffix for a unit-aware distance. */
+export function distanceUnitLabel(units: UnitSystem): "nm" | "km" {
+  return units === "metric" ? "km" : "nm";
+}
+
+/** Converts a canonical nautical-mile distance to the display unit's bare
+ * number (no suffix), rounded to one decimal — the numeric value a chart
+ * plots, not the string a label shows. */
+export function convertDistance(distanceNm: number, units: UnitSystem): number {
+  const value = units === "metric" ? distanceNm / NM_PER_KM : distanceNm;
+  return Math.round(value * 10) / 10;
+}
+
+/** `"1.2K"`, `"48"`, `"3.4M"` — a compact count for chart axes and dense
+ * tooltips, where `formatMessageCount`'s full `12,345` would crowd the
+ * label. */
+export function formatCompactNumber(value: number): string {
+  return new Intl.NumberFormat(undefined, { notation: "compact" }).format(
+    value,
+  );
+}
+
+/** Parses a `YYYY-MM-DD` receiver-local calendar date (`AnalyticsWindow`'s
+ * `first_day`/`last_day`) as that day's UTC midnight, so formatting it never
+ * shifts a day backward in a browser west of UTC — the string already *is*
+ * the receiver-local date; there is nothing left to convert. */
+function parseCalendarDay(day: string): Date {
+  return new Date(`${day}T00:00:00Z`);
+}
+
+function formatCalendarDay(day: string): string {
+  const date = parseCalendarDay(day);
+  if (Number.isNaN(date.getTime())) {
+    return day;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    timeZone: "UTC",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+/** `"Aug 25 – Aug 31, 2026 · America/Los_Angeles"` (or a single date when
+ * the window is one day) — the subtle window caption every analytics card
+ * shows beneath its title, so a chart is never read against the wrong
+ * range. */
+export function formatWindowLabel(window: AnalyticsWindow): string {
+  const range =
+    window.first_day === window.last_day
+      ? formatCalendarDay(window.first_day)
+      : `${formatCalendarDay(window.first_day)} – ${formatCalendarDay(window.last_day)}`;
+  return `${range} · ${window.timezone}`;
+}
+
+/** `"military_transport"` -> `"Military transport"` — a plain-language
+ * fallback for the short mission-category slugs the analytics aircraft rows
+ * carry, when no richer classification lookup applies. */
+export function humanizeSlug(slug: string): string {
+  const spaced = slug.replace(/_/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}

--- a/frontend/src/features/analytics/lib/urlState.test.ts
+++ b/frontend/src/features/analytics/lib/urlState.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_PRESET,
+  parseAnalyticsPreset,
+  serializeAnalyticsPreset,
+} from "@/features/analytics/lib/urlState";
+
+describe("parseAnalyticsPreset", () => {
+  it("defaults to today when the param is absent", () => {
+    expect(parseAnalyticsPreset(new URLSearchParams())).toBe("today");
+  });
+
+  it("reads a valid preset", () => {
+    expect(parseAnalyticsPreset(new URLSearchParams("preset=7d"))).toBe("7d");
+    expect(parseAnalyticsPreset(new URLSearchParams("preset=t0"))).toBe("t0");
+  });
+
+  it("defaults on a malformed value rather than throwing", () => {
+    expect(parseAnalyticsPreset(new URLSearchParams("preset=bogus"))).toBe(
+      "today",
+    );
+  });
+});
+
+describe("serializeAnalyticsPreset", () => {
+  it("omits the param for the default preset", () => {
+    expect(serializeAnalyticsPreset(DEFAULT_PRESET).toString()).toBe("");
+  });
+
+  it("writes the param for a non-default preset", () => {
+    expect(serializeAnalyticsPreset("30d").toString()).toBe("preset=30d");
+  });
+
+  it("round-trips every preset through parse -> serialize -> parse", () => {
+    const presets: (typeof DEFAULT_PRESET | "7d" | "30d" | "ytd" | "t0")[] = [
+      "today",
+      "7d",
+      "30d",
+      "ytd",
+      "t0",
+    ];
+    for (const preset of presets) {
+      const params = serializeAnalyticsPreset(preset);
+      expect(parseAnalyticsPreset(params)).toBe(preset);
+    }
+  });
+});

--- a/frontend/src/features/analytics/lib/urlState.ts
+++ b/frontend/src/features/analytics/lib/urlState.ts
@@ -1,0 +1,46 @@
+/**
+ * The Analytics page's preset <-> query string, round-tripped through one
+ * key: `preset` (SPEC §58: Today / 7 days / 30 days / This year / Since T0).
+ * Mirrors `features/aircraft-page/lib/urlState.ts`'s split — pure
+ * `URLSearchParams` in and out, so this half is unit-testable without a
+ * router. Only written when it differs from the default, so `/analytics`
+ * and `/analytics?preset=today` are the same page.
+ */
+
+import { ANALYTICS_PRESETS, type AnalyticsPreset } from "@/lib/api/analytics";
+
+export const DEFAULT_PRESET: AnalyticsPreset = "today";
+
+const KEY = "preset";
+
+function isAnalyticsPreset(value: string): value is AnalyticsPreset {
+  return (ANALYTICS_PRESETS as readonly string[]).includes(value);
+}
+
+/** Restores the preset from a query string, defaulting to `"today"` when
+ * absent or malformed rather than rejecting the whole URL. */
+export function parseAnalyticsPreset(params: URLSearchParams): AnalyticsPreset {
+  const raw = params.get(KEY);
+  return raw !== null && isAnalyticsPreset(raw) ? raw : DEFAULT_PRESET;
+}
+
+/** Builds the query-string representation of `preset` — empty for the
+ * default, so a shared link to the default view stays short. */
+export function serializeAnalyticsPreset(
+  preset: AnalyticsPreset,
+): URLSearchParams {
+  const params = new URLSearchParams();
+  if (preset !== DEFAULT_PRESET) {
+    params.set(KEY, preset);
+  }
+  return params;
+}
+
+/** Human labels for the preset selector, in SPEC §58's documented order. */
+export const PRESET_LABELS: Record<AnalyticsPreset, string> = {
+  today: "Today",
+  "7d": "7 days",
+  "30d": "30 days",
+  ytd: "This year",
+  t0: "Since T0",
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,6 +35,13 @@
   --sidebar: oklch(0.97 0.004 240);
   --sidebar-foreground: oklch(0.2 0.03 250);
   --sidebar-border: oklch(0.9 0.006 240);
+
+  /* Chart categorical series (slice 032) — three validated, CVD-safe hues in
+   * fixed order (never cycled/reassigned): blue, orange, aqua. Series 1
+   * doubles as the single-hue color for a chart with only one series. */
+  --chart-series-1: #2a78d6;
+  --chart-series-2: #eb6834;
+  --chart-series-3: #1baf7a;
 }
 
 .dark {
@@ -61,6 +68,13 @@
   --sidebar: oklch(0.125 0.02 250);
   --sidebar-foreground: oklch(0.93 0.01 235);
   --sidebar-border: oklch(0.24 0.02 250);
+
+  /* Chart categorical series — the same three hues, stepped for the dark
+   * surface (docs/DEVELOPMENT.md's data-viz palette; see index.css light
+   * block for the ordering rationale). */
+  --chart-series-1: #3987e5;
+  --chart-series-2: #d95926;
+  --chart-series-3: #199e70;
 }
 
 @theme inline {

--- a/frontend/src/lib/api/analytics.test.ts
+++ b/frontend/src/lib/api/analytics.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  AnalyticsApiError,
+  getAnalyticsClassificationActivity,
+  getAnalyticsDaily,
+  getAnalyticsRarity,
+  getAnalyticsTopAircraft,
+  getAnalyticsTopOperators,
+  getAnalyticsTopTypes,
+} from "@/lib/api/analytics";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+const EMPTY_WINDOW = {
+  preset: "today",
+  from: "2026-08-31T00:00:00.000Z",
+  to: "2026-09-01T00:00:00.000Z",
+  first_day: "2026-08-31",
+  last_day: "2026-08-31",
+  timezone: "UTC",
+};
+
+describe("getAnalyticsDaily", () => {
+  it("sends only the preset by default", async () => {
+    const fetchMock = vi.fn((_input?: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(jsonResponse({ window: EMPTY_WINDOW, items: [] })),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getAnalyticsDaily({ preset: "7d" });
+
+    const url = new URL(
+      String(fetchMock.mock.calls[0]?.[0]),
+      "http://localhost",
+    );
+    expect(url.pathname).toBe("/api/v1/analytics/daily");
+    expect(url.searchParams.get("preset")).toBe("7d");
+    expect(url.searchParams.has("limit")).toBe(false);
+  });
+
+  it("throws AnalyticsApiError carrying the §2.5 code and message on a non-2xx response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_input?: RequestInfo | URL, _init?: RequestInit) =>
+        Promise.resolve(
+          jsonResponse(
+            {
+              error: {
+                code: "validation_error",
+                message: "bad preset",
+                detail: null,
+              },
+            },
+            422,
+          ),
+        ),
+      ),
+    );
+
+    await expect(getAnalyticsDaily({ preset: "today" })).rejects.toMatchObject({
+      status: 422,
+      code: "validation_error",
+      message: "bad preset",
+    });
+  });
+
+  it("still throws AnalyticsApiError when the error response has no JSON body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_input?: RequestInfo | URL, _init?: RequestInit) =>
+        Promise.resolve(new Response("", { status: 500 })),
+      ),
+    );
+
+    const error = await getAnalyticsDaily({ preset: "today" }).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(AnalyticsApiError);
+    expect((error as AnalyticsApiError).status).toBe(500);
+    expect((error as AnalyticsApiError).code).toBeNull();
+  });
+});
+
+describe("getAnalyticsClassificationActivity", () => {
+  it("requests the classification-activity path", async () => {
+    const fetchMock = vi.fn((_input?: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(
+        jsonResponse({
+          window: EMPTY_WINDOW,
+          military: 0,
+          government: 0,
+          law_enforcement: 0,
+          interesting: 0,
+          series: [],
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getAnalyticsClassificationActivity({ preset: "ytd" });
+
+    const url = new URL(
+      String(fetchMock.mock.calls[0]?.[0]),
+      "http://localhost",
+    );
+    expect(url.pathname).toBe("/api/v1/analytics/classification-activity");
+    expect(url.searchParams.get("preset")).toBe("ytd");
+  });
+});
+
+describe("ranking endpoints", () => {
+  it("getAnalyticsTopAircraft includes limit when given", async () => {
+    const fetchMock = vi.fn((_input?: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(jsonResponse({ window: EMPTY_WINDOW, items: [] })),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getAnalyticsTopAircraft({ preset: "t0", limit: 5 });
+
+    const url = new URL(
+      String(fetchMock.mock.calls[0]?.[0]),
+      "http://localhost",
+    );
+    expect(url.pathname).toBe("/api/v1/analytics/top-aircraft");
+    expect(url.searchParams.get("limit")).toBe("5");
+  });
+
+  it("getAnalyticsTopTypes and getAnalyticsTopOperators hit their own paths", async () => {
+    const fetchMock = vi.fn((_input?: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(jsonResponse({ window: EMPTY_WINDOW, items: [] })),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getAnalyticsTopTypes({ preset: "30d" });
+    await getAnalyticsTopOperators({ preset: "30d" });
+
+    expect(
+      new URL(String(fetchMock.mock.calls[0]?.[0]), "http://localhost")
+        .pathname,
+    ).toBe("/api/v1/analytics/top-types");
+    expect(
+      new URL(String(fetchMock.mock.calls[1]?.[0]), "http://localhost")
+        .pathname,
+    ).toBe("/api/v1/analytics/top-operators");
+  });
+});
+
+describe("getAnalyticsRarity", () => {
+  it("includes limit and max_sightings when given", async () => {
+    const fetchMock = vi.fn((_input?: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(
+        jsonResponse({
+          window: EMPTY_WINDOW,
+          never_seen_before: 0,
+          rare_max_sightings: 2,
+          rare_max_type_aircraft: 2,
+          rare_aircraft: [],
+          rare_types: [],
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getAnalyticsRarity({ preset: "today", limit: 8, maxSightings: 3 });
+
+    const url = new URL(
+      String(fetchMock.mock.calls[0]?.[0]),
+      "http://localhost",
+    );
+    expect(url.pathname).toBe("/api/v1/analytics/rarity");
+    expect(url.searchParams.get("limit")).toBe("8");
+    expect(url.searchParams.get("max_sightings")).toBe("3");
+  });
+
+  it("omits limit and max_sightings when not given", async () => {
+    const fetchMock = vi.fn((_input?: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(
+        jsonResponse({
+          window: EMPTY_WINDOW,
+          never_seen_before: 0,
+          rare_max_sightings: 2,
+          rare_max_type_aircraft: 2,
+          rare_aircraft: [],
+          rare_types: [],
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getAnalyticsRarity({ preset: "today" });
+
+    const url = new URL(
+      String(fetchMock.mock.calls[0]?.[0]),
+      "http://localhost",
+    );
+    expect(url.searchParams.has("limit")).toBe(false);
+    expect(url.searchParams.has("max_sightings")).toBe(false);
+  });
+});

--- a/frontend/src/lib/api/analytics.ts
+++ b/frontend/src/lib/api/analytics.ts
@@ -1,0 +1,317 @@
+/**
+ * Typed client for the Analytics endpoints — `GET /api/v1/analytics/*`
+ * (`docs/API.md` §3.7, roadmap slice 031/032). Six of the seven §3.7
+ * endpoints are covered here; `/analytics/summary` feeds a separate
+ * today-at-a-glance widget (SPEC §59) outside this slice's scope.
+ *
+ * Every endpoint takes the same window parameters and echoes back the
+ * `AnalyticsWindow` it actually resolved (§3.7: presets resolve against the
+ * *receiver's* local calendar, never the browser's), so every response type
+ * here carries a `window` field the caller renders rather than re-derives.
+ *
+ * Reuses the `{"error": {...}}` envelope pattern `lib/api/sightings.ts`
+ * established for `/api/v1` — duplicated rather than imported so this module
+ * stays a self-contained read of one small file, the same call every other
+ * `/api/v1` client in this directory makes.
+ */
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+/** §3.7's time presets, spelled as the query values. */
+export type AnalyticsPreset = "today" | "7d" | "30d" | "ytd" | "t0";
+
+export const ANALYTICS_PRESETS: readonly AnalyticsPreset[] = [
+  "today",
+  "7d",
+  "30d",
+  "ytd",
+  "t0",
+];
+
+/** The window an analytics response was actually computed over — echoed on
+ * every §3.7 payload. `first_day`/`last_day` are receiver-local calendar
+ * dates (`YYYY-MM-DD`). */
+export interface AnalyticsWindow {
+  preset: AnalyticsPreset | null;
+  from: string;
+  to: string;
+  first_day: string;
+  last_day: string;
+  timezone: string;
+}
+
+/** One receiver-local day of the §3.7 `daily` series. `receiver_*` fields are
+ * slice 033's joined activity for the same day, `null` where that slice
+ * recorded none. */
+export interface AnalyticsDailyRow {
+  day: string;
+  unique_aircraft: number;
+  new_aircraft: number;
+  sightings: number;
+  interesting: number;
+  military: number;
+  government: number;
+  law_enforcement: number;
+  max_range_nm: number | null;
+  busiest_hour: number | null;
+  receiver_messages: number | null;
+  receiver_positions: number | null;
+  receiver_aircraft_max: number | null;
+  receiver_max_range_nm: number | null;
+}
+
+export interface AnalyticsDailyResponse {
+  window: AnalyticsWindow;
+  items: AnalyticsDailyRow[];
+}
+
+/** One airframe in a §3.7 ranking or rarity list. `classification` is a
+ * short mission-category slug (e.g. `"military_transport"`), not the full
+ * `Classification` block the live/history APIs return. */
+export interface AnalyticsAircraftRow {
+  icao: string;
+  registration: string | null;
+  type: string | null;
+  model: string | null;
+  operator: string | null;
+  operator_group: string | null;
+  classification: string | null;
+  military: boolean;
+  government: boolean;
+  law_enforcement: boolean;
+  /** Sightings inside the window; the lifetime total for a since-T0 window. */
+  sightings: number;
+  first_seen_at: string;
+  last_seen_at: string;
+  max_range_nm: number | null;
+}
+
+export interface AnalyticsAircraftResponse {
+  window: AnalyticsWindow;
+  items: AnalyticsAircraftRow[];
+}
+
+/** One type designator or operator group in a §3.7 ranking. `key` is the
+ * stable identifier, `label` what to display. */
+export interface AnalyticsGroupRow {
+  key: string;
+  label: string | null;
+  sightings: number;
+  unique_aircraft: number;
+  days_seen: number;
+  first_seen_at: string | null;
+  last_seen_at: string | null;
+}
+
+export interface AnalyticsGroupResponse {
+  window: AnalyticsWindow;
+  items: AnalyticsGroupRow[];
+}
+
+export interface AnalyticsClassificationResponse {
+  window: AnalyticsWindow;
+  military: number;
+  government: number;
+  law_enforcement: number;
+  interesting: number;
+  series: AnalyticsDailyRow[];
+}
+
+/** One locally rare type designator (receiver-relative, since T0). */
+export interface AnalyticsRareType {
+  type: string;
+  unique_aircraft: number;
+  total_sightings: number;
+  first_seen_at: string;
+  last_seen_at: string;
+}
+
+export interface AnalyticsRarityResponse {
+  window: AnalyticsWindow;
+  /** Airframes whose first-ever observation fell inside the window. */
+  never_seen_before: number;
+  rare_max_sightings: number;
+  rare_max_type_aircraft: number;
+  rare_aircraft: AnalyticsAircraftRow[];
+  rare_types: AnalyticsRareType[];
+}
+
+interface ApiV1ErrorBody {
+  error?: { code?: string; message?: string; detail?: unknown };
+}
+
+/** Thrown for any non-2xx response. `code` is the §2.5 machine-readable
+ * slug, `null` when the response did not carry the documented envelope. */
+export class AnalyticsApiError extends Error {
+  readonly status: number;
+  readonly code: string | null;
+
+  constructor(status: number, body: ApiV1ErrorBody | undefined) {
+    super(body?.error?.message ?? `Request failed with status ${status}`);
+    this.name = "AnalyticsApiError";
+    this.status = status;
+    this.code = body?.error?.code ?? null;
+  }
+}
+
+async function apiV1Fetch<T>(path: string): Promise<T> {
+  const response = await fetch(path);
+  if (!response.ok) {
+    let body: ApiV1ErrorBody | undefined;
+    try {
+      body = (await response.json()) as ApiV1ErrorBody;
+    } catch {
+      body = undefined;
+    }
+    throw new AnalyticsApiError(response.status, body);
+  }
+  return (await response.json()) as T;
+}
+
+/** Every §3.7 endpoint takes the same `preset` (and an optional `limit` for
+ * the ranking endpoints). This slice only ever drives the presets, never an
+ * explicit `from`/`to` range — that stays available to a future comparison
+ * feature (out of scope here, roadmap slice 032). */
+export interface AnalyticsWindowParams {
+  preset: AnalyticsPreset;
+}
+
+export interface AnalyticsTopParams extends AnalyticsWindowParams {
+  limit?: number;
+}
+
+export interface AnalyticsRarityParams extends AnalyticsTopParams {
+  maxSightings?: number;
+}
+
+function windowQuery(params: AnalyticsWindowParams): URLSearchParams {
+  return new URLSearchParams({ preset: params.preset });
+}
+
+function topQuery(params: AnalyticsTopParams): URLSearchParams {
+  const search = windowQuery(params);
+  if (params.limit !== undefined) {
+    search.set("limit", String(params.limit));
+  }
+  return search;
+}
+
+export function getAnalyticsDaily(
+  params: AnalyticsWindowParams,
+): Promise<AnalyticsDailyResponse> {
+  return apiV1Fetch<AnalyticsDailyResponse>(
+    `/api/v1/analytics/daily?${windowQuery(params).toString()}`,
+  );
+}
+
+export function getAnalyticsClassificationActivity(
+  params: AnalyticsWindowParams,
+): Promise<AnalyticsClassificationResponse> {
+  return apiV1Fetch<AnalyticsClassificationResponse>(
+    `/api/v1/analytics/classification-activity?${windowQuery(params).toString()}`,
+  );
+}
+
+export function getAnalyticsTopAircraft(
+  params: AnalyticsTopParams,
+): Promise<AnalyticsAircraftResponse> {
+  return apiV1Fetch<AnalyticsAircraftResponse>(
+    `/api/v1/analytics/top-aircraft?${topQuery(params).toString()}`,
+  );
+}
+
+export function getAnalyticsTopTypes(
+  params: AnalyticsTopParams,
+): Promise<AnalyticsGroupResponse> {
+  return apiV1Fetch<AnalyticsGroupResponse>(
+    `/api/v1/analytics/top-types?${topQuery(params).toString()}`,
+  );
+}
+
+export function getAnalyticsTopOperators(
+  params: AnalyticsTopParams,
+): Promise<AnalyticsGroupResponse> {
+  return apiV1Fetch<AnalyticsGroupResponse>(
+    `/api/v1/analytics/top-operators?${topQuery(params).toString()}`,
+  );
+}
+
+export function getAnalyticsRarity(
+  params: AnalyticsRarityParams,
+): Promise<AnalyticsRarityResponse> {
+  const search = topQuery(params);
+  if (params.maxSightings !== undefined) {
+    search.set("max_sightings", String(params.maxSightings));
+  }
+  return apiV1Fetch<AnalyticsRarityResponse>(
+    `/api/v1/analytics/rarity?${search.toString()}`,
+  );
+}
+
+export const analyticsQueryKeys = {
+  daily: (params: AnalyticsWindowParams) =>
+    ["analytics", "daily", params] as const,
+  classification: (params: AnalyticsWindowParams) =>
+    ["analytics", "classification-activity", params] as const,
+  topAircraft: (params: AnalyticsTopParams) =>
+    ["analytics", "top-aircraft", params] as const,
+  topTypes: (params: AnalyticsTopParams) =>
+    ["analytics", "top-types", params] as const,
+  topOperators: (params: AnalyticsTopParams) =>
+    ["analytics", "top-operators", params] as const,
+  rarity: (params: AnalyticsRarityParams) =>
+    ["analytics", "rarity", params] as const,
+};
+
+export function useAnalyticsDailyQuery(
+  params: AnalyticsWindowParams,
+): UseQueryResult<AnalyticsDailyResponse> {
+  return useQuery({
+    queryKey: analyticsQueryKeys.daily(params),
+    queryFn: () => getAnalyticsDaily(params),
+  });
+}
+
+export function useAnalyticsClassificationActivityQuery(
+  params: AnalyticsWindowParams,
+): UseQueryResult<AnalyticsClassificationResponse> {
+  return useQuery({
+    queryKey: analyticsQueryKeys.classification(params),
+    queryFn: () => getAnalyticsClassificationActivity(params),
+  });
+}
+
+export function useAnalyticsTopAircraftQuery(
+  params: AnalyticsTopParams,
+): UseQueryResult<AnalyticsAircraftResponse> {
+  return useQuery({
+    queryKey: analyticsQueryKeys.topAircraft(params),
+    queryFn: () => getAnalyticsTopAircraft(params),
+  });
+}
+
+export function useAnalyticsTopTypesQuery(
+  params: AnalyticsTopParams,
+): UseQueryResult<AnalyticsGroupResponse> {
+  return useQuery({
+    queryKey: analyticsQueryKeys.topTypes(params),
+    queryFn: () => getAnalyticsTopTypes(params),
+  });
+}
+
+export function useAnalyticsTopOperatorsQuery(
+  params: AnalyticsTopParams,
+): UseQueryResult<AnalyticsGroupResponse> {
+  return useQuery({
+    queryKey: analyticsQueryKeys.topOperators(params),
+    queryFn: () => getAnalyticsTopOperators(params),
+  });
+}
+
+export function useAnalyticsRarityQuery(
+  params: AnalyticsRarityParams,
+): UseQueryResult<AnalyticsRarityResponse> {
+  return useQuery({
+    queryKey: analyticsQueryKeys.rarity(params),
+    queryFn: () => getAnalyticsRarity(params),
+  });
+}

--- a/frontend/src/pages/AnalyticsPage.lazyRoute.test.tsx
+++ b/frontend/src/pages/AnalyticsPage.lazyRoute.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Confirms the Analytics route (roadmap slice 032) actually works end to
+ * end through the real, lazily-loaded route definition in `src/routes.tsx`
+ * — as opposed to every other Analytics test, which renders
+ * `features/analytics/AnalyticsPage` (or `pages/AnalyticsPage`'s
+ * synchronous re-export) directly. Exercises the `React.lazy` +
+ * `Suspense` wiring itself: the fallback shows first, then the real page.
+ */
+import { QueryClientProvider } from "@tanstack/react-query";
+import { act, render, screen } from "@testing-library/react";
+import { RouterProvider } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { queryClient } from "@/lib/queryClient";
+import { router } from "@/routes";
+import { installAnalyticsApiMock } from "@/test/analyticsApiMock";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Analytics lazy route", () => {
+  it("loads the Analytics page through the router's lazy import", async () => {
+    installAnalyticsApiMock();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    );
+
+    // Start at the Live Map (the router's index route) and navigate over
+    // to Analytics — the same way a user reaches it — so the Suspense
+    // fallback and the real, dynamically-imported page both get a chance
+    // to render.
+    await act(async () => {
+      await router.navigate("/analytics");
+    });
+
+    // The dynamic import behind `React.lazy` genuinely fetches and
+    // evaluates a module under Vitest's transform pipeline (unlike every
+    // other synchronous mock in this suite), so this can take longer than
+    // the default poll window under load — give it more room.
+    expect(
+      await screen.findByRole(
+        "heading",
+        { level: 1, name: "Analytics" },
+        { timeout: 10000 },
+      ),
+    ).toBeInTheDocument();
+  }, 15000);
+});

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -1,8 +1,1 @@
-import { requireNavItem } from "@/components/shell/nav-items";
-import { PlaceholderPage } from "@/pages/PlaceholderPage";
-
-const item = requireNavItem("/analytics");
-
-export function AnalyticsPage() {
-  return <PlaceholderPage title={item.label} description={item.description} />;
-}
+export { AnalyticsPage } from "@/features/analytics/AnalyticsPage";

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from "react";
 import { createBrowserRouter } from "react-router-dom";
 
 import { AppShell } from "@/components/shell/AppShell";
@@ -6,12 +7,27 @@ import { SetupWizardPage } from "@/features/setup/SetupWizardPage";
 import { AircraftDetailPage } from "@/pages/AircraftDetailPage";
 import { AircraftPage } from "@/pages/AircraftPage";
 import { AlertsPage } from "@/pages/AlertsPage";
-import { AnalyticsPage } from "@/pages/AnalyticsPage";
 import { LiveMapPage } from "@/pages/LiveMapPage";
 import { ReceiverPage } from "@/pages/ReceiverPage";
 import { SettingsPage } from "@/pages/SettingsPage";
 import { SightingDetailPage } from "@/pages/SightingDetailPage";
 import { SightingsPage } from "@/pages/SightingsPage";
+
+/**
+ * The Analytics page pulls in ECharts (roadmap slice 032), which the Live
+ * Map — the app's index route, and the one every session loads first — has
+ * no use for. Route-level `lazy` keeps that chunk out of the initial bundle
+ * entirely; it only downloads when a user actually navigates here.
+ */
+/* eslint-disable react-refresh/only-export-components -- this route config
+   module's only real export is `router`; the lazy-loaded component binding
+   has to live beside the route tree that references it. */
+const AnalyticsPage = lazy(() =>
+  import("@/pages/AnalyticsPage").then((module) => ({
+    default: module.AnalyticsPage,
+  })),
+);
+/* eslint-enable react-refresh/only-export-components */
 
 export const router = createBrowserRouter([
   {
@@ -29,7 +45,20 @@ export const router = createBrowserRouter([
           { path: "aircraft/:icao", element: <AircraftDetailPage /> },
           { path: "sightings", element: <SightingsPage /> },
           { path: "sightings/:id", element: <SightingDetailPage /> },
-          { path: "analytics", element: <AnalyticsPage /> },
+          {
+            path: "analytics",
+            element: (
+              <Suspense
+                fallback={
+                  <p className="p-8 text-sm text-muted-foreground">
+                    Loading analytics…
+                  </p>
+                }
+              >
+                <AnalyticsPage />
+              </Suspense>
+            ),
+          },
           { path: "receiver", element: <ReceiverPage /> },
           { path: "alerts", element: <AlertsPage /> },
           { path: "settings", element: <SettingsPage /> },

--- a/frontend/src/test/analyticsApiMock.ts
+++ b/frontend/src/test/analyticsApiMock.ts
@@ -1,0 +1,129 @@
+import { vi } from "vitest";
+
+import type {
+  AnalyticsAircraftResponse,
+  AnalyticsClassificationResponse,
+  AnalyticsDailyResponse,
+  AnalyticsGroupResponse,
+  AnalyticsPreset,
+  AnalyticsRarityResponse,
+  AnalyticsWindow,
+} from "@/lib/api/analytics";
+import type { ReceiverInfo } from "@/lib/api/live";
+
+import { defaultReceiverInfo } from "@/test/aircraftApiMock";
+
+/** A plausible `AnalyticsWindow` for the given preset — every test fixture
+ * below echoes one, matching what a real response always carries
+ * (`docs/API.md` §3.7). */
+export function analyticsWindow(
+  preset: AnalyticsPreset = "today",
+): AnalyticsWindow {
+  return {
+    preset,
+    from: "2026-08-31T00:00:00.000Z",
+    to: "2026-09-01T00:00:00.000Z",
+    first_day: "2026-08-31",
+    last_day: "2026-08-31",
+    timezone: "America/Los_Angeles",
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export interface MockAnalyticsApiOptions {
+  receiver?: ReceiverInfo;
+  daily?: AnalyticsDailyResponse;
+  classification?: AnalyticsClassificationResponse;
+  topAircraft?: AnalyticsAircraftResponse;
+  topTypes?: AnalyticsGroupResponse;
+  topOperators?: AnalyticsGroupResponse;
+  rarity?: AnalyticsRarityResponse;
+}
+
+const EMPTY_DAILY: AnalyticsDailyResponse = {
+  window: analyticsWindow(),
+  items: [],
+};
+const EMPTY_CLASSIFICATION: AnalyticsClassificationResponse = {
+  window: analyticsWindow(),
+  military: 0,
+  government: 0,
+  law_enforcement: 0,
+  interesting: 0,
+  series: [],
+};
+const EMPTY_AIRCRAFT: AnalyticsAircraftResponse = {
+  window: analyticsWindow(),
+  items: [],
+};
+const EMPTY_GROUP: AnalyticsGroupResponse = {
+  window: analyticsWindow(),
+  items: [],
+};
+const EMPTY_RARITY: AnalyticsRarityResponse = {
+  window: analyticsWindow(),
+  never_seen_before: 0,
+  rare_max_sightings: 2,
+  rare_max_type_aircraft: 2,
+  rare_aircraft: [],
+  rare_types: [],
+};
+
+/** Installs a `global.fetch` stub serving `GET /api/v1/receiver` and every
+ * `/api/v1/analytics/*` endpoint the Analytics page (roadmap slice 032)
+ * queries, so its tests exercise the real API clients and TanStack Query
+ * hooks without a running backend. Any other URL throws, surfacing an
+ * un-mocked request as a test failure — the same contract
+ * `installSightingsApiMock` establishes. */
+export function installAnalyticsApiMock(options: MockAnalyticsApiOptions = {}) {
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const raw = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      const url = new URL(raw, "http://localhost");
+
+      if (url.pathname === "/api/v1/receiver" && method === "GET") {
+        return jsonResponse(options.receiver ?? defaultReceiverInfo());
+      }
+      if (url.pathname === "/api/v1/analytics/daily" && method === "GET") {
+        return jsonResponse(options.daily ?? EMPTY_DAILY);
+      }
+      if (
+        url.pathname === "/api/v1/analytics/classification-activity" &&
+        method === "GET"
+      ) {
+        return jsonResponse(options.classification ?? EMPTY_CLASSIFICATION);
+      }
+      if (
+        url.pathname === "/api/v1/analytics/top-aircraft" &&
+        method === "GET"
+      ) {
+        return jsonResponse(options.topAircraft ?? EMPTY_AIRCRAFT);
+      }
+      if (url.pathname === "/api/v1/analytics/top-types" && method === "GET") {
+        return jsonResponse(options.topTypes ?? EMPTY_GROUP);
+      }
+      if (
+        url.pathname === "/api/v1/analytics/top-operators" &&
+        method === "GET"
+      ) {
+        return jsonResponse(options.topOperators ?? EMPTY_GROUP);
+      }
+      if (url.pathname === "/api/v1/analytics/rarity" && method === "GET") {
+        return jsonResponse(options.rarity ?? EMPTY_RARITY);
+      }
+
+      throw new Error(`Unhandled fetch in test: ${method} ${raw}`);
+    },
+  );
+
+  vi.stubGlobal("fetch", fetchMock);
+
+  return { fetchMock };
+}

--- a/frontend/src/test/echartsMock.ts
+++ b/frontend/src/test/echartsMock.ts
@@ -1,0 +1,87 @@
+import { vi } from "vitest";
+
+/**
+ * A minimal stand-in for `echarts/core`'s `init`/`use`, used globally via
+ * `vi.mock("echarts/core", ...)` in `test/setup.ts`. ECharts' `CanvasRenderer`
+ * needs a real 2D canvas context, which jsdom does not provide — mocking the
+ * module (rather than the canvas) is the same approach this suite already
+ * takes for `maplibre-gl`'s WebGL requirement (`test/maplibreGlMock.ts`), and
+ * keeps every test that merely navigates through the Analytics route (e.g.
+ * the full-route sweep in `routes.test.tsx`) from touching real chart
+ * rendering at all.
+ *
+ * `EChart.tsx` (roadmap slice 032) is the only production code that calls
+ * `init`; its own tests use `getLastMockChart`/`resetEchartsMock` to assert
+ * `setOption`/`resize`/`dispose` calls and to drive `on("click", ...)`
+ * handlers directly.
+ */
+
+export type MockEventHandler = (params?: unknown) => void;
+
+export class MockEChartsInstance {
+  static instances: MockEChartsInstance[] = [];
+
+  readonly dom: Element;
+  /** Every `setOption` call's argument, in order — lets a test assert the
+   * final (or a specific) themed option without re-deriving it. */
+  readonly optionCalls: unknown[] = [];
+  disposed = false;
+  private readonly handlers = new Map<string, Set<MockEventHandler>>();
+
+  constructor(dom: Element) {
+    this.dom = dom;
+    MockEChartsInstance.instances.push(this);
+  }
+
+  setOption = vi.fn((option: unknown) => {
+    this.optionCalls.push(option);
+  });
+
+  resize = vi.fn();
+
+  on = vi.fn((event: string, handler: MockEventHandler) => {
+    if (!this.handlers.has(event)) {
+      this.handlers.set(event, new Set());
+    }
+    this.handlers.get(event)?.add(handler);
+  });
+
+  off = vi.fn((event: string, handler: MockEventHandler) => {
+    this.handlers.get(event)?.delete(handler);
+  });
+
+  dispose = vi.fn(() => {
+    this.disposed = true;
+  });
+
+  /** Test-only helper: invokes every handler registered for `event` (e.g.
+   * `"click"`) — simulates a user interacting with the (unrendered) chart. */
+  emit(event: string, params?: unknown): void {
+    for (const handler of this.handlers.get(event) ?? []) {
+      handler(params);
+    }
+  }
+}
+
+export const init = vi.fn(
+  (dom: Element): MockEChartsInstance => new MockEChartsInstance(dom),
+);
+export const use = vi.fn();
+
+/** Resets captured instances and call history between tests. */
+export function resetEchartsMock(): void {
+  MockEChartsInstance.instances = [];
+  init.mockClear();
+  use.mockClear();
+}
+
+/** Returns the most recently constructed mock chart instance. Throws if none
+ * exists yet — a test bug (asserting before the chart mounted), not a case
+ * to guard defensively against. */
+export function getLastMockChart(): MockEChartsInstance {
+  const instance = MockEChartsInstance.instances.at(-1);
+  if (!instance) {
+    throw new Error("No MockEChartsInstance instance has been constructed yet");
+  }
+  return instance;
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -3,8 +3,17 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach, vi } from "vitest";
 
+import * as echartsCoreMock from "@/test/echartsMock";
+import { resetEchartsMock } from "@/test/echartsMock";
 import { AttributionControlMock, MapLibreMockMap } from "@/test/maplibreGlMock";
 import { FakeWebSocket, resetWebSocketMock } from "@/test/webSocketMock";
+
+/**
+ * ECharts' `CanvasRenderer` requires a real 2D canvas context, which jsdom
+ * does not provide — mocked globally for the same reason MapLibre is below
+ * (`test/echartsMock.ts` has the full rationale).
+ */
+vi.mock("echarts/core", () => echartsCoreMock);
 
 /**
  * MapLibre GL JS requires a real WebGL context, which jsdom does not
@@ -113,4 +122,5 @@ Object.defineProperty(globalThis, "Image", {
 afterEach(() => {
   cleanup();
   resetWebSocketMock();
+  resetEchartsMock();
 });

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -877,7 +877,7 @@ slices:
     title: "Analytics page"
     phase: 5
     branch: "032-analytics-page"
-    status: planned
+    status: merged
     depends_on: ["031", "033"]
     objective: "Analytics UI with time presets and aviation-styled charts."
     scope:


### PR DESCRIPTION
## Slice
- **Slice ID:** 032 — Analytics page
- **Roadmap:** `planning/roadmap.yaml` slice 032 (phase 5)
- **Issue:** Closes #77

## Objective
Analytics UI with time presets and aviation-styled charts.

## Implementation summary
- Shared EChart wrapper: theme-rebuilding via pure buildOption(theme), resize-observing, disposed on unmount, role=img + aria-label + hidden data summary, No-data state
- Modular echarts/core imports + route-level lazy loading — ECharts is a separate 185 KB-gzip chunk, provably absent from the Live Map bundle
- Eight cards over the SPEC §58 set (top aircraft clickable to detail, types/operators, mil/gov/police stacked, daily counts, unit-aware max distance, receiver activity, never-seen-before, rarity as accessible tables); URL-persisted presets; validated 3-hue CVD-checked series palette added to the tokens
- Global echarts mock mirroring the maplibre pattern — no canvas in jsdom

## Acceptance criteria
- [x] all presets render correct data from fixture history; empty states handled
- [x] charts legible in both themes; text alternatives per chart (a11y checks in 048 build on these)

## Tests added/run
1057 passed; coverage 97.5%/91.3%. Reviewer re-ran gates.

## Performance / Security / Data considerations
Lazy chunking; no data changes; no secrets.

## Documentation updates
None required.

## Known limitations
The §3.7 summary endpoint is consumed by slice 036's widget, not here (scoped).

## Follow-up work
034 reuses the EChart wrapper; 036 today-at-a-glance.

## Fable self-review (SPEC §104)
- [x] Full diff inspected; bundle separation verified from build output; a11y pattern sound; no TODO/FIXME
- [x] Branch on dev tip; suite green
- [ ] CI green on this PR (gate before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)