### PR TITLE
Slice 043: Backup & restore

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
 [project.scripts]
 flightsite-serve = "flightsite.__main__:main"
 flightsite-capture = "flightsite.devtools.capture:main"
+flightsite-backup = "flightsite.backup.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/backend/src/flightsite/backup/__init__.py
+++ b/backend/src/flightsite/backup/__init__.py
@@ -1,0 +1,95 @@
+"""Version-aware, checksum-validated backup and restore (SPEC §72, slice 043).
+
+A FlightSite backup is one ``tar.gz`` under ``<data_dir>/backups/`` holding:
+
+======================= ========================================================
+``flightsite.sqlite3``  a ``VACUUM INTO`` snapshot of the database, safe to take
+                        while the persistence worker is writing (:mod:`.snapshot`)
+``config.yaml``         the non-secret configuration
+``secrets.yaml``        **only** with ``--include-secrets`` (``docs/SECURITY.md`` §3)
+``manifest.json``       FlightSite version, schema revision, creation time,
+                        per-file SHA-256, and metadata dataset versions
+======================= ========================================================
+
+Public entry points:
+
+* :func:`create_backup` — take one.
+* :func:`verify_archive` — validate one without touching anything.
+* :func:`restore_backup` — replace a data directory with one, deliberately.
+
+The command-line face of all three is :mod:`flightsite.backup.cli`
+(``flightsite-backup``); the operator-facing procedure is ``docs/BACKUP.md``.
+"""
+
+from __future__ import annotations
+
+from flightsite.backup.compat import SchemaCompatibility, SchemaRelation, check_schema
+from flightsite.backup.create import (
+    BACKUPS_DIRNAME,
+    BackupResult,
+    archive_name,
+    create_backup,
+    default_backup_dir,
+)
+from flightsite.backup.errors import (
+    ArchiveValidationError,
+    BackupError,
+    ConfirmationRequiredError,
+    ManifestError,
+    RestoreError,
+    SchemaCompatibilityError,
+    SnapshotError,
+)
+from flightsite.backup.manifest import (
+    ALLOWED_MEMBERS,
+    CONFIG_MEMBER,
+    DATABASE_MEMBER,
+    FORMAT_VERSION,
+    MANIFEST_MEMBER,
+    SECRETS_MEMBER,
+    FileEntry,
+    Manifest,
+    MetadataSourceEntry,
+    parse_manifest,
+)
+from flightsite.backup.restore import RestoreResult, restore_backup
+from flightsite.backup.verify import (
+    FileCheck,
+    VerificationReport,
+    inspect_archive,
+    verify_archive,
+)
+
+__all__ = [
+    "ALLOWED_MEMBERS",
+    "BACKUPS_DIRNAME",
+    "CONFIG_MEMBER",
+    "DATABASE_MEMBER",
+    "FORMAT_VERSION",
+    "MANIFEST_MEMBER",
+    "SECRETS_MEMBER",
+    "ArchiveValidationError",
+    "BackupError",
+    "BackupResult",
+    "ConfirmationRequiredError",
+    "FileCheck",
+    "FileEntry",
+    "Manifest",
+    "ManifestError",
+    "MetadataSourceEntry",
+    "RestoreError",
+    "RestoreResult",
+    "SchemaCompatibility",
+    "SchemaCompatibilityError",
+    "SchemaRelation",
+    "SnapshotError",
+    "VerificationReport",
+    "archive_name",
+    "check_schema",
+    "create_backup",
+    "default_backup_dir",
+    "inspect_archive",
+    "parse_manifest",
+    "restore_backup",
+    "verify_archive",
+]

--- a/backend/src/flightsite/backup/archive.py
+++ b/backend/src/flightsite/backup/archive.py
@@ -1,0 +1,183 @@
+"""Reading and writing the backup container (a ``tar.gz``).
+
+The container is deliberately boring: a gzip-compressed tar holding a flat set
+of members whose names come from a fixed allowlist
+(:data:`~flightsite.backup.manifest.ALLOWED_MEMBERS`). Restore looks members up
+**by name** and writes them to paths it computes itself — ``extractall`` is
+never called, and any member that is not a plain file with an allowlisted name
+is a validation failure rather than something to skip. That makes the classic
+tar path-traversal and symlink attacks structurally impossible instead of
+merely guarded against.
+
+Everything here streams in fixed-size chunks: on a Pi the database can be
+several gigabytes and neither backup nor restore may hold it in memory.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tarfile
+import zlib
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import IO
+
+from flightsite.backup.errors import ArchiveValidationError
+
+#: Streaming chunk size for hashing and extraction.
+CHUNK_BYTES = 1024 * 1024
+
+#: Everything a damaged container can raise on the way out of tarfile/gzip.
+#: ``zlib.error`` is not an ``OSError``, so it has to be named explicitly —
+#: without it a flipped byte inside the deflate stream would escape as an
+#: unhandled exception instead of a "this archive is corrupt" refusal.
+CONTAINER_ERRORS = (tarfile.TarError, OSError, EOFError, zlib.error)
+
+
+@dataclass(frozen=True, slots=True)
+class Digest:
+    """A file's SHA-256 and byte length."""
+
+    sha256: str
+    size_bytes: int
+
+
+def digest_file(path: Path) -> Digest:
+    """Hash a file on disk without reading it all into memory."""
+    hasher = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        while chunk := handle.read(CHUNK_BYTES):
+            hasher.update(chunk)
+            size += len(chunk)
+    return Digest(hasher.hexdigest(), size)
+
+
+def _open_tar(path: Path) -> tarfile.TarFile:
+    try:
+        return tarfile.open(path, "r:gz")
+    except CONTAINER_ERRORS as exc:
+        raise ArchiveValidationError(
+            f"{path} is not a readable FlightSite backup archive (expected gzip tar): {exc}"
+        ) from exc
+
+
+@contextmanager
+def open_archive(path: Path) -> Iterator[tarfile.TarFile]:
+    """Open a backup archive for reading.
+
+    Raises:
+        ArchiveValidationError: if the file is missing, not gzip, or not a tar.
+    """
+    if not path.exists():
+        raise ArchiveValidationError(f"no such archive: {path}")
+    with _open_tar(path) as handle:
+        yield handle
+
+
+def member_names(archive: tarfile.TarFile) -> tuple[str, ...]:
+    """Names of every entry in the archive, in stored order."""
+    try:
+        return tuple(info.name for info in archive.getmembers())
+    except CONTAINER_ERRORS as exc:
+        raise ArchiveValidationError(f"archive index is unreadable: {exc}") from exc
+
+
+def irregular_members(archive: tarfile.TarFile) -> tuple[str, ...]:
+    """Names of entries that are not plain files (links, devices, directories)."""
+    try:
+        return tuple(info.name for info in archive.getmembers() if not info.isfile())
+    except CONTAINER_ERRORS as exc:  # pragma: no cover - getmembers already ran above
+        raise ArchiveValidationError(f"archive index is unreadable: {exc}") from exc
+
+
+def read_member(archive: tarfile.TarFile, name: str) -> bytes:
+    """Read a small member (the manifest) fully into memory."""
+    stream = _member_stream(archive, name)
+    try:
+        return stream.read()
+    except CONTAINER_ERRORS as exc:
+        raise ArchiveValidationError(f"member {name!r} could not be read: {exc}") from exc
+    finally:
+        stream.close()
+
+
+def copy_member(archive: tarfile.TarFile, name: str, destination: Path | None) -> Digest:
+    """Stream a member out, hashing it, optionally writing it to ``destination``.
+
+    Passing ``destination=None`` verifies without extracting — that is what
+    ``flightsite-backup verify`` does, and why it can never modify anything.
+    """
+    hasher = hashlib.sha256()
+    size = 0
+    stream = _member_stream(archive, name)
+    try:
+        if destination is None:
+            while chunk := stream.read(CHUNK_BYTES):
+                hasher.update(chunk)
+                size += len(chunk)
+        else:
+            with destination.open("wb") as handle:
+                while chunk := stream.read(CHUNK_BYTES):
+                    hasher.update(chunk)
+                    size += len(chunk)
+                    handle.write(chunk)
+                handle.flush()
+                os.fsync(handle.fileno())
+    except CONTAINER_ERRORS as exc:
+        raise ArchiveValidationError(f"member {name!r} could not be read: {exc}") from exc
+    finally:
+        stream.close()
+    return Digest(hasher.hexdigest(), size)
+
+
+def _member_stream(archive: tarfile.TarFile, name: str) -> IO[bytes]:
+    try:
+        info = archive.getmember(name)
+    except KeyError as exc:
+        raise ArchiveValidationError(f"archive is missing member {name!r}") from exc
+    if not info.isfile():
+        raise ArchiveValidationError(f"archive member {name!r} is not a regular file")
+    stream = archive.extractfile(info)
+    if stream is None:  # pragma: no cover - isfile() already guarantees a stream
+        raise ArchiveValidationError(f"archive member {name!r} has no readable content")
+    return stream
+
+
+def write_archive(destination: Path, sources: dict[str, Path], *, mtime: int) -> None:
+    """Write ``sources`` (member name -> file on disk) as a gzip tar.
+
+    Ownership and timestamps are normalized so two backups of identical bytes
+    differ only by their creation time, and so an archive never carries the
+    uid/gid of whoever happened to run the command.
+    """
+
+    def normalize(info: tarfile.TarInfo) -> tarfile.TarInfo:
+        info.uid = 0
+        info.gid = 0
+        info.uname = ""
+        info.gname = ""
+        info.mtime = mtime
+        info.mode = 0o600
+        return info
+
+    with tarfile.open(destination, "w:gz") as archive:
+        for name, path in sources.items():
+            archive.add(path, arcname=name, filter=normalize)
+
+
+__all__ = [
+    "CHUNK_BYTES",
+    "CONTAINER_ERRORS",
+    "Digest",
+    "copy_member",
+    "digest_file",
+    "irregular_members",
+    "member_names",
+    "open_archive",
+    "read_member",
+    "write_archive",
+]

--- a/backend/src/flightsite/backup/cli.py
+++ b/backend/src/flightsite/backup/cli.py
@@ -1,0 +1,155 @@
+"""``flightsite-backup`` — the backup, restore, and verify commands.
+
+Run inside the container, where the data directory is mounted::
+
+    docker compose exec backend flightsite-backup create
+    docker compose exec backend flightsite-backup verify \\
+        /opt/flightsite/data/backups/flightsite-backup-20260901T120000Z.tar.gz
+    docker compose exec backend flightsite-backup restore \\
+        /opt/flightsite/data/backups/flightsite-backup-20260901T120000Z.tar.gz --confirm
+
+Exit codes are stable enough to script against:
+
+======= ================================================================
+``0``   the command succeeded
+``1``   the command refused: damaged archive, incompatible schema, no
+        database to back up, failed swap
+``2``   the invocation was wrong, including a ``restore`` without
+        ``--confirm``
+======= ================================================================
+
+The data directory resolves the same way it does for the application
+(:func:`flightsite.config.paths.resolve_data_dir`): ``--data-dir``, else
+``FLIGHTSITE_DATA_DIR``, else ``/opt/flightsite/data``. That is what makes the
+in-container invocation above need no arguments at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from flightsite.backup.create import create_backup
+from flightsite.backup.errors import BackupError, ConfirmationRequiredError
+from flightsite.backup.restore import OPERATIONAL_RULE, restore_backup
+from flightsite.backup.verify import verify_archive
+from flightsite.config.paths import resolve_data_dir
+
+EXIT_OK = 0
+EXIT_REFUSED = 1
+EXIT_USAGE = 2
+
+PROGRAM = "flightsite-backup"
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """The ``flightsite-backup`` argument parser."""
+    parser = argparse.ArgumentParser(
+        prog=PROGRAM,
+        description="Back up, verify, and restore a FlightSite data directory.",
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    create = subcommands.add_parser(
+        "create", help="write a checksum-validated backup archive", description="Take a backup."
+    )
+    _add_data_dir(create)
+    create.add_argument(
+        "--include-secrets",
+        action="store_true",
+        help=(
+            "also archive secrets.yaml. Off by default: the archive is then as "
+            "sensitive as the secrets file itself"
+        ),
+    )
+    create.add_argument(
+        "--out",
+        metavar="DIR",
+        help="destination directory (default: <data-dir>/backups)",
+    )
+
+    restore = subcommands.add_parser(
+        "restore",
+        help="replace a data directory's contents with an archive",
+        description="Restore a backup. Destructive; stop FlightSite first.",
+    )
+    restore.add_argument("archive", help="path to a flightsite-backup-*.tar.gz")
+    _add_data_dir(restore)
+    restore.add_argument(
+        "--confirm",
+        action="store_true",
+        help="required: acknowledge that this overwrites the data directory",
+    )
+
+    verify = subcommands.add_parser(
+        "verify",
+        help="check an archive's checksums, manifest, and schema compatibility",
+        description="Validate a backup without modifying anything.",
+    )
+    verify.add_argument("archive", help="path to a flightsite-backup-*.tar.gz")
+
+    return parser
+
+
+def _add_data_dir(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--data-dir",
+        metavar="DIR",
+        help="FlightSite data directory (default: $FLIGHTSITE_DATA_DIR or /opt/flightsite/data)",
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the ``flightsite-backup`` console script."""
+    args = build_arg_parser().parse_args(argv)
+
+    try:
+        if args.command == "create":
+            return _create(args)
+        if args.command == "restore":
+            return _restore(args)
+        return _verify(args)
+    except ConfirmationRequiredError as exc:
+        print(f"{PROGRAM}: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+    except BackupError as exc:
+        print(f"{PROGRAM}: {exc}", file=sys.stderr)
+        return EXIT_REFUSED
+
+
+def _create(args: argparse.Namespace) -> int:
+    result = create_backup(
+        resolve_data_dir(args.data_dir),
+        include_secrets=args.include_secrets,
+        out_dir=Path(args.out) if args.out else None,
+    )
+    print(result.render())
+    if args.include_secrets and not result.manifest.includes_secrets:
+        print(
+            "note: --include-secrets was given but no secrets.yaml exists; "
+            "the manifest records includes_secrets=false",
+            file=sys.stderr,
+        )
+    return EXIT_OK
+
+
+def _restore(args: argparse.Namespace) -> int:
+    if not args.confirm:
+        raise ConfirmationRequiredError(
+            "restore replaces the database and configuration in the data directory. "
+            f"{OPERATIONAL_RULE} Then re-run with --confirm."
+        )
+    result = restore_backup(Path(args.archive), resolve_data_dir(args.data_dir), confirm=True)
+    print(result.render())
+    return EXIT_OK
+
+
+def _verify(args: argparse.Namespace) -> int:
+    report = verify_archive(Path(args.archive))
+    print(report.render())
+    return EXIT_OK if report.ok else EXIT_REFUSED
+
+
+__all__ = ["EXIT_OK", "EXIT_REFUSED", "EXIT_USAGE", "PROGRAM", "build_arg_parser", "main"]

--- a/backend/src/flightsite/backup/compat.py
+++ b/backend/src/flightsite/backup/compat.py
@@ -1,0 +1,102 @@
+"""Schema-compatibility rules for restoring a backup (SPEC §72).
+
+The rule, stated once:
+
+    A backup is restorable by this build **iff** its ``schema_revision`` is an
+    ancestor of, or equal to, this build's Alembic head.
+
+Both halves matter.
+
+* **Ancestor (older backup).** The restored database is behind the code, which
+  is the ordinary upgrade path: FlightSite migrates it to head at the next
+  startup exactly as it migrates an in-place data directory
+  (:func:`flightsite.db.startup.initialize_database`). Restore does *not*
+  migrate; it puts the files in place and lets the normal startup sequence do
+  the one thing that already has migration tests behind it.
+* **Equal.** Nothing to do.
+* **Anything else (newer, or unknown lineage).** Refused. A revision this
+  build's migration graph has never heard of means the archive was written by a
+  newer FlightSite whose migrations this code does not contain — it could not
+  migrate the database *down*, and running an older code base against a newer
+  schema is how data gets silently mangled. ``docs/RELEASE.md`` §Rollback
+  depends on this refusal being reliable.
+
+An unstamped snapshot (no ``alembic_version`` row) is treated as "older than
+everything": migrating it from base is well defined, and refusing it would make
+a backup of a freshly created data directory unrestorable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from flightsite.db import migrate
+
+
+class SchemaRelation(StrEnum):
+    """How a backup's schema revision relates to this build's head."""
+
+    #: Same revision — restore and start, no migration needed.
+    SAME = "same"
+    #: An ancestor of head — restore, then startup migrates forward.
+    OLDER = "older"
+    #: Not in this build's migration graph at all — refuse.
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaCompatibility:
+    """The verdict for one backup, with the text the CLI prints."""
+
+    backup_revision: str | None
+    head_revision: str
+    relation: SchemaRelation
+
+    @property
+    def restorable(self) -> bool:
+        """True when this build may restore the backup."""
+        return self.relation is not SchemaRelation.UNKNOWN
+
+    @property
+    def migration_required(self) -> bool:
+        """True when the restored database still has to be migrated forward."""
+        return self.relation is SchemaRelation.OLDER
+
+    def summary(self) -> str:
+        """One line explaining the verdict, suitable for a CLI or an exception."""
+        shown = self.backup_revision if self.backup_revision is not None else "(unstamped)"
+        if self.relation is SchemaRelation.SAME:
+            return f"schema revision {shown} matches this build's head; no migration needed"
+        if self.relation is SchemaRelation.OLDER:
+            return (
+                f"schema revision {shown} is older than this build's head "
+                f"{self.head_revision}; FlightSite will migrate it forward on the next start"
+            )
+        return (
+            f"schema revision {shown} is not part of this build's migration history "
+            f"(head {self.head_revision}). This backup was almost certainly written by a "
+            "newer FlightSite; restoring it into this older build would corrupt it. "
+            "Upgrade FlightSite to at least the version that wrote the backup, then retry."
+        )
+
+
+def check_schema(backup_revision: str | None) -> SchemaCompatibility:
+    """Classify ``backup_revision`` against this build's migration graph."""
+    head = migrate.head_revision()
+    if backup_revision is None:
+        return SchemaCompatibility(None, head, SchemaRelation.OLDER)
+    if backup_revision == head:
+        return SchemaCompatibility(backup_revision, head, SchemaRelation.SAME)
+
+    script = migrate.script_directory()
+    try:
+        ancestors = {revision.revision for revision in script.iterate_revisions(head, "base")}
+    except Exception:  # pragma: no cover - a broken graph fails the single-head test first
+        ancestors = set()
+
+    relation = SchemaRelation.OLDER if backup_revision in ancestors else SchemaRelation.UNKNOWN
+    return SchemaCompatibility(backup_revision, head, relation)
+
+
+__all__ = ["SchemaCompatibility", "SchemaRelation", "check_schema"]

--- a/backend/src/flightsite/backup/create.py
+++ b/backend/src/flightsite/backup/create.py
@@ -1,0 +1,216 @@
+"""Taking a backup.
+
+Produces one self-describing ``tar.gz`` under ``<data_dir>/backups/``
+(``docs/ARCHITECTURE.md`` §2.1) holding a SQLite-safe snapshot of the database,
+``config.yaml``, optionally ``secrets.yaml``, and the manifest that makes the
+archive version-aware (SPEC §72).
+
+The whole command is synchronous stdlib work over files. It borrows nothing
+from a running application — no engine, no writer lock, no event loop — which
+is what lets the same command serve both documented situations: taken from
+inside the running container (``docker compose exec``) while ingestion
+continues, and taken against a stopped installation's data directory.
+
+Secrets are opt-in (``docs/SECURITY.md`` §3). ``includes_secrets`` in the
+manifest records what actually went in, not what was asked for: requesting
+secrets for an installation that has no ``secrets.yaml`` yields an archive
+whose manifest honestly says ``false``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from flightsite import __version__
+from flightsite.backup import archive as archive_io
+from flightsite.backup.errors import BackupError
+from flightsite.backup.manifest import (
+    CONFIG_MEMBER,
+    DATABASE_MEMBER,
+    FORMAT_VERSION,
+    MANIFEST_MEMBER,
+    SECRETS_MEMBER,
+    FileEntry,
+    Manifest,
+    utc_iso,
+)
+from flightsite.backup.snapshot import (
+    metadata_source_entries,
+    snapshot_revision,
+    vacuum_into,
+)
+from flightsite.config.paths import config_path, secrets_path
+from flightsite.db.engine import database_path
+
+#: Backup directory inside the data directory (``docs/ARCHITECTURE.md`` §2.1).
+BACKUPS_DIRNAME = "backups"
+
+#: ``strftime`` pattern for the timestamp in an archive's filename.
+FILENAME_TIMESTAMP = "%Y%m%dT%H%M%SZ"
+
+#: Prefix of every archive this command writes.
+FILENAME_PREFIX = "flightsite-backup-"
+
+FILENAME_SUFFIX = ".tar.gz"
+
+
+@dataclass(frozen=True, slots=True)
+class BackupResult:
+    """What a completed backup produced."""
+
+    path: Path
+    manifest: Manifest
+    size_bytes: int
+
+    def render(self) -> str:
+        """The summary ``flightsite-backup create`` prints."""
+        lines = [
+            f"wrote {self.path} ({self.size_bytes} bytes)",
+            f"  flightsite version: {self.manifest.flightsite_version}",
+            f"  schema revision:    {self.manifest.schema_revision or '(unstamped)'}",
+            f"  created (UTC):      {self.manifest.created_utc}",
+            f"  includes secrets:   {'yes' if self.manifest.includes_secrets else 'no'}",
+            "  contents:           " + ", ".join(sorted(self.manifest.file_names)),
+        ]
+        return "\n".join(lines)
+
+
+def default_backup_dir(data_dir: Path) -> Path:
+    """Where backups land when ``--out`` is not given."""
+    return data_dir / BACKUPS_DIRNAME
+
+
+def archive_name(created: datetime) -> str:
+    """Archive filename for a backup created at ``created``."""
+    return (
+        f"{FILENAME_PREFIX}{created.astimezone(UTC).strftime(FILENAME_TIMESTAMP)}{FILENAME_SUFFIX}"
+    )
+
+
+def create_backup(
+    data_dir: Path,
+    *,
+    include_secrets: bool = False,
+    out_dir: Path | None = None,
+    now: Callable[[], datetime] | None = None,
+) -> BackupResult:
+    """Create a backup of the installation rooted at ``data_dir``.
+
+    Args:
+        data_dir: the FlightSite data directory to back up.
+        include_secrets: also archive ``secrets.yaml`` (``docs/SECURITY.md`` §3).
+        out_dir: destination directory; defaults to ``<data_dir>/backups``.
+        now: clock injection point for tests.
+
+    Raises:
+        BackupError: if there is no database to back up, the destination is
+            unusable, or an archive of the same name already exists.
+    """
+    clock = now or _utc_now
+    created = clock().astimezone(UTC)
+
+    database = database_path(data_dir)
+    if not database.exists():
+        raise BackupError(
+            f"no FlightSite database at {database} — is {data_dir} really a data directory?"
+        )
+
+    destination_dir = out_dir if out_dir is not None else default_backup_dir(data_dir)
+    try:
+        destination_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise BackupError(f"cannot create backup directory {destination_dir}: {exc}") from exc
+
+    final_path = destination_dir / archive_name(created)
+    if final_path.exists():
+        raise BackupError(
+            f"{final_path} already exists; a backup for this second has already been taken"
+        )
+
+    # The workspace lives beside the finished archive so the snapshot and the
+    # final rename stay on one filesystem, and so a Pi's small /tmp is never
+    # asked to hold a multi-gigabyte database.
+    workspace = Path(tempfile.mkdtemp(dir=destination_dir, prefix=".flightsite-backup-"))
+    temp_archive = destination_dir / f".{final_path.name}.tmp"
+    try:
+        sources = _stage(workspace, data_dir, database, include_secrets=include_secrets)
+        manifest = _build_manifest(workspace, sources, created=created)
+        manifest_file = workspace / MANIFEST_MEMBER
+        manifest_file.write_text(manifest.to_json(), encoding="utf-8", newline="\n")
+
+        members = {MANIFEST_MEMBER: manifest_file}
+        members.update(sources)
+        temp_archive.unlink(missing_ok=True)
+        archive_io.write_archive(temp_archive, members, mtime=int(created.timestamp()))
+        os.replace(temp_archive, final_path)
+    except BaseException:
+        temp_archive.unlink(missing_ok=True)
+        raise
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+    return BackupResult(path=final_path, manifest=manifest, size_bytes=final_path.stat().st_size)
+
+
+def _stage(
+    workspace: Path, data_dir: Path, database: Path, *, include_secrets: bool
+) -> dict[str, Path]:
+    """Collect the payload files into ``workspace``, keyed by member name."""
+    staged: dict[str, Path] = {}
+
+    snapshot = workspace / DATABASE_MEMBER
+    vacuum_into(database, snapshot)
+    staged[DATABASE_MEMBER] = snapshot
+
+    config = config_path(data_dir)
+    if config.exists():
+        shutil.copy2(config, workspace / CONFIG_MEMBER)
+        staged[CONFIG_MEMBER] = workspace / CONFIG_MEMBER
+
+    if include_secrets:
+        secrets = secrets_path(data_dir)
+        if secrets.exists():
+            shutil.copy2(secrets, workspace / SECRETS_MEMBER)
+            staged[SECRETS_MEMBER] = workspace / SECRETS_MEMBER
+
+    return staged
+
+
+def _build_manifest(workspace: Path, sources: dict[str, Path], *, created: datetime) -> Manifest:
+    snapshot = workspace / DATABASE_MEMBER
+    entries: list[FileEntry] = []
+    for name, path in sorted(sources.items()):
+        digest = archive_io.digest_file(path)
+        entries.append(FileEntry(name=name, sha256=digest.sha256, size_bytes=digest.size_bytes))
+
+    return Manifest(
+        format_version=FORMAT_VERSION,
+        flightsite_version=__version__,
+        schema_revision=snapshot_revision(snapshot),
+        created_utc=utc_iso(created),
+        includes_secrets=SECRETS_MEMBER in sources,
+        files=tuple(entries),
+        metadata_sources=metadata_source_entries(snapshot),
+    )
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+__all__ = [
+    "BACKUPS_DIRNAME",
+    "FILENAME_PREFIX",
+    "FILENAME_SUFFIX",
+    "FILENAME_TIMESTAMP",
+    "BackupResult",
+    "archive_name",
+    "create_backup",
+    "default_backup_dir",
+]

--- a/backend/src/flightsite/backup/errors.py
+++ b/backend/src/flightsite/backup/errors.py
@@ -1,0 +1,52 @@
+"""Failure modes of the backup/restore commands.
+
+Every refusal the CLI reports is one of these, so a caller embedding the
+package (and the tests) can distinguish "this archive is damaged" from "this
+archive is from a newer FlightSite" from "you did not pass ``--confirm``"
+without matching on message text.
+"""
+
+from __future__ import annotations
+
+
+class BackupError(Exception):
+    """Base class for every backup/restore failure."""
+
+
+class SnapshotError(BackupError):
+    """The SQLite snapshot could not be taken."""
+
+
+class ManifestError(BackupError):
+    """``manifest.json`` is missing, unreadable, or structurally wrong."""
+
+
+class ArchiveValidationError(BackupError):
+    """The archive failed integrity validation (container, members, checksums)."""
+
+
+class SchemaCompatibilityError(BackupError):
+    """The backup's schema revision is not restorable by this build.
+
+    Raised for the SPEC §72 case "refuse a newer-schema backup on an
+    incompatible older FlightSite version".
+    """
+
+
+class ConfirmationRequiredError(BackupError):
+    """A destructive restore was requested without explicit confirmation (SPEC §72)."""
+
+
+class RestoreError(BackupError):
+    """The data directory could not be swapped over to the restored files."""
+
+
+__all__ = [
+    "ArchiveValidationError",
+    "BackupError",
+    "ConfirmationRequiredError",
+    "ManifestError",
+    "RestoreError",
+    "SchemaCompatibilityError",
+    "SnapshotError",
+]

--- a/backend/src/flightsite/backup/manifest.py
+++ b/backend/src/flightsite/backup/manifest.py
@@ -1,0 +1,256 @@
+"""The backup manifest: what an archive contains and what produced it.
+
+SPEC §72 makes backups *version-aware*: the manifest carries the FlightSite
+version, the database schema revision, the creation time, checksums, and the
+relevant metadata/source versions. Restore reads it before touching anything.
+
+The manifest is deliberately plain JSON parsed by hand rather than a Pydantic
+model. It is the one file a restore must be able to read from an archive
+written by a *different* build of FlightSite, so its parser has to fail with a
+precise, human-readable complaint about an unexpected shape rather than a
+validation traceback — and it must never gain a field whose absence breaks an
+older reader silently. ``format_version`` is the compatibility gate: a reader
+refuses a format it does not know.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Final
+
+from flightsite.backup.errors import ManifestError
+
+#: Manifest schema version written by this build.
+FORMAT_VERSION: Final = 1
+
+#: Manifest schema versions this build can read.
+SUPPORTED_FORMAT_VERSIONS: Final = frozenset({1})
+
+#: Archive member holding the manifest.
+MANIFEST_MEMBER: Final = "manifest.json"
+
+#: Archive member holding the SQLite snapshot.
+DATABASE_MEMBER: Final = "flightsite.sqlite3"
+
+#: Archive member holding the non-secret configuration.
+CONFIG_MEMBER: Final = "config.yaml"
+
+#: Archive member holding secrets — present only when explicitly requested.
+SECRETS_MEMBER: Final = "secrets.yaml"
+
+#: Every member name an archive is allowed to contain. Restore reads members by
+#: name from this set and never calls ``extractall``, so a hostile archive
+#: cannot write outside the destination directory.
+ALLOWED_MEMBERS: Final = frozenset(
+    {MANIFEST_MEMBER, DATABASE_MEMBER, CONFIG_MEMBER, SECRETS_MEMBER}
+)
+
+#: Payload members in the order restore swaps them into the data directory.
+PAYLOAD_MEMBERS: Final = (DATABASE_MEMBER, CONFIG_MEMBER, SECRETS_MEMBER)
+
+
+def utc_iso(moment: datetime) -> str:
+    """Render ``moment`` as a ``Z``-suffixed UTC ISO-8601 string."""
+    return moment.astimezone(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def utc_iso_from_ms(epoch_ms: int | None) -> str | None:
+    """Render an epoch-millisecond column as UTC ISO-8601, passing ``None`` through."""
+    if epoch_ms is None:
+        return None
+    return utc_iso(datetime.fromtimestamp(epoch_ms / 1000, tz=UTC))
+
+
+@dataclass(frozen=True, slots=True)
+class FileEntry:
+    """Checksum and size of one payload member."""
+
+    name: str
+    sha256: str
+    size_bytes: int
+
+
+@dataclass(frozen=True, slots=True)
+class MetadataSourceEntry:
+    """A ``metadata_sources`` row as the manifest records it (SPEC §72).
+
+    Enough to answer "which metadata datasets does this backup carry?" without
+    opening the database — the question a user asks when choosing between two
+    archives.
+    """
+
+    source: str
+    dataset_version: str | None
+    last_success: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class Manifest:
+    """The contents of ``manifest.json``."""
+
+    format_version: int
+    flightsite_version: str
+    #: Alembic revision stamped in the snapshot; ``None`` if it was unstamped.
+    schema_revision: str | None
+    created_utc: str
+    includes_secrets: bool
+    files: tuple[FileEntry, ...]
+    metadata_sources: tuple[MetadataSourceEntry, ...]
+
+    def file(self, name: str) -> FileEntry | None:
+        """The entry for ``name``, or ``None`` if the manifest does not list it."""
+        for entry in self.files:
+            if entry.name == name:
+                return entry
+        return None
+
+    @property
+    def file_names(self) -> frozenset[str]:
+        """Names of every payload member the manifest claims."""
+        return frozenset(entry.name for entry in self.files)
+
+    def to_dict(self) -> dict[str, Any]:
+        """The JSON-serializable form written into the archive."""
+        return {
+            "format_version": self.format_version,
+            "flightsite_version": self.flightsite_version,
+            "schema_revision": self.schema_revision,
+            "created_utc": self.created_utc,
+            "includes_secrets": self.includes_secrets,
+            "files": {
+                entry.name: {"sha256": entry.sha256, "size_bytes": entry.size_bytes}
+                for entry in self.files
+            },
+            "metadata_sources": [
+                {
+                    "source": entry.source,
+                    "dataset_version": entry.dataset_version,
+                    "last_success": entry.last_success,
+                }
+                for entry in self.metadata_sources
+            ],
+        }
+
+    def to_json(self) -> str:
+        """Pretty-printed JSON, newline-terminated so the file reads cleanly."""
+        return json.dumps(self.to_dict(), indent=2, sort_keys=False) + "\n"
+
+
+def _require(data: Mapping[str, Any], key: str) -> Any:
+    if key not in data:
+        raise ManifestError(f"manifest is missing required key {key!r}")
+    return data[key]
+
+
+def _require_str(data: Mapping[str, Any], key: str) -> str:
+    value = _require(data, key)
+    if not isinstance(value, str):
+        raise ManifestError(f"manifest key {key!r} must be a string, got {type(value).__name__}")
+    return value
+
+
+def _optional_str(data: Mapping[str, Any], key: str) -> str | None:
+    value = _require(data, key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ManifestError(
+            f"manifest key {key!r} must be a string or null, got {type(value).__name__}"
+        )
+    return value
+
+
+def _parse_files(raw: Any) -> tuple[FileEntry, ...]:
+    if not isinstance(raw, dict):
+        raise ManifestError("manifest key 'files' must be an object of name -> checksum record")
+    entries: list[FileEntry] = []
+    for name, record in raw.items():
+        if not isinstance(record, dict):
+            raise ManifestError(f"manifest file entry {name!r} must be an object")
+        sha256 = record.get("sha256")
+        size = record.get("size_bytes")
+        if not isinstance(sha256, str) or len(sha256) != 64:
+            raise ManifestError(f"manifest file entry {name!r} has no valid 'sha256'")
+        if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+            raise ManifestError(f"manifest file entry {name!r} has no valid 'size_bytes'")
+        entries.append(FileEntry(name=str(name), sha256=sha256, size_bytes=size))
+    return tuple(sorted(entries, key=lambda entry: entry.name))
+
+
+def _parse_metadata_sources(raw: Any) -> tuple[MetadataSourceEntry, ...]:
+    if not isinstance(raw, list):
+        raise ManifestError("manifest key 'metadata_sources' must be a list")
+    entries: list[MetadataSourceEntry] = []
+    for record in raw:
+        if not isinstance(record, dict):
+            raise ManifestError("each 'metadata_sources' item must be an object")
+        entries.append(
+            MetadataSourceEntry(
+                source=_require_str(record, "source"),
+                dataset_version=_optional_str(record, "dataset_version"),
+                last_success=_optional_str(record, "last_success"),
+            )
+        )
+    return tuple(entries)
+
+
+def parse_manifest(payload: bytes | str) -> Manifest:
+    """Parse ``manifest.json`` bytes into a :class:`Manifest`.
+
+    Raises:
+        ManifestError: if the JSON is unreadable, the format version is one
+            this build does not support, or a required key is missing or
+            mistyped.
+    """
+    try:
+        data = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ManifestError(f"manifest is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ManifestError("manifest must be a JSON object")
+
+    format_version = _require(data, "format_version")
+    if not isinstance(format_version, int) or isinstance(format_version, bool):
+        raise ManifestError("manifest key 'format_version' must be an integer")
+    if format_version not in SUPPORTED_FORMAT_VERSIONS:
+        supported = ", ".join(str(version) for version in sorted(SUPPORTED_FORMAT_VERSIONS))
+        raise ManifestError(
+            f"manifest format_version {format_version} is not supported by this "
+            f"FlightSite build (supported: {supported}). Restore this backup with "
+            "the FlightSite version that wrote it, or upgrade."
+        )
+
+    includes_secrets = _require(data, "includes_secrets")
+    if not isinstance(includes_secrets, bool):
+        raise ManifestError("manifest key 'includes_secrets' must be a boolean")
+
+    return Manifest(
+        format_version=format_version,
+        flightsite_version=_require_str(data, "flightsite_version"),
+        schema_revision=_optional_str(data, "schema_revision"),
+        created_utc=_require_str(data, "created_utc"),
+        includes_secrets=includes_secrets,
+        files=_parse_files(_require(data, "files")),
+        metadata_sources=_parse_metadata_sources(_require(data, "metadata_sources")),
+    )
+
+
+__all__ = [
+    "ALLOWED_MEMBERS",
+    "CONFIG_MEMBER",
+    "DATABASE_MEMBER",
+    "FORMAT_VERSION",
+    "MANIFEST_MEMBER",
+    "PAYLOAD_MEMBERS",
+    "SECRETS_MEMBER",
+    "SUPPORTED_FORMAT_VERSIONS",
+    "FileEntry",
+    "Manifest",
+    "MetadataSourceEntry",
+    "parse_manifest",
+    "utc_iso",
+    "utc_iso_from_ms",
+]

--- a/backend/src/flightsite/backup/restore.py
+++ b/backend/src/flightsite/backup/restore.py
@@ -1,0 +1,262 @@
+"""Restoring a backup into a data directory.
+
+Restore is the destructive half of SPEC §72, so its shape is dictated by two
+rules: **validate everything before touching anything**, and **never leave the
+data directory in a half-restored state**.
+
+Sequence
+--------
+
+1. Refuse without explicit confirmation (SPEC §72's "destructive restore
+   operations must be deliberate"; the same posture §73 gives data reset).
+2. Read and validate the manifest, then check schema compatibility — both cheap
+   — so a newer-schema archive is refused before a multi-gigabyte database is
+   written anywhere.
+3. Extract every payload member into a staging directory *inside the data
+   directory*, verifying SHA-256 as the bytes stream past. Staging inside the
+   data directory keeps the final moves on one filesystem, which is what makes
+   them atomic renames rather than copies.
+4. Swap. For each member: move the live file aside to
+   ``<name>.pre-restore.<timestamp>``, then :func:`os.replace` the staged file
+   into place. If any step fails, every move already made is undone and the
+   directory is left exactly as it was found.
+5. Delete the preserved copies only after the whole swap succeeded.
+
+Stale WAL sidecars
+------------------
+
+``flightsite.sqlite3-wal`` and ``-shm`` belong to the database being replaced.
+Left beside a restored database file they are worse than useless — SQLite would
+try to recover a write-ahead log written against a *different* file. They are
+therefore moved aside with the same ``.pre-restore`` discipline. The snapshot in
+the archive is fully materialized (``VACUUM INTO``, see :mod:`.snapshot`), so it
+needs no sidecar of its own, and the pragmas in
+:mod:`flightsite.db.engine` put it back into WAL mode on the first connection.
+
+Restoring while FlightSite is running
+-------------------------------------
+
+There is no lock file or pid check, deliberately: any cheap heuristic would be
+both spoofable and wrong across container restarts, and a wrong "FlightSite is
+running" refusal is worse than no check. The operational rule is documented
+instead — *stop FlightSite before restoring* (``docs/BACKUP.md``) — and the
+mechanism is chosen so that a restore performed against a running instance is
+survivable rather than corrupting: each file is swapped whole by rename, so a
+running process keeps its open handle on the old inode and writes to a file
+that is no longer linked into the directory, instead of writing into the middle
+of the restored one. Its work is lost on the next restart, which is what the
+user asked for, but the restored files are intact.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from flightsite.backup.compat import SchemaCompatibility
+from flightsite.backup.errors import (
+    ArchiveValidationError,
+    ConfirmationRequiredError,
+    RestoreError,
+    SchemaCompatibilityError,
+)
+from flightsite.backup.manifest import (
+    DATABASE_MEMBER,
+    PAYLOAD_MEMBERS,
+    SECRETS_MEMBER,
+    Manifest,
+)
+from flightsite.backup.verify import inspect_archive
+
+#: Suffix given to the files a restore displaces, until it succeeds.
+PRESERVED_SUFFIX = "pre-restore"
+
+#: SQLite sidecars of the database being replaced. They describe the *old*
+#: file and must not survive into the restored installation.
+DATABASE_SIDECARS = (f"{DATABASE_MEMBER}-wal", f"{DATABASE_MEMBER}-shm")
+
+#: What ``restore`` tells the operator to do next, every time.
+OPERATIONAL_RULE = (
+    "Stop FlightSite before restoring (docs/BACKUP.md); start it afterwards so "
+    "migrations and the startup integrity check run."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RestoreResult:
+    """What a completed restore changed."""
+
+    data_dir: Path
+    archive: Path
+    manifest: Manifest
+    compatibility: SchemaCompatibility
+    #: Member names now live in the data directory.
+    restored: tuple[str, ...]
+    #: Files that were moved aside and then removed once the swap succeeded.
+    displaced: tuple[str, ...]
+
+    @property
+    def migration_required(self) -> bool:
+        """True when the next startup has migrations to apply."""
+        return self.compatibility.migration_required
+
+    @property
+    def secrets_restored(self) -> bool:
+        """True when ``secrets.yaml`` came out of the archive."""
+        return SECRETS_MEMBER in self.restored
+
+    def render(self) -> str:
+        """The summary ``flightsite-backup restore`` prints."""
+        lines = [
+            f"restored {self.archive}",
+            f"  into:              {self.data_dir}",
+            f"  files:             {', '.join(self.restored)}",
+            f"  schema:            {self.compatibility.summary()}",
+            f"  secrets restored:  {'yes' if self.secrets_restored else 'no'}",
+        ]
+        if not self.secrets_restored:
+            lines.append(
+                f"  note:              the archive carried no {SECRETS_MEMBER}; any existing "
+                "one was left untouched"
+            )
+        lines.append(f"  next:              {OPERATIONAL_RULE}")
+        return "\n".join(lines)
+
+
+def restore_backup(
+    archive: Path,
+    data_dir: Path,
+    *,
+    confirm: bool,
+    now: Callable[[], datetime] | None = None,
+) -> RestoreResult:
+    """Replace the contents of ``data_dir`` with the contents of ``archive``.
+
+    Args:
+        archive: the ``tar.gz`` to restore.
+        data_dir: the data directory to restore into. Created if absent.
+        confirm: must be ``True``. The flag exists so that no caller — CLI,
+            test, or future UI action — can perform a destructive restore
+            without saying so explicitly (SPEC §72).
+        now: clock injection point for the ``.pre-restore`` timestamps.
+
+    Raises:
+        ConfirmationRequiredError: if ``confirm`` is not ``True``.
+        SchemaCompatibilityError: if the backup's schema is not restorable.
+        ArchiveValidationError: if the archive is damaged or does not match its
+            manifest.
+        RestoreError: if the data directory could not be swapped over.
+    """
+    if not confirm:
+        raise ConfirmationRequiredError(
+            "restore is destructive: it replaces the database and configuration in "
+            f"{data_dir}. Re-run with --confirm once you have stopped FlightSite."
+        )
+
+    clock = now or _utc_now
+    stamp = clock().astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+    try:
+        data_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RestoreError(f"cannot create data directory {data_dir}: {exc}") from exc
+
+    staging = data_dir / f".flightsite-restore-{stamp}"
+    if staging.exists():
+        shutil.rmtree(staging, ignore_errors=True)
+    staging.mkdir()
+
+    try:
+        report = inspect_archive(archive, extract_to=staging)
+        compatibility = report.compatibility
+        if compatibility is not None and not compatibility.restorable:
+            raise SchemaCompatibilityError(compatibility.summary())
+        if not report.ok:
+            raise ArchiveValidationError(
+                f"{archive} failed validation and was not restored:\n"
+                + "\n".join(f"  - {problem}" for problem in report.problems)
+            )
+        # Both are non-None once the report is clean; assert for the type checker.
+        manifest = report.manifest
+        if manifest is None or compatibility is None:  # pragma: no cover - unreachable when ok
+            raise ArchiveValidationError(f"{archive} produced no manifest")
+
+        restored, displaced = _swap(data_dir, staging, manifest, stamp=stamp)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+    return RestoreResult(
+        data_dir=data_dir,
+        archive=archive,
+        manifest=manifest,
+        compatibility=compatibility,
+        restored=restored,
+        displaced=displaced,
+    )
+
+
+def _swap(
+    data_dir: Path, staging: Path, manifest: Manifest, *, stamp: str
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Move staged files into place, all or nothing.
+
+    Returns the member names restored and the names of the files displaced (and
+    then removed). On any failure every move is undone before re-raising.
+    """
+    incoming = [name for name in PAYLOAD_MEMBERS if name in manifest.file_names]
+    # Sidecars of the database being replaced are displaced but never restored.
+    aside = list(DATABASE_SIDECARS) if DATABASE_MEMBER in incoming else []
+
+    moved_aside: list[tuple[Path, Path]] = []
+    placed: list[Path] = []
+
+    try:
+        for name in [*incoming, *aside]:
+            live = data_dir / name
+            if not live.exists():
+                continue
+            preserved = data_dir / f"{name}.{PRESERVED_SUFFIX}.{stamp}"
+            preserved.unlink(missing_ok=True)
+            os.replace(live, preserved)
+            moved_aside.append((live, preserved))
+
+        for name in incoming:
+            target = data_dir / name
+            os.replace(staging / name, target)
+            placed.append(target)
+    except OSError as exc:
+        _roll_back(placed, moved_aside)
+        raise RestoreError(
+            f"restoring into {data_dir} failed ({exc}); the data directory was left unchanged"
+        ) from exc
+
+    for _, preserved in moved_aside:
+        preserved.unlink(missing_ok=True)
+
+    return tuple(incoming), tuple(preserved.name for _, preserved in moved_aside)
+
+
+def _roll_back(placed: list[Path], moved_aside: list[tuple[Path, Path]]) -> None:
+    """Undo a partial swap: remove what landed, put back what was displaced."""
+    for target in placed:
+        target.unlink(missing_ok=True)
+    for live, preserved in moved_aside:
+        if preserved.exists():
+            os.replace(preserved, live)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+__all__ = [
+    "DATABASE_SIDECARS",
+    "OPERATIONAL_RULE",
+    "PRESERVED_SUFFIX",
+    "RestoreResult",
+    "restore_backup",
+]

--- a/backend/src/flightsite/backup/restore.py
+++ b/backend/src/flightsite/backup/restore.py
@@ -79,10 +79,13 @@ PRESERVED_SUFFIX = "pre-restore"
 #: file and must not survive into the restored installation.
 DATABASE_SIDECARS = (f"{DATABASE_MEMBER}-wal", f"{DATABASE_MEMBER}-shm")
 
-#: What ``restore`` tells the operator to do next, every time.
-OPERATIONAL_RULE = (
-    "Stop FlightSite before restoring (docs/BACKUP.md); start it afterwards so "
-    "migrations and the startup integrity check run."
+#: The rule that stands in for a running-process check. Printed whenever a
+#: restore is refused for lack of confirmation.
+OPERATIONAL_RULE = "Stop FlightSite before restoring (docs/BACKUP.md)."
+
+#: What a completed restore tells the operator to do next.
+NEXT_STEP = (
+    "start FlightSite; it applies any pending migrations and runs its startup integrity check"
 )
 
 
@@ -123,7 +126,7 @@ class RestoreResult:
                 f"  note:              the archive carried no {SECRETS_MEMBER}; any existing "
                 "one was left untouched"
             )
-        lines.append(f"  next:              {OPERATIONAL_RULE}")
+        lines.append(f"  next:              {NEXT_STEP}")
         return "\n".join(lines)
 
 
@@ -255,6 +258,7 @@ def _utc_now() -> datetime:
 
 __all__ = [
     "DATABASE_SIDECARS",
+    "NEXT_STEP",
     "OPERATIONAL_RULE",
     "PRESERVED_SUFFIX",
     "RestoreResult",

--- a/backend/src/flightsite/backup/snapshot.py
+++ b/backend/src/flightsite/backup/snapshot.py
@@ -1,0 +1,167 @@
+"""SQLite-safe snapshotting, and reading a snapshot's provenance.
+
+Why ``VACUUM INTO`` rather than the online backup API
+-----------------------------------------------------
+
+FlightSite backs up a database that a live process is writing to: the
+write-behind persistence worker commits a batch every flush interval
+(ADR-0008). Both SQLite-safe options were considered and ``VACUUM INTO`` wins
+on this workload:
+
+* **The online backup API** (``sqlite3_backup_step`` / Python's
+  ``Connection.backup``) copies pages incrementally, and SQLite *restarts the
+  copy from the beginning* whenever the source database is written through a
+  different connection mid-copy. Against a continuously writing FlightSite that
+  is a livelock risk on a multi-gigabyte history. Copying in a single step
+  instead avoids the restart, but only by holding a read lock over the whole
+  copy — which stalls the writer, and ADR-0008's whole point is that ingestion
+  never blocks on disk.
+* **``VACUUM INTO``** runs inside one ordinary read transaction. ADR-0001 puts
+  the database in ``journal_mode=WAL``, where a reader neither blocks nor is
+  blocked by the writer, so the snapshot is a consistent point-in-time image of
+  the database *as of the read transaction's start* and the persistence worker
+  keeps committing throughout. It also writes a compacted, fully materialized
+  single file: no ``-wal``/``-shm`` sidecars to carry into the archive, and no
+  possibility of shipping a main file whose committed tail is still in a WAL
+  the archive does not contain.
+
+The snapshot is taken through this module's **own** stdlib ``sqlite3``
+connection, never through :class:`~flightsite.db.engine.Database`. That keeps
+the command usable when the app is stopped (there is no ``Database`` to borrow)
+and, when the app *is* running, keeps the backup off the writer lock entirely —
+it is a reader, and readers do not queue behind the writer under WAL.
+
+``busy_timeout`` is set to the same value the application uses so a snapshot
+taken at the instant of a checkpoint waits rather than failing.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from sqlalchemy import create_engine
+
+from flightsite.backup.errors import SnapshotError
+from flightsite.backup.manifest import MetadataSourceEntry, utc_iso_from_ms
+from flightsite.db import migrate
+from flightsite.db.engine import BUSY_TIMEOUT_MS
+
+#: Seconds the snapshot connection waits for a locked database before failing.
+SNAPSHOT_TIMEOUT_S = BUSY_TIMEOUT_MS / 1000
+
+#: Table the metadata framework (slice 021) keeps per-source import status in.
+METADATA_SOURCES_TABLE = "metadata_sources"
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    """Open ``path`` read-oriented, in autocommit mode.
+
+    ``isolation_level=None`` matters: Python's legacy transaction handling would
+    otherwise wrap statements in an implicit transaction, and ``VACUUM`` cannot
+    run inside one.
+    """
+    connection = sqlite3.connect(path, timeout=SNAPSHOT_TIMEOUT_S, isolation_level=None)
+    connection.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+    return connection
+
+
+def vacuum_into(source: Path, destination: Path) -> None:
+    """Write a consistent snapshot of ``source`` to ``destination``.
+
+    Safe to run while FlightSite is writing to ``source``; see this module's
+    docstring for why ``VACUUM INTO`` is the mechanism.
+
+    Raises:
+        SnapshotError: if ``source`` does not exist, ``destination`` already
+            exists (``VACUUM INTO`` refuses to overwrite), or SQLite fails.
+    """
+    if not source.exists():
+        raise SnapshotError(f"no database to back up at {source}")
+    if destination.exists():
+        raise SnapshotError(f"snapshot destination already exists: {destination}")
+
+    connection = _connect(source)
+    try:
+        # Bound parameter rather than string interpolation: the INTO clause
+        # takes an expression, so the path never becomes SQL.
+        connection.execute("VACUUM INTO ?", (destination.as_posix(),))
+    except sqlite3.Error as exc:
+        destination.unlink(missing_ok=True)
+        raise SnapshotError(f"SQLite snapshot of {source} failed: {exc}") from exc
+    finally:
+        connection.close()
+
+
+def quick_check(path: Path) -> list[str]:
+    """Run ``PRAGMA quick_check`` against a database file.
+
+    A healthy database returns ``["ok"]``. Used to prove a snapshot is sound
+    before it is archived.
+    """
+    connection = _connect(path)
+    try:
+        rows = connection.execute("PRAGMA quick_check").fetchall()
+    except sqlite3.Error as exc:
+        raise SnapshotError(f"integrity check of {path} failed: {exc}") from exc
+    finally:
+        connection.close()
+    return [str(row[0]) for row in rows]
+
+
+def snapshot_revision(path: Path) -> str | None:
+    """The Alembic revision stamped in the database at ``path``.
+
+    Read from the *snapshot*, not from the live database, so the manifest
+    describes exactly the bytes in the archive.
+    """
+    engine = create_engine(f"sqlite:///{path.as_posix()}")
+    try:
+        with engine.connect() as connection:
+            return migrate.current_revision(connection)
+    finally:
+        engine.dispose()
+
+
+def metadata_source_entries(path: Path) -> tuple[MetadataSourceEntry, ...]:
+    """Per-source dataset versions recorded in the database at ``path``.
+
+    Returns an empty tuple when the table does not exist — a backup taken from
+    a database older than the metadata framework is still a valid backup.
+    """
+    connection = _connect(path)
+    try:
+        present = connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (METADATA_SOURCES_TABLE,),
+        ).fetchone()
+        if present is None:
+            return ()
+        # The table name is a module constant, never caller input.
+        rows = connection.execute(
+            f"SELECT source, dataset_version, last_success_ms FROM {METADATA_SOURCES_TABLE} "
+            "ORDER BY source"
+        ).fetchall()
+    except sqlite3.Error as exc:
+        raise SnapshotError(f"reading metadata sources from {path} failed: {exc}") from exc
+    finally:
+        connection.close()
+
+    return tuple(
+        MetadataSourceEntry(
+            source=str(row[0]),
+            dataset_version=None if row[1] is None else str(row[1]),
+            last_success=utc_iso_from_ms(None if row[2] is None else int(row[2])),
+        )
+        for row in rows
+    )
+
+
+__all__ = [
+    "METADATA_SOURCES_TABLE",
+    "SNAPSHOT_TIMEOUT_S",
+    "metadata_source_entries",
+    "quick_check",
+    "snapshot_revision",
+    "vacuum_into",
+]

--- a/backend/src/flightsite/backup/verify.py
+++ b/backend/src/flightsite/backup/verify.py
@@ -1,0 +1,218 @@
+"""Archive validation, shared by ``verify`` and ``restore``.
+
+``flightsite-backup verify`` and the validation phase of
+``flightsite-backup restore`` run the *same* checks in the same order — the
+only difference is what they do with the answer and whether member payloads are
+written to disk on the way past. That is why this module exposes one
+:func:`inspect_archive` used by both: a restore can never be laxer than the
+verification a user ran beforehand.
+
+Checks, in order (cheapest and most diagnostic first):
+
+1. The container opens as a gzip tar.
+2. ``manifest.json`` exists and parses at a supported ``format_version``.
+3. Members are exactly the manifest's payload set plus the manifest itself —
+   no extras, no missing entries, no non-regular entries.
+4. Schema compatibility against this build's Alembic head (:mod:`.compat`).
+5. Every payload member's SHA-256 and byte length match the manifest.
+
+Verification collects *every* problem rather than stopping at the first, so a
+user diagnosing a bad archive sees the whole picture in one run.
+"""
+
+from __future__ import annotations
+
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from flightsite.backup import archive as archive_io
+from flightsite.backup.compat import SchemaCompatibility, check_schema
+from flightsite.backup.errors import ArchiveValidationError, BackupError
+from flightsite.backup.manifest import (
+    ALLOWED_MEMBERS,
+    MANIFEST_MEMBER,
+    Manifest,
+    parse_manifest,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FileCheck:
+    """The checksum verdict for one payload member."""
+
+    name: str
+    expected_sha256: str
+    actual_sha256: str
+    expected_size: int
+    actual_size: int
+
+    @property
+    def ok(self) -> bool:
+        """True when the member matched the manifest byte for byte."""
+        return self.expected_sha256 == self.actual_sha256 and self.expected_size == self.actual_size
+
+    def problem(self) -> str | None:
+        """A human-readable description of the mismatch, or ``None``."""
+        if self.ok:
+            return None
+        if self.expected_size != self.actual_size:
+            return (
+                f"{self.name}: size mismatch — manifest says {self.expected_size} bytes, "
+                f"archive holds {self.actual_size}"
+            )
+        return (
+            f"{self.name}: checksum mismatch — manifest says sha256 "
+            f"{self.expected_sha256}, archive holds {self.actual_sha256}. "
+            "The archive is corrupted or was modified after it was written."
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationReport:
+    """Everything ``verify`` learned about one archive."""
+
+    archive: Path
+    manifest: Manifest | None = None
+    compatibility: SchemaCompatibility | None = None
+    checks: tuple[FileCheck, ...] = ()
+    problems: tuple[str, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        """True when the archive is intact and restorable by this build."""
+        return not self.problems
+
+    def render(self) -> str:
+        """The multi-line report ``flightsite-backup verify`` prints."""
+        lines = [f"archive: {self.archive}"]
+        manifest = self.manifest
+        if manifest is not None:
+            lines += [
+                f"  format version:     {manifest.format_version}",
+                f"  flightsite version: {manifest.flightsite_version}",
+                f"  created (UTC):      {manifest.created_utc}",
+                f"  schema revision:    {manifest.schema_revision or '(unstamped)'}",
+                f"  includes secrets:   {'yes' if manifest.includes_secrets else 'no'}",
+            ]
+            if manifest.metadata_sources:
+                lines.append("  metadata sources:")
+                lines += [
+                    f"    - {entry.source}: version={entry.dataset_version or '-'} "
+                    f"last_success={entry.last_success or 'never'}"
+                    for entry in manifest.metadata_sources
+                ]
+            else:
+                lines.append("  metadata sources:   (none recorded)")
+        if self.checks:
+            lines.append("  checksums:")
+            lines += [
+                f"    - {check.name}: {'OK' if check.ok else 'FAILED'} ({check.actual_size} bytes)"
+                for check in self.checks
+            ]
+        if self.compatibility is not None:
+            lines.append(f"  compatibility:      {self.compatibility.summary()}")
+        if self.problems:
+            lines.append("  RESULT: NOT RESTORABLE")
+            lines += [f"    - {problem}" for problem in self.problems]
+        else:
+            lines.append("  RESULT: restorable")
+        return "\n".join(lines)
+
+
+def _member_problems(
+    names: tuple[str, ...], irregular: tuple[str, ...], manifest: Manifest
+) -> list[str]:
+    problems: list[str] = []
+    present = set(names)
+    expected = manifest.file_names | {MANIFEST_MEMBER}
+
+    for name in sorted(present - expected):
+        problems.append(f"archive holds {name!r}, which the manifest does not list")
+    for name in sorted(expected - present):
+        problems.append(f"manifest lists {name!r}, which the archive does not contain")
+    for name in sorted(present - ALLOWED_MEMBERS):
+        problems.append(f"member {name!r} is not a member name FlightSite backups may contain")
+    for name in sorted(set(irregular)):
+        problems.append(f"member {name!r} is not a regular file")
+    return problems
+
+
+def inspect_archive(path: Path, *, extract_to: Path | None = None) -> VerificationReport:
+    """Validate ``path``, optionally extracting payload members to ``extract_to``.
+
+    Never raises for a *content* problem: everything wrong with the archive
+    lands in :attr:`VerificationReport.problems`. Extraction to ``extract_to``
+    happens as part of the checksum pass, so a caller that wants the files
+    reads them exactly once.
+    """
+    problems: list[str] = []
+    manifest: Manifest | None = None
+    compatibility: SchemaCompatibility | None = None
+    checks: tuple[FileCheck, ...] = ()
+
+    try:
+        with archive_io.open_archive(path) as handle:
+            names = archive_io.member_names(handle)
+            manifest = parse_manifest(archive_io.read_member(handle, MANIFEST_MEMBER))
+            problems += _member_problems(names, archive_io.irregular_members(handle), manifest)
+
+            compatibility = check_schema(manifest.schema_revision)
+            if not compatibility.restorable:
+                problems.append(compatibility.summary())
+
+            checks, checksum_problems = _check_payloads(handle, manifest, names, extract_to)
+            problems += checksum_problems
+    except BackupError as exc:
+        problems.append(str(exc))
+
+    return VerificationReport(
+        archive=path,
+        manifest=manifest,
+        compatibility=compatibility,
+        checks=checks,
+        problems=tuple(problems),
+    )
+
+
+def _check_payloads(
+    handle: tarfile.TarFile,
+    manifest: Manifest,
+    names: tuple[str, ...],
+    extract_to: Path | None,
+) -> tuple[tuple[FileCheck, ...], list[str]]:
+    checks: list[FileCheck] = []
+    problems: list[str] = []
+    present = set(names)
+
+    for entry in manifest.files:
+        if entry.name not in present:
+            # Already reported as a missing member; do not also fail on it here.
+            continue
+        destination = None if extract_to is None else extract_to / entry.name
+        try:
+            digest = archive_io.copy_member(handle, entry.name, destination)
+        except ArchiveValidationError as exc:
+            problems.append(str(exc))
+            continue
+        check = FileCheck(
+            name=entry.name,
+            expected_sha256=entry.sha256,
+            actual_sha256=digest.sha256,
+            expected_size=entry.size_bytes,
+            actual_size=digest.size_bytes,
+        )
+        checks.append(check)
+        problem = check.problem()
+        if problem is not None:
+            problems.append(problem)
+
+    return tuple(checks), problems
+
+
+def verify_archive(path: Path) -> VerificationReport:
+    """Validate an archive without touching anything on disk."""
+    return inspect_archive(path, extract_to=None)
+
+
+__all__ = ["FileCheck", "VerificationReport", "inspect_archive", "verify_archive"]

--- a/backend/tests/backup/__init__.py
+++ b/backend/tests/backup/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the backup/restore commands (SPEC §72, §84 critical coverage)."""

--- a/backend/tests/backup/conftest.py
+++ b/backend/tests/backup/conftest.py
@@ -1,0 +1,233 @@
+"""Fixtures and helpers for the backup tests.
+
+The helpers here build and *tamper with* archives, because half of what this
+slice must prove is that damaged or mislabelled archives are refused. Repacking
+goes through :func:`repack` so a test can express "same archive, but the
+manifest claims a future schema revision" or "same archive, but one byte of the
+database is flipped" in a line.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import tarfile
+from collections.abc import AsyncIterator, Callable, Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from flightsite.backup.manifest import MANIFEST_MEMBER
+from flightsite.config import ConfigStore, Settings
+from flightsite.db import Database, database_path
+from flightsite.db.models import Aircraft, MetadataSource, Sighting
+from tests.conftest import SECRET_SENTINEL
+
+#: A fixed creation moment, so archive names and manifests are predictable.
+FIXED_NOW = datetime(2026, 9, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def fixed_clock(moment: datetime = FIXED_NOW) -> Callable[[], datetime]:
+    """A ``now`` callable for the backup/restore commands."""
+    return lambda: moment
+
+
+@pytest.fixture
+def data_dir(isolated_data_dir: Path) -> Path:
+    """The test's data directory (from the root ``conftest``)."""
+    return isolated_data_dir
+
+
+@pytest.fixture
+def config_files(data_dir: Path) -> ConfigStore:
+    """A data directory carrying both ``config.yaml`` and ``secrets.yaml``."""
+    store = ConfigStore(data_dir)
+    settings = Settings.model_validate(
+        {"data_dir": data_dir, "enrichment": {"aerodatabox_api_key": SECRET_SENTINEL}}
+    )
+    store.save(settings)
+    store.save_secrets(settings)
+    return store
+
+
+@pytest.fixture
+async def populated_db(data_dir: Path) -> AsyncIterator[Path]:
+    """A migrated database at head holding a small, self-consistent data set."""
+    path = database_path(data_dir)
+    database = Database(path)
+    try:
+        await database.upgrade_to("head")
+        await write_sightings(database, count=5)
+        await write_metadata_source(
+            database,
+            source="opensky",
+            dataset_version="2026-08-01",
+            last_success_ms=1_756_000_000_000,
+        )
+    finally:
+        await database.dispose()
+    yield path
+
+
+async def insert_pair(session: AsyncSession, index: int) -> None:
+    """Insert one aircraft and its sighting on ``session``, without committing.
+
+    Called inside a writer session so the pair lands in a single transaction:
+    that is the atomic unit a snapshot must never split.
+    """
+    aircraft = Aircraft(
+        icao24=f"{index:06x}",
+        first_seen_ms=1_700_000_000_000 + index,
+        last_seen_ms=1_700_000_000_000 + index,
+        sighting_count=1,
+    )
+    session.add(aircraft)
+    await session.flush()
+    session.add(
+        Sighting(
+            aircraft_id=aircraft.id,
+            started_ms=1_700_000_000_000 + index,
+            ended_ms=1_700_000_000_500 + index,
+        )
+    )
+
+
+async def write_sightings(database: Database, *, count: int, start: int = 0) -> None:
+    """Insert ``count`` aircraft each with one sighting, in one transaction each.
+
+    Aircraft and its sighting are written together so that a snapshot may never
+    legitimately contain a sighting whose aircraft is missing — that is the
+    invariant the live-backup consistency test checks.
+    """
+    for index in range(start, start + count):
+        async with database.writer_session() as session:
+            await insert_pair(session, index)
+
+
+async def write_metadata_source(
+    database: Database, *, source: str, dataset_version: str, last_success_ms: int
+) -> None:
+    """Seed one ``metadata_sources`` row so the manifest has something to record."""
+    async with database.writer_session() as session:
+        session.add(
+            MetadataSource(
+                source=source,
+                status="ok",
+                last_attempt_ms=last_success_ms,
+                last_success_ms=last_success_ms,
+                dataset_version=dataset_version,
+                row_count=42,
+            )
+        )
+
+
+def make_backup(data_dir: Path, *, include_secrets: bool = False) -> Path:
+    """Take a backup at :data:`FIXED_NOW` and return the archive path."""
+    from flightsite.backup import create_backup
+
+    return create_backup(data_dir, include_secrets=include_secrets, now=fixed_clock()).path
+
+
+def read_members(archive: Path) -> dict[str, bytes]:
+    """Every member of an archive as raw bytes."""
+    members: dict[str, bytes] = {}
+    with tarfile.open(archive, "r:gz") as handle:
+        for info in handle.getmembers():
+            stream = handle.extractfile(info)
+            members[info.name] = b"" if stream is None else stream.read()
+    return members
+
+
+def read_manifest_dict(archive: Path) -> dict[str, Any]:
+    """The archive's manifest as a plain dict."""
+    payload = read_members(archive)[MANIFEST_MEMBER]
+    parsed: dict[str, Any] = json.loads(payload)
+    return parsed
+
+
+def write_members(destination: Path, members: Mapping[str, bytes]) -> Path:
+    """Write ``members`` as a gzip tar at ``destination``."""
+    destination.unlink(missing_ok=True)
+    with tarfile.open(destination, "w:gz") as handle:
+        for name, payload in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            info.mtime = int(FIXED_NOW.timestamp())
+            handle.addfile(info, BytesReader(payload))
+    return destination
+
+
+def repack(
+    archive: Path,
+    destination: Path,
+    *,
+    mutate: Callable[[dict[str, bytes]], None] | None = None,
+    mutate_manifest: Callable[[dict[str, Any]], None] | None = None,
+) -> Path:
+    """Rebuild ``archive`` at ``destination`` with the given mutations applied."""
+    members = read_members(archive)
+    if mutate_manifest is not None:
+        manifest = json.loads(members[MANIFEST_MEMBER])
+        mutate_manifest(manifest)
+        members[MANIFEST_MEMBER] = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
+    if mutate is not None:
+        mutate(members)
+    return write_members(destination, members)
+
+
+def flip_byte(payload: bytes, offset: int) -> bytes:
+    """Return ``payload`` with the byte at ``offset`` inverted."""
+    mutable = bytearray(payload)
+    mutable[offset] ^= 0xFF
+    return bytes(mutable)
+
+
+class BytesReader:
+    """Minimal read-only stream over bytes for :meth:`tarfile.TarFile.addfile`."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+        self._offset = 0
+
+    def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            size = len(self._payload) - self._offset
+        chunk = self._payload[self._offset : self._offset + size]
+        self._offset += len(chunk)
+        return chunk
+
+
+def file_bytes(path: Path) -> bytes:
+    """Read a file. A plain function so ``async`` tests stay free of blocking I/O calls."""
+    return path.read_bytes()
+
+
+def glob_names(directory: Path, pattern: str) -> list[str]:
+    """Sorted names of the entries in ``directory`` matching ``pattern``."""
+    return sorted(path.name for path in directory.glob(pattern))
+
+
+def tree_mtimes(directory: Path) -> dict[str, int]:
+    """Modification times of every path under ``directory``, keyed by name."""
+    return {str(path): path.stat().st_mtime_ns for path in sorted(directory.rglob("*"))}
+
+
+def sqlite_rows(path: Path, sql: str) -> list[tuple[Any, ...]]:
+    """Run a query against a database file with stdlib ``sqlite3``.
+
+    Deliberately not through the ORM: an assertion about what a *restored file*
+    contains must not be satisfiable by the application's own machinery.
+    """
+    connection = sqlite3.connect(path)
+    try:
+        return [tuple(row) for row in connection.execute(sql).fetchall()]
+    finally:
+        connection.close()
+
+
+def sqlite_scalar(path: Path, sql: str) -> Any:
+    """Run a single-value query against a database file."""
+    return sqlite_rows(path, sql)[0][0]

--- a/backend/tests/backup/test_cli.py
+++ b/backend/tests/backup/test_cli.py
@@ -1,0 +1,199 @@
+"""``flightsite-backup``: argument handling, output, and exit codes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from flightsite.backup import DATABASE_MEMBER, SECRETS_MEMBER, default_backup_dir
+from flightsite.backup.cli import EXIT_OK, EXIT_REFUSED, EXIT_USAGE, build_arg_parser, main
+from flightsite.config import ConfigStore
+from flightsite.config.paths import DATA_DIR_ENV_VAR
+from tests.backup.conftest import (
+    file_bytes,
+    flip_byte,
+    make_backup,
+    read_members,
+    repack,
+    sqlite_scalar,
+    write_sightings,
+)
+from tests.conftest import SECRET_SENTINEL
+
+
+def only_archive(data_dir: Path) -> Path:
+    """The single archive in the data directory's backups folder."""
+    archives = sorted(default_backup_dir(data_dir).glob("*.tar.gz"))
+    assert len(archives) == 1
+    return archives[0]
+
+
+async def test_create_writes_an_archive_and_reports_it(
+    data_dir: Path, populated_db: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(["create"]) == EXIT_OK
+
+    archive = only_archive(data_dir)
+    out = capsys.readouterr().out
+    assert str(archive) in out
+    assert "includes secrets:   no" in out
+
+
+async def test_create_resolves_the_data_dir_from_the_environment(
+    data_dir: Path, populated_db: Path
+) -> None:
+    """No arguments needed inside the container, where the env var is set."""
+    import os
+
+    assert os.environ[DATA_DIR_ENV_VAR] == str(data_dir)
+
+    assert main(["create"]) == EXIT_OK
+    assert only_archive(data_dir).exists()
+
+
+async def test_create_accepts_an_explicit_data_dir_and_out_dir(
+    data_dir: Path, populated_db: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(DATA_DIR_ENV_VAR)
+    destination = tmp_path / "external-drive"
+
+    assert main(["create", "--data-dir", str(data_dir), "--out", str(destination)]) == EXIT_OK
+
+    assert len(list(destination.glob("*.tar.gz"))) == 1
+
+
+async def test_create_include_secrets_puts_them_in_the_archive(
+    data_dir: Path, populated_db: Path, config_files: ConfigStore
+) -> None:
+    assert main(["create", "--include-secrets"]) == EXIT_OK
+
+    members = read_members(only_archive(data_dir))
+    assert SECRET_SENTINEL.encode() in members[SECRETS_MEMBER]
+
+
+async def test_create_warns_when_there_are_no_secrets_to_include(
+    data_dir: Path, populated_db: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(["create", "--include-secrets"]) == EXIT_OK
+
+    captured = capsys.readouterr()
+    assert "includes_secrets=false" in captured.err
+    assert "includes secrets:   no" in captured.out
+
+
+async def test_create_without_a_database_is_refused(
+    data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(["create"]) == EXIT_REFUSED
+    assert "no FlightSite database" in capsys.readouterr().err
+
+
+async def test_verify_prints_a_report_and_exits_zero(
+    data_dir: Path, populated_db: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    archive = make_backup(data_dir)
+
+    assert main(["verify", str(archive)]) == EXIT_OK
+
+    out = capsys.readouterr().out
+    assert "RESULT: restorable" in out
+    assert f"- {DATABASE_MEMBER}: OK" in out
+
+
+async def test_verify_of_a_corrupted_archive_exits_nonzero(
+    data_dir: Path, populated_db: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    archive = make_backup(data_dir)
+    damaged = repack(
+        archive,
+        tmp_path / "damaged.tar.gz",
+        mutate=lambda members: members.__setitem__(
+            DATABASE_MEMBER, flip_byte(members[DATABASE_MEMBER], 3000)
+        ),
+    )
+
+    assert main(["verify", str(damaged)]) == EXIT_REFUSED
+
+    out = capsys.readouterr().out
+    assert "RESULT: NOT RESTORABLE" in out
+    assert "checksum mismatch" in out
+
+
+async def test_restore_without_confirm_is_a_usage_error(
+    data_dir: Path, populated_db: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    archive = make_backup(data_dir)
+    before = file_bytes(populated_db)
+
+    assert main(["restore", str(archive)]) == EXIT_USAGE
+
+    err = capsys.readouterr().err
+    assert "--confirm" in err
+    assert "Stop FlightSite before restoring" in err
+    assert file_bytes(populated_db) == before
+
+
+async def test_restore_with_confirm_replaces_the_database(
+    data_dir: Path, populated_db: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    archive = make_backup(data_dir)
+
+    from flightsite.db import Database
+
+    database = Database(populated_db)
+    try:
+        await write_sightings(database, count=2, start=900)
+    finally:
+        await database.dispose()
+    assert sqlite_scalar(populated_db, "SELECT COUNT(*) FROM sightings") == 7
+
+    assert main(["restore", str(archive), "--confirm"]) == EXIT_OK
+
+    assert sqlite_scalar(populated_db, "SELECT COUNT(*) FROM sightings") == 5
+    assert "Stop FlightSite before restoring" in capsys.readouterr().out
+
+
+async def test_restore_of_a_damaged_archive_exits_refused(
+    data_dir: Path, populated_db: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    archive = make_backup(data_dir)
+    damaged = repack(
+        archive,
+        tmp_path / "damaged.tar.gz",
+        mutate=lambda members: members.__setitem__(
+            DATABASE_MEMBER, flip_byte(members[DATABASE_MEMBER], 3000)
+        ),
+    )
+
+    assert main(["restore", str(damaged), "--confirm"]) == EXIT_REFUSED
+    assert "checksum mismatch" in capsys.readouterr().err
+
+
+async def test_restore_of_a_newer_schema_archive_exits_refused(
+    data_dir: Path, populated_db: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    archive = make_backup(data_dir)
+    future = repack(
+        archive,
+        tmp_path / "future.tar.gz",
+        mutate_manifest=lambda manifest: manifest.__setitem__("schema_revision", "8888"),
+    )
+
+    assert main(["restore", str(future), "--confirm"]) == EXIT_REFUSED
+    assert "Upgrade FlightSite" in capsys.readouterr().err
+
+
+def test_a_missing_subcommand_is_a_usage_error() -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        main([])
+
+    assert exit_info.value.code == EXIT_USAGE
+
+
+def test_the_parser_documents_every_subcommand() -> None:
+    help_text = build_arg_parser().format_help()
+
+    assert "create" in help_text
+    assert "restore" in help_text
+    assert "verify" in help_text

--- a/backend/tests/backup/test_cli.py
+++ b/backend/tests/backup/test_cli.py
@@ -151,7 +151,7 @@ async def test_restore_with_confirm_replaces_the_database(
     assert main(["restore", str(archive), "--confirm"]) == EXIT_OK
 
     assert sqlite_scalar(populated_db, "SELECT COUNT(*) FROM sightings") == 5
-    assert "Stop FlightSite before restoring" in capsys.readouterr().out
+    assert "start FlightSite" in capsys.readouterr().out
 
 
 async def test_restore_of_a_damaged_archive_exits_refused(

--- a/backend/tests/backup/test_create.py
+++ b/backend/tests/backup/test_create.py
@@ -1,0 +1,215 @@
+"""Creating backups: contents, manifest correctness, secrets policy."""
+
+from __future__ import annotations
+
+import tarfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from flightsite import __version__
+from flightsite.backup import (
+    CONFIG_MEMBER,
+    DATABASE_MEMBER,
+    FORMAT_VERSION,
+    MANIFEST_MEMBER,
+    SECRETS_MEMBER,
+    BackupError,
+    archive_name,
+    create_backup,
+    default_backup_dir,
+)
+from flightsite.backup.snapshot import quick_check
+from flightsite.config import ConfigStore
+from flightsite.db import migrate
+from tests.backup.conftest import (
+    FIXED_NOW,
+    fixed_clock,
+    read_manifest_dict,
+    read_members,
+    sqlite_scalar,
+)
+from tests.conftest import SECRET_SENTINEL
+
+
+async def test_backup_lands_in_the_documented_location(data_dir: Path, populated_db: Path) -> None:
+    result = create_backup(data_dir, now=fixed_clock())
+
+    assert result.path.parent == default_backup_dir(data_dir)
+    assert result.path.name == "flightsite-backup-20260901T120000Z.tar.gz"
+    assert result.path.exists()
+    assert result.size_bytes == result.path.stat().st_size
+
+
+async def test_backup_contains_database_config_and_manifest(
+    data_dir: Path, populated_db: Path, config_files: ConfigStore
+) -> None:
+    result = create_backup(data_dir, now=fixed_clock())
+
+    assert set(read_members(result.path)) == {MANIFEST_MEMBER, DATABASE_MEMBER, CONFIG_MEMBER}
+
+
+async def test_manifest_records_version_revision_and_checksums(
+    data_dir: Path, populated_db: Path, config_files: ConfigStore
+) -> None:
+    result = create_backup(data_dir, now=fixed_clock())
+    manifest = read_manifest_dict(result.path)
+
+    assert manifest["format_version"] == FORMAT_VERSION
+    assert manifest["flightsite_version"] == __version__
+    assert manifest["schema_revision"] == migrate.head_revision()
+    assert manifest["created_utc"] == "2026-09-01T12:00:00Z"
+    assert manifest["includes_secrets"] is False
+
+    members = read_members(result.path)
+    for name, entry in manifest["files"].items():
+        assert entry["size_bytes"] == len(members[name])
+        assert len(entry["sha256"]) == 64
+
+
+async def test_manifest_checksums_match_the_archived_bytes(
+    data_dir: Path, populated_db: Path
+) -> None:
+    import hashlib
+
+    result = create_backup(data_dir, now=fixed_clock())
+    members = read_members(result.path)
+    manifest = read_manifest_dict(result.path)
+
+    for name, entry in manifest["files"].items():
+        assert hashlib.sha256(members[name]).hexdigest() == entry["sha256"]
+
+
+async def test_manifest_records_metadata_source_versions(
+    data_dir: Path, populated_db: Path
+) -> None:
+    manifest = read_manifest_dict(create_backup(data_dir, now=fixed_clock()).path)
+
+    assert manifest["metadata_sources"] == [
+        {
+            "source": "opensky",
+            "dataset_version": "2026-08-01",
+            "last_success": "2025-08-24T01:46:40Z",
+        }
+    ]
+
+
+async def test_snapshot_is_a_healthy_standalone_database(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    result = create_backup(data_dir, now=fixed_clock())
+
+    extracted = tmp_path / "extracted"
+    extracted.mkdir()
+    with tarfile.open(result.path, "r:gz") as handle:
+        member = handle.extractfile(DATABASE_MEMBER)
+        assert member is not None
+        (extracted / DATABASE_MEMBER).write_bytes(member.read())
+
+    snapshot = extracted / DATABASE_MEMBER
+    assert quick_check(snapshot) == ["ok"]
+    assert sqlite_scalar(snapshot, "SELECT COUNT(*) FROM sightings") == 5
+
+
+async def test_secrets_are_excluded_unless_requested(
+    data_dir: Path, populated_db: Path, config_files: ConfigStore
+) -> None:
+    result = create_backup(data_dir, now=fixed_clock())
+
+    members = read_members(result.path)
+    assert SECRETS_MEMBER not in members
+    assert result.manifest.includes_secrets is False
+    assert SECRET_SENTINEL.encode() not in b"".join(members.values())
+
+
+async def test_secrets_are_included_and_declared_when_requested(
+    data_dir: Path, populated_db: Path, config_files: ConfigStore
+) -> None:
+    result = create_backup(data_dir, include_secrets=True, now=fixed_clock())
+
+    members = read_members(result.path)
+    assert SECRET_SENTINEL.encode() in members[SECRETS_MEMBER]
+    assert result.manifest.includes_secrets is True
+    assert read_manifest_dict(result.path)["includes_secrets"] is True
+
+
+async def test_include_secrets_stays_honest_when_there_are_no_secrets(
+    data_dir: Path, populated_db: Path
+) -> None:
+    """No ``secrets.yaml`` means the manifest says ``false``, not ``true``."""
+    result = create_backup(data_dir, include_secrets=True, now=fixed_clock())
+
+    assert SECRETS_MEMBER not in read_members(result.path)
+    assert result.manifest.includes_secrets is False
+
+
+async def test_backup_of_a_data_dir_without_config_still_works(
+    data_dir: Path, populated_db: Path
+) -> None:
+    result = create_backup(data_dir, now=fixed_clock())
+
+    assert set(read_members(result.path)) == {MANIFEST_MEMBER, DATABASE_MEMBER}
+
+
+async def test_out_dir_overrides_the_default_location(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    elsewhere = tmp_path / "usb-stick" / "flightsite"
+    result = create_backup(data_dir, out_dir=elsewhere, now=fixed_clock())
+
+    assert result.path.parent == elsewhere
+    assert not default_backup_dir(data_dir).exists()
+
+
+async def test_backup_refuses_a_data_dir_with_no_database(data_dir: Path) -> None:
+    with pytest.raises(BackupError, match="no FlightSite database"):
+        create_backup(data_dir, now=fixed_clock())
+
+
+async def test_backup_refuses_to_overwrite_an_existing_archive(
+    data_dir: Path, populated_db: Path
+) -> None:
+    create_backup(data_dir, now=fixed_clock())
+
+    with pytest.raises(BackupError, match="already exists"):
+        create_backup(data_dir, now=fixed_clock())
+
+
+async def test_backup_leaves_no_temporary_files_behind(data_dir: Path, populated_db: Path) -> None:
+    result = create_backup(data_dir, now=fixed_clock())
+
+    assert [path.name for path in result.path.parent.iterdir()] == [result.path.name]
+
+
+async def test_a_failed_backup_leaves_the_destination_clean(
+    data_dir: Path, populated_db: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def explode(*args: object, **kwargs: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("flightsite.backup.create.archive_io.write_archive", explode)
+
+    with pytest.raises(OSError, match="disk full"):
+        create_backup(data_dir, now=fixed_clock())
+
+    assert list(default_backup_dir(data_dir).iterdir()) == []
+
+
+def test_archive_name_is_utc_regardless_of_the_clock_s_zone() -> None:
+    from datetime import timedelta, timezone
+
+    local = FIXED_NOW.astimezone(timezone(timedelta(hours=9)))
+
+    assert archive_name(local) == archive_name(FIXED_NOW)
+    assert archive_name(datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)).startswith(
+        "flightsite-backup-20260102T030405Z"
+    )
+
+
+async def test_result_render_summarises_the_backup(data_dir: Path, populated_db: Path) -> None:
+    rendered = create_backup(data_dir, now=fixed_clock()).render()
+
+    assert "includes secrets:   no" in rendered
+    assert migrate.head_revision() in rendered
+    assert DATABASE_MEMBER in rendered

--- a/backend/tests/backup/test_cross_version.py
+++ b/backend/tests/backup/test_cross_version.py
@@ -1,0 +1,165 @@
+"""Cross-version restore (SPEC §72, roadmap 043 ACs 2 and 3).
+
+Two directions, both required:
+
+* an **older** backup restores into this build and is migrated to head by the
+  ordinary startup sequence — proven with a real earlier revision produced by
+  the migration harness's downgrade, not a hand-built fixture file;
+* a **newer** backup is refused, because this build has no migration that could
+  bring the schema back.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from flightsite.backup import (
+    SchemaCompatibilityError,
+    SchemaRelation,
+    check_schema,
+    restore_backup,
+    verify_archive,
+)
+from flightsite.counters import counters
+from flightsite.db import Database, database_path, migrate
+from flightsite.db.startup import DATABASE_SUBSYSTEM, initialize_database
+from flightsite.readiness import ReadinessRegistry
+from tests.backup.conftest import fixed_clock, make_backup, repack, sqlite_scalar, write_sightings
+from tests.db.harness import INITIAL_REVISION
+
+#: An earlier revision that predates several tables — far enough back that
+#: "restore then migrate" is doing real work, not a no-op.
+OLDER_REVISION = "0004"
+
+
+def test_head_is_reported_as_same() -> None:
+    verdict = check_schema(migrate.head_revision())
+
+    assert verdict.relation is SchemaRelation.SAME
+    assert verdict.restorable
+    assert not verdict.migration_required
+    assert "no migration needed" in verdict.summary()
+
+
+def test_an_ancestor_revision_is_older_and_migratable() -> None:
+    verdict = check_schema(INITIAL_REVISION)
+
+    assert verdict.relation is SchemaRelation.OLDER
+    assert verdict.restorable
+    assert verdict.migration_required
+    assert "migrate it forward on the next start" in verdict.summary()
+
+
+def test_an_unknown_revision_is_refused() -> None:
+    verdict = check_schema("deadbeef")
+
+    assert verdict.relation is SchemaRelation.UNKNOWN
+    assert not verdict.restorable
+    assert "newer FlightSite" in verdict.summary()
+
+
+def test_an_unstamped_database_is_treated_as_base() -> None:
+    verdict = check_schema(None)
+
+    assert verdict.relation is SchemaRelation.OLDER
+    assert "(unstamped)" in verdict.summary()
+
+
+async def test_an_old_backup_restores_and_migrates_to_head_on_startup(
+    data_dir: Path, tmp_path: Path
+) -> None:
+    """The rollback path of ``docs/RELEASE.md``, end to end."""
+    # 1. Build a data directory at an earlier real revision, the way an older
+    #    release left it: upgrade to head, then downgrade through the graph.
+    source = Database(database_path(data_dir))
+    try:
+        await source.upgrade_to("head")
+        await source.downgrade_to(OLDER_REVISION)
+        assert await source.current_revision() == OLDER_REVISION
+        await write_sightings(source, count=3)
+    finally:
+        await source.dispose()
+
+    # 2. Back it up. The manifest must record the old revision, not head.
+    archive = make_backup(data_dir)
+    report = verify_archive(archive)
+    assert report.manifest is not None
+    assert report.manifest.schema_revision == OLDER_REVISION
+    assert report.compatibility is not None
+    assert report.compatibility.migration_required
+    assert report.ok
+
+    # 3. Restore into a fresh data directory.
+    target = tmp_path / "upgraded-host"
+    result = restore_backup(archive, target, confirm=True, now=fixed_clock())
+    assert result.migration_required
+    restored_db = database_path(target)
+    assert sqlite_scalar(restored_db, "SELECT version_num FROM alembic_version") == OLDER_REVISION
+
+    # 4. Start FlightSite on it: the ordinary startup sequence migrates to head.
+    database = Database(restored_db)
+    readiness = ReadinessRegistry()
+    readiness.register(DATABASE_SUBSYSTEM)
+    try:
+        assert await initialize_database(database, readiness, counters=counters) is True
+        assert await database.current_revision() == migrate.head_revision()
+        assert await database.quick_check() == ["ok"]
+    finally:
+        await database.dispose()
+
+    assert readiness.snapshot()[DATABASE_SUBSYSTEM] is True
+    # The pre-migration rows survived the upgrade.
+    assert sqlite_scalar(restored_db, "SELECT COUNT(*) FROM sightings") == 3
+
+
+async def test_a_newer_schema_backup_is_refused_by_verify_and_restore(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    archive = make_backup(data_dir)
+    from_the_future = repack(
+        archive,
+        tmp_path / "future.tar.gz",
+        mutate_manifest=lambda manifest: manifest.__setitem__("schema_revision", "0999_warp_drive"),
+    )
+
+    report = verify_archive(from_the_future)
+    assert not report.ok
+    assert any("not part of this build's migration history" in p for p in report.problems)
+    assert "Upgrade FlightSite" in report.render()
+
+    with pytest.raises(SchemaCompatibilityError):
+        restore_backup(from_the_future, tmp_path / "victim", confirm=True, now=fixed_clock())
+
+
+async def test_an_unstamped_snapshot_restores_and_migrates_from_base(
+    data_dir: Path, tmp_path: Path
+) -> None:
+    """A backup of a data directory that was created but never migrated."""
+    import sqlite3
+
+    path = database_path(data_dir)
+    connection = sqlite3.connect(path)
+    connection.execute("CREATE TABLE placeholder (x INTEGER)")
+    connection.commit()
+    connection.close()
+
+    archive = make_backup(data_dir)
+    report = verify_archive(archive)
+    assert report.ok
+    assert report.manifest is not None
+    assert report.manifest.schema_revision is None
+    assert report.manifest.metadata_sources == ()
+
+    target = tmp_path / "from-blank"
+    restore_backup(archive, target, confirm=True, now=fixed_clock())
+
+    database = Database(database_path(target))
+    readiness = ReadinessRegistry()
+    readiness.register(DATABASE_SUBSYSTEM)
+    try:
+        assert await initialize_database(database, readiness, counters=counters) is True
+        assert await database.current_revision() == migrate.head_revision()
+    finally:
+        await database.dispose()

--- a/backend/tests/backup/test_errors.py
+++ b/backend/tests/backup/test_errors.py
@@ -1,0 +1,178 @@
+"""Failure paths: every refusal must be a clear message, never a traceback.
+
+A backup tool earns trust by how it behaves when something is wrong, so the
+error handlers get the same coverage as the happy path (SPEC §84 puts
+backup/restore in the critical set).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from flightsite.backup import (
+    DATABASE_MEMBER,
+    MANIFEST_MEMBER,
+    ArchiveValidationError,
+    BackupError,
+    RestoreError,
+    SnapshotError,
+    create_backup,
+    restore_backup,
+    verify_archive,
+)
+from flightsite.backup import archive as archive_io
+from flightsite.backup.snapshot import metadata_source_entries, quick_check, vacuum_into
+from tests.backup.conftest import FIXED_NOW, BytesReader, fixed_clock, make_backup, read_members
+
+# --------------------------------------------------------------- snapshotting
+
+
+def test_snapshot_refuses_a_missing_source(tmp_path: Path) -> None:
+    with pytest.raises(SnapshotError, match="no database to back up"):
+        vacuum_into(tmp_path / "absent.sqlite3", tmp_path / "out.sqlite3")
+
+
+def test_snapshot_refuses_to_overwrite_its_destination(tmp_path: Path) -> None:
+    source = tmp_path / "source.sqlite3"
+    sqlite3.connect(source).close()
+    destination = tmp_path / "out.sqlite3"
+    destination.write_bytes(b"")
+
+    with pytest.raises(SnapshotError, match="destination already exists"):
+        vacuum_into(source, destination)
+
+
+def test_snapshot_of_a_non_database_is_reported(tmp_path: Path) -> None:
+    junk = tmp_path / "not-a-database.sqlite3"
+    junk.write_bytes(b"SQLite format 3\x00 but not really" + b"\x00" * 200)
+
+    with pytest.raises(SnapshotError, match="SQLite snapshot"):
+        vacuum_into(junk, tmp_path / "out.sqlite3")
+
+    assert not (tmp_path / "out.sqlite3").exists()
+
+
+def test_integrity_check_of_a_non_database_is_reported(tmp_path: Path) -> None:
+    junk = tmp_path / "junk.sqlite3"
+    junk.write_bytes(b"SQLite format 3\x00" + b"\xff" * 4096)
+
+    with pytest.raises(SnapshotError, match="integrity check"):
+        quick_check(junk)
+
+
+def test_reading_metadata_sources_from_a_non_database_is_reported(tmp_path: Path) -> None:
+    junk = tmp_path / "junk.sqlite3"
+    junk.write_bytes(b"SQLite format 3\x00" + b"\xff" * 4096)
+
+    with pytest.raises(SnapshotError, match="reading metadata sources"):
+        metadata_source_entries(junk)
+
+
+# ------------------------------------------------------------------- creating
+
+
+async def test_create_reports_an_unusable_output_directory(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    blocked = tmp_path / "a-file-not-a-directory"
+    blocked.write_text("in the way", encoding="utf-8")
+
+    with pytest.raises(BackupError, match="cannot create backup directory"):
+        create_backup(data_dir, out_dir=blocked, now=fixed_clock())
+
+
+# ------------------------------------------------------------------ restoring
+
+
+async def test_restore_reports_an_unusable_data_directory(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    archive = make_backup(data_dir)
+    blocked = tmp_path / "a-file-not-a-directory"
+    blocked.write_text("in the way", encoding="utf-8")
+
+    with pytest.raises(RestoreError, match="cannot create data directory"):
+        restore_backup(archive, blocked, confirm=True, now=fixed_clock())
+
+
+# -------------------------------------------------------------- archive I/O
+
+
+async def test_a_truncated_archive_fails_while_reading_the_index(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    """The tar index is interleaved with the data, so truncation breaks it."""
+    archive = make_backup(data_dir)
+    truncated = tmp_path / "truncated.tar.gz"
+    payload = archive.read_bytes()
+    truncated.write_bytes(payload[: len(payload) // 2])
+
+    report = verify_archive(truncated)
+
+    assert not report.ok
+    assert any(
+        "unreadable" in problem or "not a readable" in problem for problem in report.problems
+    )
+
+
+async def test_a_member_the_manifest_lists_but_that_is_a_symlink_is_refused(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    """A hostile archive cannot smuggle a link in under a listed member's name."""
+    members = read_members(make_backup(data_dir))
+    hostile = tmp_path / "hostile.tar.gz"
+    with tarfile.open(hostile, "w:gz") as handle:
+        manifest = tarfile.TarInfo(MANIFEST_MEMBER)
+        manifest.size = len(members[MANIFEST_MEMBER])
+        manifest.mtime = int(FIXED_NOW.timestamp())
+        handle.addfile(manifest, BytesReader(members[MANIFEST_MEMBER]))
+
+        link = tarfile.TarInfo(DATABASE_MEMBER)
+        link.type = tarfile.SYMTYPE
+        link.linkname = "/etc/passwd"
+        link.mtime = int(FIXED_NOW.timestamp())
+        handle.addfile(link)
+
+    report = verify_archive(hostile)
+
+    assert not report.ok
+    assert any("is not a regular file" in problem for problem in report.problems)
+
+
+async def test_a_member_that_fails_mid_read_is_reported_not_raised(
+    data_dir: Path, populated_db: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An I/O error part-way through a member becomes a validation problem."""
+    archive = make_backup(data_dir)
+
+    class FailingStream:
+        def read(self, size: int = -1) -> bytes:
+            raise OSError("input/output error")
+
+        def close(self) -> None:
+            return None
+
+    with archive_io.open_archive(archive) as handle:
+        monkeypatch.setattr(handle, "extractfile", lambda info: FailingStream())
+
+        with pytest.raises(ArchiveValidationError, match="could not be read"):
+            archive_io.copy_member(handle, DATABASE_MEMBER, None)
+
+        with pytest.raises(ArchiveValidationError, match="could not be read"):
+            archive_io.read_member(handle, MANIFEST_MEMBER)
+
+
+async def test_reading_a_member_the_archive_lacks_is_reported(
+    data_dir: Path, populated_db: Path
+) -> None:
+    archive = make_backup(data_dir)
+
+    with (
+        archive_io.open_archive(archive) as handle,
+        pytest.raises(ArchiveValidationError, match="missing member"),
+    ):
+        archive_io.read_member(handle, "secrets.yaml")

--- a/backend/tests/backup/test_live_backup.py
+++ b/backend/tests/backup/test_live_backup.py
@@ -1,0 +1,112 @@
+"""Backing up a database that is being written to (roadmap 043 AC 1).
+
+The acceptance criterion is "backup during active ingestion yields a
+consistent, restorable snapshot". The write pattern here mirrors the
+persistence worker's: every aircraft and its sighting are inserted in **one**
+writer transaction through :meth:`Database.writer_session`, so a snapshot that
+tore mid-transaction would show a sighting whose aircraft row is absent. That
+is the invariant the assertions below stand on — not merely "the file opens".
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from flightsite.backup import DATABASE_MEMBER, create_backup, restore_backup
+from flightsite.backup.snapshot import quick_check
+from flightsite.db import Database, database_path
+from tests.backup.conftest import (
+    fixed_clock,
+    insert_pair,
+    read_members,
+    sqlite_rows,
+    sqlite_scalar,
+)
+
+
+async def _write_until(database: Database, stop: asyncio.Event, *, start: int) -> int:
+    """Insert aircraft+sighting pairs until ``stop`` is set; return how many."""
+    written = 0
+    index = start
+    while not stop.is_set():
+        async with database.writer_session() as session:
+            await insert_pair(session, index)
+        written += 1
+        index += 1
+        # Yield so the snapshot thread actually interleaves with the writer.
+        await asyncio.sleep(0)
+    return written
+
+
+async def test_backup_while_the_writer_is_committing(data_dir: Path, tmp_path: Path) -> None:
+    database = Database(database_path(data_dir))
+    stop = asyncio.Event()
+    try:
+        await database.upgrade_to("head")
+        writer = asyncio.create_task(_write_until(database, stop, start=1))
+
+        # Let a few transactions land, then snapshot while the writer runs on.
+        await asyncio.sleep(0.05)
+        result = await asyncio.to_thread(create_backup, data_dir, now=fixed_clock())
+        assert not writer.done(), "the writer stopped before the snapshot finished"
+
+        await asyncio.sleep(0.05)
+        stop.set()
+        total_written = await writer
+    finally:
+        stop.set()
+        await database.dispose()
+
+    snapshot = tmp_path / DATABASE_MEMBER
+    snapshot.write_bytes(read_members(result.path)[DATABASE_MEMBER])
+
+    # 1. The snapshot is a sound SQLite database on its own.
+    assert quick_check(snapshot) == ["ok"]
+
+    # 2. It caught a prefix of the writer's work — neither empty nor impossible.
+    snapshot_sightings = sqlite_scalar(snapshot, "SELECT COUNT(*) FROM sightings")
+    assert 0 < snapshot_sightings <= total_written
+
+    # 3. The sighting set is consistent: no sighting without its aircraft, and
+    #    no half-written pair. A torn snapshot would break exactly here.
+    assert sqlite_rows(snapshot, "PRAGMA foreign_key_check") == []
+    assert (
+        sqlite_scalar(
+            snapshot,
+            "SELECT COUNT(*) FROM sightings s "
+            "LEFT JOIN aircraft a ON a.id = s.aircraft_id WHERE a.id IS NULL",
+        )
+        == 0
+    )
+    assert sqlite_scalar(snapshot, "SELECT COUNT(*) FROM aircraft") == snapshot_sightings
+
+    # 4. The archive carries no WAL sidecar: VACUUM INTO materializes everything.
+    assert set(read_members(result.path)) == {"manifest.json", DATABASE_MEMBER}
+
+
+async def test_a_live_backup_restores_into_a_working_installation(
+    data_dir: Path, tmp_path: Path
+) -> None:
+    database = Database(database_path(data_dir))
+    stop = asyncio.Event()
+    try:
+        await database.upgrade_to("head")
+        writer = asyncio.create_task(_write_until(database, stop, start=500))
+        await asyncio.sleep(0.05)
+        result = await asyncio.to_thread(create_backup, data_dir, now=fixed_clock())
+        stop.set()
+        await writer
+    finally:
+        stop.set()
+        await database.dispose()
+
+    target = tmp_path / "restored-data"
+    restore_backup(result.path, target, confirm=True, now=fixed_clock())
+
+    restored = Database(database_path(target))
+    try:
+        assert await restored.quick_check() == ["ok"]
+        assert await restored.current_revision() is not None
+    finally:
+        await restored.dispose()

--- a/backend/tests/backup/test_manifest.py
+++ b/backend/tests/backup/test_manifest.py
@@ -1,0 +1,158 @@
+"""Manifest parsing: it must reject a wrong shape with a readable complaint."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from flightsite.backup import FORMAT_VERSION, ManifestError, parse_manifest
+from flightsite.backup.manifest import (
+    FileEntry,
+    Manifest,
+    MetadataSourceEntry,
+    utc_iso,
+    utc_iso_from_ms,
+)
+
+
+def valid_manifest_dict(**overrides: Any) -> dict[str, Any]:
+    document: dict[str, Any] = {
+        "format_version": FORMAT_VERSION,
+        "flightsite_version": "0.0.1",
+        "schema_revision": "0009",
+        "created_utc": "2026-09-01T12:00:00Z",
+        "includes_secrets": False,
+        "files": {"flightsite.sqlite3": {"sha256": "a" * 64, "size_bytes": 4096}},
+        "metadata_sources": [],
+    }
+    document.update(overrides)
+    return document
+
+
+def test_round_trip_preserves_every_field() -> None:
+    manifest = Manifest(
+        format_version=FORMAT_VERSION,
+        flightsite_version="1.2.3",
+        schema_revision="0007",
+        created_utc="2026-09-01T12:00:00Z",
+        includes_secrets=True,
+        files=(FileEntry("config.yaml", "b" * 64, 12),),
+        metadata_sources=(MetadataSourceEntry("opensky", "2026-08-01", "2026-08-01T00:00:00Z"),),
+    )
+
+    assert parse_manifest(manifest.to_json()) == manifest
+
+
+def test_manifest_json_is_newline_terminated() -> None:
+    manifest = parse_manifest(json.dumps(valid_manifest_dict()))
+
+    assert manifest.to_json().endswith("}\n")
+
+
+def test_file_lookup_and_names() -> None:
+    manifest = parse_manifest(json.dumps(valid_manifest_dict()))
+
+    assert manifest.file("flightsite.sqlite3") is not None
+    assert manifest.file("secrets.yaml") is None
+    assert manifest.file_names == frozenset({"flightsite.sqlite3"})
+
+
+def test_unparseable_json_is_rejected() -> None:
+    with pytest.raises(ManifestError, match="not valid JSON"):
+        parse_manifest(b"{not json")
+
+
+def test_a_non_object_manifest_is_rejected() -> None:
+    with pytest.raises(ManifestError, match="must be a JSON object"):
+        parse_manifest(b"[1, 2, 3]")
+
+
+def test_an_unsupported_format_version_is_refused_with_advice() -> None:
+    payload = json.dumps(valid_manifest_dict(format_version=FORMAT_VERSION + 1))
+
+    with pytest.raises(ManifestError, match="is not supported by this FlightSite build"):
+        parse_manifest(payload)
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["format_version", "flightsite_version", "created_utc", "includes_secrets", "files"],
+)
+def test_a_missing_required_key_is_named(key: str) -> None:
+    document = valid_manifest_dict()
+    del document[key]
+
+    with pytest.raises(ManifestError, match=f"missing required key '{key}'"):
+        parse_manifest(json.dumps(document))
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"format_version": "1"}, "'format_version' must be an integer"),
+        ({"flightsite_version": 1}, "'flightsite_version' must be a string"),
+        ({"schema_revision": 9}, "'schema_revision' must be a string or null"),
+        ({"includes_secrets": "yes"}, "'includes_secrets' must be a boolean"),
+        ({"files": []}, "'files' must be an object"),
+        ({"metadata_sources": {}}, "'metadata_sources' must be a list"),
+    ],
+)
+def test_mistyped_keys_are_reported(overrides: dict[str, Any], message: str) -> None:
+    with pytest.raises(ManifestError, match=message):
+        parse_manifest(json.dumps(valid_manifest_dict(**overrides)))
+
+
+@pytest.mark.parametrize(
+    ("entry", "message"),
+    [
+        ("not-an-object", "must be an object"),
+        ({"sha256": "short", "size_bytes": 1}, "no valid 'sha256'"),
+        ({"size_bytes": 1}, "no valid 'sha256'"),
+        ({"sha256": "a" * 64}, "no valid 'size_bytes'"),
+        ({"sha256": "a" * 64, "size_bytes": -1}, "no valid 'size_bytes'"),
+        ({"sha256": "a" * 64, "size_bytes": True}, "no valid 'size_bytes'"),
+    ],
+)
+def test_bad_file_entries_are_reported(entry: Any, message: str) -> None:
+    document = valid_manifest_dict(files={"flightsite.sqlite3": entry})
+
+    with pytest.raises(ManifestError, match=message):
+        parse_manifest(json.dumps(document))
+
+
+def test_metadata_source_items_must_be_objects() -> None:
+    document = valid_manifest_dict(metadata_sources=["opensky"])
+
+    with pytest.raises(ManifestError, match="must be an object"):
+        parse_manifest(json.dumps(document))
+
+
+def test_metadata_source_entries_allow_nulls() -> None:
+    document = valid_manifest_dict(
+        metadata_sources=[{"source": "opensky", "dataset_version": None, "last_success": None}]
+    )
+
+    manifest = parse_manifest(json.dumps(document))
+
+    assert manifest.metadata_sources[0].dataset_version is None
+    assert manifest.metadata_sources[0].last_success is None
+
+
+def test_undecodable_bytes_are_reported_as_bad_json() -> None:
+    with pytest.raises(ManifestError, match="not valid JSON"):
+        parse_manifest(b"\xff\xfe\x00\x01")
+
+
+def test_timestamps_are_rendered_as_utc_with_a_z_suffix() -> None:
+    tokyo = datetime(2026, 9, 1, 21, 0, 0, tzinfo=timezone(timedelta(hours=9)))
+
+    assert utc_iso(tokyo) == "2026-09-01T12:00:00Z"
+    assert utc_iso(datetime(2026, 9, 1, 12, 0, 0, tzinfo=UTC)) == "2026-09-01T12:00:00Z"
+
+
+def test_epoch_millisecond_columns_render_or_stay_none() -> None:
+    assert utc_iso_from_ms(None) is None
+    assert utc_iso_from_ms(0) == "1970-01-01T00:00:00Z"

--- a/backend/tests/backup/test_restore.py
+++ b/backend/tests/backup/test_restore.py
@@ -212,14 +212,12 @@ async def test_restore_rolls_back_a_failed_swap(
     assert glob_names(data_dir, f"*.{PRESERVED_SUFFIX}.*") == []
 
 
-async def test_restore_render_states_the_operational_rule(
-    data_dir: Path, populated_db: Path
-) -> None:
+async def test_restore_render_states_the_next_step(data_dir: Path, populated_db: Path) -> None:
     archive = make_backup(data_dir)
 
     rendered = restore_backup(archive, data_dir, confirm=True, now=fixed_clock()).render()
 
-    assert "Stop FlightSite before restoring" in rendered
+    assert "start FlightSite" in rendered
     assert str(data_dir) in rendered
 
 

--- a/backend/tests/backup/test_restore.py
+++ b/backend/tests/backup/test_restore.py
@@ -1,0 +1,236 @@
+"""Restore: confirmation gating, validation refusals, and the atomic-ish swap."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from flightsite.backup import (
+    CONFIG_MEMBER,
+    DATABASE_MEMBER,
+    SECRETS_MEMBER,
+    ArchiveValidationError,
+    ConfirmationRequiredError,
+    RestoreError,
+    SchemaCompatibilityError,
+    restore_backup,
+)
+from flightsite.backup.restore import DATABASE_SIDECARS, PRESERVED_SUFFIX
+from flightsite.backup.snapshot import quick_check
+from flightsite.config import ConfigStore
+from flightsite.db import Database, database_path
+from tests.backup.conftest import (
+    file_bytes,
+    fixed_clock,
+    flip_byte,
+    glob_names,
+    make_backup,
+    repack,
+    sqlite_scalar,
+    write_sightings,
+)
+from tests.conftest import SECRET_SENTINEL
+
+
+async def test_restore_refuses_without_confirmation(data_dir: Path, populated_db: Path) -> None:
+    archive = make_backup(data_dir)
+    before = file_bytes(populated_db)
+
+    with pytest.raises(ConfirmationRequiredError, match="--confirm"):
+        restore_backup(archive, data_dir, confirm=False)
+
+    assert file_bytes(populated_db) == before
+
+
+async def test_restore_replaces_the_database(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    archive = make_backup(data_dir)
+
+    # Move the installation on: five more sightings after the backup.
+    database = Database(populated_db)
+    try:
+        await write_sightings(database, count=5, start=100)
+    finally:
+        await database.dispose()
+    assert sqlite_scalar(populated_db, "SELECT COUNT(*) FROM sightings") == 10
+
+    result = restore_backup(archive, data_dir, confirm=True, now=fixed_clock())
+
+    assert result.restored == (DATABASE_MEMBER,)
+    assert sqlite_scalar(populated_db, "SELECT COUNT(*) FROM sightings") == 5
+    assert quick_check(populated_db) == ["ok"]
+
+
+async def test_restore_into_an_empty_directory(
+    data_dir: Path, populated_db: Path, config_files: ConfigStore, tmp_path: Path
+) -> None:
+    archive = make_backup(data_dir)
+    fresh = tmp_path / "new-host-data"
+
+    result = restore_backup(archive, fresh, confirm=True, now=fixed_clock())
+
+    assert sorted(result.restored) == [CONFIG_MEMBER, DATABASE_MEMBER]
+    assert sqlite_scalar(database_path(fresh), "SELECT COUNT(*) FROM sightings") == 5
+    assert (fresh / CONFIG_MEMBER).exists()
+
+
+async def test_restore_removes_the_preserved_copies_on_success(
+    data_dir: Path, populated_db: Path
+) -> None:
+    archive = make_backup(data_dir)
+
+    result = restore_backup(archive, data_dir, confirm=True, now=fixed_clock())
+
+    assert result.displaced == (f"{DATABASE_MEMBER}.{PRESERVED_SUFFIX}.20260901T120000Z",)
+    assert glob_names(data_dir, f"*.{PRESERVED_SUFFIX}.*") == []
+
+
+async def test_restore_leaves_no_staging_directory(data_dir: Path, populated_db: Path) -> None:
+    archive = make_backup(data_dir)
+
+    restore_backup(archive, data_dir, confirm=True, now=fixed_clock())
+
+    assert glob_names(data_dir, ".flightsite-restore-*") == []
+
+
+async def test_restore_clears_stale_wal_sidecars(data_dir: Path, populated_db: Path) -> None:
+    """A ``-wal`` describing the replaced file must not survive the swap."""
+    archive = make_backup(data_dir)
+    for sidecar in DATABASE_SIDECARS:
+        (data_dir / sidecar).write_bytes(b"stale write-ahead log")
+
+    restore_backup(archive, data_dir, confirm=True, now=fixed_clock())
+
+    for sidecar in DATABASE_SIDECARS:
+        assert not (data_dir / sidecar).exists()
+
+
+async def test_restore_replaces_config_and_secrets_when_the_archive_carries_them(
+    data_dir: Path, populated_db: Path, config_files: ConfigStore
+) -> None:
+    archive = make_backup(data_dir, include_secrets=True)
+    config_files.config_path.write_text("map: {}\n", encoding="utf-8")
+    config_files.secrets_path.write_text("enrichment:\n  aerodatabox_api_key: changed\n", "utf-8")
+
+    result = restore_backup(archive, data_dir, confirm=True, now=fixed_clock())
+
+    assert result.secrets_restored is True
+    assert SECRET_SENTINEL in config_files.secrets_path.read_text(encoding="utf-8")
+    assert "map: {}" not in config_files.config_path.read_text(encoding="utf-8")
+
+
+async def test_restore_leaves_existing_secrets_alone_when_the_archive_has_none(
+    data_dir: Path, populated_db: Path, config_files: ConfigStore
+) -> None:
+    """A secrets-free backup must not silently delete a live API key."""
+    archive = make_backup(data_dir)
+
+    result = restore_backup(archive, data_dir, confirm=True, now=fixed_clock())
+
+    assert result.secrets_restored is False
+    assert SECRETS_MEMBER not in result.restored
+    assert SECRET_SENTINEL in config_files.secrets_path.read_text(encoding="utf-8")
+    assert "carried no secrets.yaml" in result.render()
+
+
+async def test_restore_refuses_a_corrupted_archive_and_changes_nothing(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    archive = make_backup(data_dir)
+    before = file_bytes(populated_db)
+
+    def corrupt(members: dict[str, bytes]) -> None:
+        members[DATABASE_MEMBER] = flip_byte(members[DATABASE_MEMBER], 4096)
+
+    damaged = repack(archive, tmp_path / "damaged.tar.gz", mutate=corrupt)
+
+    with pytest.raises(ArchiveValidationError, match="checksum mismatch"):
+        restore_backup(damaged, data_dir, confirm=True, now=fixed_clock())
+
+    assert file_bytes(populated_db) == before
+    assert glob_names(data_dir, ".flightsite-restore-*") == []
+
+
+async def test_restore_refuses_an_archive_that_is_not_an_archive(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    plain = tmp_path / "readme.txt"
+    plain.write_text("hello", encoding="utf-8")
+
+    with pytest.raises(ArchiveValidationError, match="not a readable FlightSite backup archive"):
+        restore_backup(plain, data_dir, confirm=True, now=fixed_clock())
+
+
+async def test_restore_refuses_a_newer_schema_backup(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    """SPEC §72: an older FlightSite must refuse a newer-schema backup."""
+    archive = make_backup(data_dir)
+    before = file_bytes(populated_db)
+
+    from_the_future = repack(
+        archive,
+        tmp_path / "future.tar.gz",
+        mutate_manifest=lambda manifest: manifest.__setitem__("schema_revision", "9999"),
+    )
+
+    with pytest.raises(SchemaCompatibilityError, match="not part of this build's migration"):
+        restore_backup(from_the_future, data_dir, confirm=True, now=fixed_clock())
+
+    assert file_bytes(populated_db) == before
+
+
+async def test_restore_rolls_back_a_failed_swap(
+    data_dir: Path, populated_db: Path, config_files: ConfigStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = make_backup(data_dir, include_secrets=True)
+    database_before = file_bytes(populated_db)
+    config_before = file_bytes(config_files.config_path)
+    secrets_before = file_bytes(config_files.secrets_path)
+
+    real_replace = os.replace
+    calls: list[int] = []
+
+    def flaky(src: object, dst: object) -> None:
+        calls.append(1)
+        # Fail once the first payload has landed, so a rollback is genuinely needed.
+        if len(calls) == 5:
+            raise OSError("read-only file system")
+        real_replace(src, dst)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("flightsite.backup.restore.os.replace", flaky)
+
+    with pytest.raises(RestoreError, match="left unchanged"):
+        restore_backup(archive, data_dir, confirm=True, now=fixed_clock())
+
+    assert file_bytes(populated_db) == database_before
+    assert file_bytes(config_files.config_path) == config_before
+    assert file_bytes(config_files.secrets_path) == secrets_before
+    assert glob_names(data_dir, f"*.{PRESERVED_SUFFIX}.*") == []
+
+
+async def test_restore_render_states_the_operational_rule(
+    data_dir: Path, populated_db: Path
+) -> None:
+    archive = make_backup(data_dir)
+
+    rendered = restore_backup(archive, data_dir, confirm=True, now=fixed_clock()).render()
+
+    assert "Stop FlightSite before restoring" in rendered
+    assert str(data_dir) in rendered
+
+
+async def test_restore_replaces_a_stale_staging_directory(
+    data_dir: Path, populated_db: Path
+) -> None:
+    archive = make_backup(data_dir)
+    stale = data_dir / ".flightsite-restore-20260901T120000Z"
+    stale.mkdir()
+    (stale / "leftover").write_text("from an interrupted run", encoding="utf-8")
+
+    restore_backup(archive, data_dir, confirm=True, now=fixed_clock())
+
+    assert not stale.exists()

--- a/backend/tests/backup/test_verify.py
+++ b/backend/tests/backup/test_verify.py
@@ -1,0 +1,204 @@
+"""``flightsite-backup verify``: checksums, manifest, schema report, no side effects."""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+from flightsite.backup import (
+    CONFIG_MEMBER,
+    DATABASE_MEMBER,
+    SchemaRelation,
+    create_backup,
+    verify_archive,
+)
+from flightsite.config import ConfigStore
+from flightsite.db import migrate
+from tests.backup.conftest import (
+    FIXED_NOW,
+    BytesReader,
+    fixed_clock,
+    flip_byte,
+    read_members,
+    repack,
+    tree_mtimes,
+    write_members,
+)
+
+
+async def test_a_fresh_backup_verifies_clean(
+    data_dir: Path, populated_db: Path, config_files: ConfigStore
+) -> None:
+    archive = create_backup(data_dir, now=fixed_clock()).path
+
+    report = verify_archive(archive)
+
+    assert report.ok
+    assert report.problems == ()
+    assert {check.name for check in report.checks} == {DATABASE_MEMBER, CONFIG_MEMBER}
+    assert all(check.ok for check in report.checks)
+    assert report.compatibility is not None
+    assert report.compatibility.relation is SchemaRelation.SAME
+
+
+async def test_verify_reports_versions_checksums_and_compatibility(
+    data_dir: Path, populated_db: Path
+) -> None:
+    archive = create_backup(data_dir, now=fixed_clock()).path
+
+    rendered = verify_archive(archive).render()
+
+    assert str(archive) in rendered
+    assert "created (UTC):      2026-09-01T12:00:00Z" in rendered
+    assert f"schema revision:    {migrate.head_revision()}" in rendered
+    assert "includes secrets:   no" in rendered
+    assert "- opensky: version=2026-08-01" in rendered
+    assert f"- {DATABASE_MEMBER}: OK" in rendered
+    assert "RESULT: restorable" in rendered
+
+
+async def test_verify_notes_when_no_metadata_sources_are_recorded(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    archive = create_backup(data_dir, now=fixed_clock()).path
+    stripped = repack(
+        archive,
+        tmp_path / "stripped.tar.gz",
+        mutate_manifest=lambda manifest: manifest.__setitem__("metadata_sources", []),
+    )
+
+    assert "metadata sources:   (none recorded)" in verify_archive(stripped).render()
+
+
+async def test_verify_does_not_modify_anything(data_dir: Path, populated_db: Path) -> None:
+    archive = create_backup(data_dir, now=fixed_clock()).path
+    before = tree_mtimes(data_dir)
+
+    verify_archive(archive)
+
+    assert tree_mtimes(data_dir) == before
+
+
+async def test_a_flipped_byte_fails_the_checksum(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    archive = create_backup(data_dir, now=fixed_clock()).path
+
+    def corrupt(members: dict[str, bytes]) -> None:
+        members[DATABASE_MEMBER] = flip_byte(members[DATABASE_MEMBER], 5000)
+
+    damaged = repack(archive, tmp_path / "damaged.tar.gz", mutate=corrupt)
+    report = verify_archive(damaged)
+
+    assert not report.ok
+    assert any("checksum mismatch" in problem for problem in report.problems)
+    assert "RESULT: NOT RESTORABLE" in report.render()
+    assert f"- {DATABASE_MEMBER}: FAILED" in report.render()
+
+
+async def test_a_truncated_member_fails_on_size(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    archive = create_backup(data_dir, now=fixed_clock()).path
+
+    def truncate(members: dict[str, bytes]) -> None:
+        members[DATABASE_MEMBER] = members[DATABASE_MEMBER][:-64]
+
+    damaged = repack(archive, tmp_path / "short.tar.gz", mutate=truncate)
+    report = verify_archive(damaged)
+
+    assert any("size mismatch" in problem for problem in report.problems)
+
+
+async def test_a_missing_member_is_reported(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    archive = create_backup(data_dir, now=fixed_clock()).path
+
+    def drop(members: dict[str, bytes]) -> None:
+        del members[DATABASE_MEMBER]
+
+    damaged = repack(archive, tmp_path / "missing.tar.gz", mutate=drop)
+    report = verify_archive(damaged)
+
+    assert any("does not contain" in problem for problem in report.problems)
+    # The missing member is reported once, not also as a checksum failure.
+    assert report.checks == ()
+
+
+async def test_an_unlisted_extra_member_is_reported(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    archive = create_backup(data_dir, now=fixed_clock()).path
+
+    def smuggle(members: dict[str, bytes]) -> None:
+        members["../evil.sh"] = b"rm -rf /\n"
+
+    damaged = repack(archive, tmp_path / "extra.tar.gz", mutate=smuggle)
+    report = verify_archive(damaged)
+
+    assert any("the manifest does not list" in problem for problem in report.problems)
+    assert any("may contain" in problem for problem in report.problems)
+
+
+async def test_a_non_regular_member_is_reported(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    archive = create_backup(data_dir, now=fixed_clock()).path
+    members = read_members(archive)
+
+    hostile = tmp_path / "symlink.tar.gz"
+    with tarfile.open(hostile, "w:gz") as handle:
+        for name, payload in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            info.mtime = int(FIXED_NOW.timestamp())
+            handle.addfile(info, BytesReader(payload))
+        link = tarfile.TarInfo(CONFIG_MEMBER + ".link")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "/etc/passwd"
+        handle.addfile(link)
+
+    report = verify_archive(hostile)
+
+    assert any("is not a regular file" in problem for problem in report.problems)
+
+
+async def test_a_manifest_free_archive_is_refused(tmp_path: Path) -> None:
+    archive = write_members(tmp_path / "no-manifest.tar.gz", {DATABASE_MEMBER: b"nope"})
+
+    report = verify_archive(archive)
+
+    assert not report.ok
+    assert any("missing member 'manifest.json'" in problem for problem in report.problems)
+    assert report.manifest is None
+
+
+async def test_a_file_that_is_not_an_archive_is_refused(tmp_path: Path) -> None:
+    plain = tmp_path / "notes.txt"
+    plain.write_text("this is not a backup", encoding="utf-8")
+
+    report = verify_archive(plain)
+
+    assert any("not a readable FlightSite backup archive" in p for p in report.problems)
+    assert "RESULT: NOT RESTORABLE" in report.render()
+
+
+async def test_a_missing_archive_is_refused(tmp_path: Path) -> None:
+    report = verify_archive(tmp_path / "absent.tar.gz")
+
+    assert any("no such archive" in problem for problem in report.problems)
+
+
+async def test_a_corrupt_gzip_stream_is_refused(
+    data_dir: Path, populated_db: Path, tmp_path: Path
+) -> None:
+    archive = create_backup(data_dir, now=fixed_clock()).path
+    mangled = tmp_path / "mangled.tar.gz"
+    payload = bytearray(archive.read_bytes())
+    payload[len(payload) // 2] ^= 0xFF
+    mangled.write_bytes(bytes(payload))
+
+    report = verify_archive(mangled)
+
+    assert not report.ok

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -1,0 +1,297 @@
+# FlightSite Backup and Restore
+
+FlightSite ships a single command — `flightsite-backup` — with three
+subcommands: `create`, `verify`, and `restore`. This document is the operator
+procedure for all three (SPEC §72).
+
+**The one rule to remember:** taking a backup is safe at any time, including
+while FlightSite is running. **Restoring is not — stop FlightSite first.**
+
+## Where backups live
+
+All persistent FlightSite state lives under one directory, by default
+`/opt/flightsite/data` (`docs/ARCHITECTURE.md` §2.1):
+
+```text
+/opt/flightsite/data/
+  config.yaml        # canonical non-secret configuration
+  secrets.yaml       # optional secrets (AeroDataBox key)
+  flightsite.sqlite3 # application database (+ -wal/-shm)
+  logs/              # rotating structured logs
+  backups/           # ← backups land here by default
+```
+
+Archives are named `flightsite-backup-<UTC timestamp>.tar.gz`, for example
+`flightsite-backup-20260901T120000Z.tar.gz`. Nothing rotates or deletes them:
+FlightSite writes backups and leaves them alone, so disk usage under
+`backups/` is yours to manage. Scheduled backups are deliberately out of scope
+for v1 — use `cron` on the host if you want them.
+
+`--out DIR` writes the archive somewhere else instead (a USB stick, an NFS
+mount, `/tmp` before you `scp` it away).
+
+## Taking a backup
+
+From the host running the Compose stack:
+
+```bash
+docker compose exec flightsite-backend flightsite-backup create
+```
+
+With the stack stopped, or on a bare install, point the command at the data
+directory:
+
+```bash
+flightsite-backup create --data-dir /opt/flightsite/data
+```
+
+Both forms produce the same archive. Inside the container no arguments are
+needed because `FLIGHTSITE_DATA_DIR` is already set.
+
+To write the archive outside the data directory:
+
+```bash
+docker compose exec flightsite-backend \
+  flightsite-backup create --out /opt/flightsite/data/backups/pre-upgrade
+```
+
+### It is safe to back up while FlightSite is running
+
+The database snapshot is taken with SQLite's `VACUUM INTO`, which runs inside a
+single read transaction. FlightSite runs the database in WAL mode
+([ADR-0001](adr/0001-sqlite-sole-persistence-store.md)), where readers neither
+block nor are blocked by the writer, so:
+
+- ingestion and the write-behind persistence worker keep running throughout;
+- the snapshot is a consistent point-in-time image — never a half-written
+  transaction;
+- the snapshot is a complete, compacted single file with no `-wal` sidecar to
+  carry along.
+
+`VACUUM INTO` is used rather than SQLite's online backup API because that API
+restarts its page copy whenever the source is written during the copy, which
+against a continuously writing FlightSite could take arbitrarily long.
+
+A backup of a multi-gigabyte history takes a while and does real disk I/O.
+On a Raspberry Pi, expect the map to feel no different but the SD card to be
+busy. Take backups when you are not also doing something else heavy.
+
+## What is in an archive
+
+| Member | Always? | What it is |
+| --- | --- | --- |
+| `manifest.json` | yes | version, schema revision, checksums, dataset versions |
+| `flightsite.sqlite3` | yes | the database snapshot: sightings, aircraft, metadata, analytics rollups, alert rules and matches |
+| `config.yaml` | if present | your non-secret configuration |
+| `secrets.yaml` | **only with `--include-secrets`** | your AeroDataBox API key |
+
+**Not** included, and not needed for a restore: `logs/`, the `-wal`/`-shm`
+sidecars (they are folded into the snapshot), earlier archives under
+`backups/`, and anything outside the data directory — notably your
+`compose.yaml` and `.env`, which you should keep in your own configuration
+backup.
+
+### Secrets policy
+
+Secrets are excluded by default (`docs/SECURITY.md` §3). An archive taken with
+`--include-secrets` is **as sensitive as `secrets.yaml` itself**: treat it
+accordingly, and prefer keeping the key in your password manager and restoring
+it by hand over copying secret-bearing archives around.
+
+The manifest always states which way it went:
+
+```json
+"includes_secrets": false
+```
+
+This is honest rather than aspirational — asking for `--include-secrets` on an
+installation that has no `secrets.yaml` records `false`, and the command says so
+on stderr.
+
+### The manifest
+
+```json
+{
+  "format_version": 1,
+  "flightsite_version": "0.5.0",
+  "schema_revision": "0009",
+  "created_utc": "2026-09-01T12:00:00Z",
+  "includes_secrets": false,
+  "files": {
+    "flightsite.sqlite3": { "sha256": "…", "size_bytes": 41582592 },
+    "config.yaml": { "sha256": "…", "size_bytes": 1874 }
+  },
+  "metadata_sources": [
+    { "source": "mictronics", "dataset_version": "2026-08-01", "last_success": "2026-08-02T03:14:00Z" }
+  ]
+}
+```
+
+`schema_revision` is the Alembic revision of the snapshot itself, and it is what
+makes restores version-aware.
+
+## Checking an archive
+
+`verify` reads an archive and reports on it. It never writes anything, so it is
+safe to run against a production data directory at any time:
+
+```bash
+docker compose exec flightsite-backend flightsite-backup verify \
+  /opt/flightsite/data/backups/flightsite-backup-20260901T120000Z.tar.gz
+```
+
+It checks, and reports on, all of:
+
+1. the archive opens as a gzip tar;
+2. `manifest.json` is present and in a format this build understands;
+3. the members are exactly what the manifest lists, and all are regular files;
+4. the schema revision is restorable by this build;
+5. every member's SHA-256 and size match the manifest.
+
+It exits `0` when the archive is restorable and `1` when it is not, printing
+every problem it found — so it works in a cron job or a pre-upgrade script.
+
+**Verify your backups periodically.** An unverified backup is a hypothesis.
+
+## Restoring
+
+Restore is destructive: it replaces the database and configuration in the data
+directory. It therefore requires `--confirm`, and there is a documented order
+of operations.
+
+```bash
+# 1. Stop FlightSite.
+docker compose down
+
+# 2. Restore. --confirm is required; without it the command refuses.
+docker compose run --rm flightsite-backend flightsite-backup restore \
+  /opt/flightsite/data/backups/flightsite-backup-20260901T120000Z.tar.gz --confirm
+
+# 3. Start FlightSite. It migrates the schema if needed and runs its
+#    startup integrity check.
+docker compose up -d
+```
+
+Then confirm the instance came back healthy:
+
+```bash
+curl -fsS http://localhost:8080/api/v1/ready
+```
+
+Without Compose:
+
+```bash
+flightsite-backup restore /path/to/archive.tar.gz \
+  --data-dir /opt/flightsite/data --confirm
+```
+
+### Stop FlightSite before restoring
+
+FlightSite has no lock file and does not try to detect whether it is running —
+any cheap check would be both spoofable and prone to false refusals across
+container restarts, and a wrong refusal during a recovery is worse than no
+check. **The rule is operational: stop the stack first.**
+
+The restore is nonetheless built to survive the mistake rather than corrupt
+your data. Each file is replaced whole, by rename, so a still-running
+FlightSite keeps writing to the old file (now unlinked) rather than into the
+middle of the restored one. You lose whatever it wrote after the restore, which
+is what you asked for anyway — but the restored files are intact. Restart the
+stack and you are in the state the archive describes.
+
+### What restore does, in order
+
+1. Refuses immediately unless `--confirm` was given.
+2. Reads and validates the manifest, and checks schema compatibility — both
+   cheap, so an incompatible archive is refused before any bytes are written.
+3. Extracts each member into a staging directory *inside* the data directory,
+   verifying SHA-256 as it goes. Nothing outside staging has been touched yet.
+4. Swaps: each live file is moved aside to `<name>.pre-restore.<timestamp>`,
+   then the staged file is renamed into place. Stale `flightsite.sqlite3-wal`
+   and `-shm` sidecars are moved aside too — they describe the *replaced*
+   database and must not survive.
+5. Deletes the `.pre-restore.*` copies, but only after the whole swap
+   succeeded. If any step fails, every move is undone and the data directory is
+   left exactly as it was found.
+
+A member the archive does not carry is left alone rather than deleted. In
+particular, restoring a backup taken **without** `--include-secrets` does not
+remove an existing `secrets.yaml`: your API key survives the restore. The
+command says which way it went in its summary.
+
+### Version compatibility (SPEC §72)
+
+| Backup schema revision | Result |
+| --- | --- |
+| same as this build's head | restored; no migration needed |
+| an ancestor of this build's head (older) | restored, then **migrated to head at the next startup** |
+| anything else (newer, or unknown) | **refused** |
+
+Older backups restoring into a newer FlightSite is the ordinary path, and it is
+the same migration path an in-place data directory takes — restore does not
+migrate anything itself; the normal startup sequence does.
+
+A **newer**-schema backup is refused on an older FlightSite because this build
+has no migration that could bring the schema back down, and running old code
+against a newer schema is how data gets silently mangled. If you hit this,
+upgrade FlightSite to at least the version that wrote the archive and retry.
+This refusal is what makes the rollback procedure in `docs/RELEASE.md` safe.
+
+### If restore refuses
+
+| Message | Meaning | What to do |
+| --- | --- | --- |
+| `checksum mismatch` / `size mismatch` | the archive is corrupt or was modified | use another backup; check the media it was stored on |
+| `not a readable FlightSite backup archive` | not a gzip tar, or badly truncated | check you named the right file, and that the copy completed |
+| `manifest is missing…` / `format_version … is not supported` | not a FlightSite archive, or from a much newer build | restore with the version that wrote it |
+| `not part of this build's migration history` | newer-schema backup | upgrade FlightSite, then retry |
+| `Re-run with --confirm` | you did not confirm | stop FlightSite, then add `--confirm` |
+
+Nothing in the data directory has been changed in any of these cases.
+
+## Moving an installation to another host (SPEC §116)
+
+A FlightSite installation is the data directory plus the deployment
+configuration. To move it:
+
+1. On the old host: `docker compose down`, then
+   `flightsite-backup create --include-secrets` (or take the backup without
+   secrets and carry the API key separately, which is safer).
+2. Copy the archive and your `compose.yaml` / `.env` to the new host.
+3. On the new host, create the data directory as described in `compose.yaml`,
+   then `flightsite-backup verify` the archive, then restore it into that
+   directory with `--confirm`.
+4. `docker compose up -d`. If the new host runs a newer FlightSite, it migrates
+   the restored database to head on that first start.
+
+Archives are architecture-independent: a backup taken on an `amd64` machine
+restores on a Raspberry Pi (`arm64`) and vice versa. SQLite database files are
+portable across both.
+
+Copying the whole data directory while the stack is stopped works too, and is
+the fastest option on the same filesystem — but the archive is the form that
+carries a manifest, checksums, and a schema revision, so it is the one to use
+when anything about the two hosts differs.
+
+## Before upgrading
+
+Release notes for versions containing schema changes recommend taking a backup
+first (`docs/RELEASE.md`). The habit worth keeping:
+
+```bash
+docker compose exec flightsite-backend flightsite-backup create
+docker compose exec flightsite-backend flightsite-backup verify \
+  /opt/flightsite/data/backups/flightsite-backup-<timestamp>.tar.gz
+docker compose pull && docker compose up -d
+```
+
+If the upgrade goes badly, `docs/RELEASE.md` §Rollback restores that archive and
+pins the previous image tags.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | success |
+| `1` | refused: damaged archive, incompatible schema, no database to back up, failed swap |
+| `2` | wrong invocation — including `restore` without `--confirm` |

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1114,7 +1114,7 @@ slices:
     title: "Backup & restore"
     phase: 7
     branch: "043-backup-restore"
-    status: planned
+    status: merged
     depends_on: ["004", "005", "021"]
     objective: "Version-aware, checksum-validated backup and restore commands safe for live SQLite."
     scope:


### PR DESCRIPTION
## Slice
- **Slice ID:** 043 — Backup & restore
- **Roadmap:** `planning/roadmap.yaml` slice 043 (phase 7)
- **Issue:** Closes #81

## Objective
Version-aware, checksum-validated, SQLite-safe backup and restore.

## Implementation summary
- `flightsite-backup create/verify/restore` console script; data-dir resolution reused so in-container needs no args
- Snapshot via VACUUM INTO on its own stdlib connection — one WAL read transaction that neither blocks nor is blocked by the single writer (documented rationale vs the online backup API's livelock/stall modes); manifest fields read from the snapshot itself
- Shared inspect_archive: container → strict manifest parse → exact member-set match → schema compat → per-member SHA-256; verify collects all problems and writes nothing
- Schema rule: restorable iff ancestor-or-equal of this build's head (newer refused before any write); older restores migrate at next startup (proved with a real downgrade-to-0004 fixture)
- Swap: same-filesystem staging, per-file aside-then-replace with full rollback on failure, stale -wal/-shm moved aside, absent members (secrets) never deleted
- Secrets only with --include-secrets; manifest records what was actually archived; hostile tar members rejected
- docs/BACKUP.md: procedures, secrets policy, portability, stop-before-restore rule

## Acceptance criteria
- [x] backup during active ingestion yields a consistent restorable snapshot (concurrent-writer test: quick_check, FK check, no orphans)
- [x] corrupted archives and newer-schema restores refused with clear errors (byte-flip, truncation, symlink, fabricated-future-revision tests)
- [x] old-backup → newer-app restore migrates cleanly (real-revision fixture)

## Tests added/run
106 backup tests; suite 2910 passed; package **99.75%**, overall 99.29%. Reviewer re-ran gates; real console-script smoke exercised.

## Performance / Security / Data considerations
No migration; writer never touched; SECURITY.md §3 manifest honesty implemented.

## Documentation updates
docs/BACKUP.md (new).

## Known limitations
No running-instance detection (documented operational rule; whole-file renames keep even that case survivable).

## Follow-up work
045 (reset) builds on this; release checklists can now exercise backup/restore.

## Fable self-review (SPEC §104)
- [x] Full diff inspected; VACUUM INTO rationale sound; refusal ordering verified; rollback path tested; no TODO/FIXME
- [x] Branch on dev tip; suite green
- [ ] CI green on this PR (gate before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)