### PR TITLE
Slice 036: Today at a glance

### DIFF
--- a/backend/src/flightsite/analytics/queries.py
+++ b/backend/src/flightsite/analytics/queries.py
@@ -56,8 +56,10 @@ from zoneinfo import ZoneInfo
 from sqlalchemy import ColumnElement, Select, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from flightsite.activity.model import ActivityEventType
 from flightsite.analytics.bucketing import Window, local_hour
 from flightsite.db import (
+    ActivityEvent,
     Aircraft,
     AircraftClassification,
     AircraftMetadataResolved,
@@ -86,6 +88,21 @@ DEFAULT_RARE_MAX_SIGHTINGS: Final = 2
 
 #: Airframes at or below which a type designator reads as locally rare.
 DEFAULT_RARE_MAX_TYPE_AIRCRAFT: Final = 2
+
+#: SPEC §59's "new milestones/records" — the ``activity_events`` types that
+#: are, per :mod:`flightsite.activity.model`, either a milestone (fires once)
+#: or a rolling record (can be beaten), as opposed to a routine operational
+#: event (``metadata_updated``, ``receiver_offline``/``restored``) or a
+#: phase-6 alert event neither word describes.
+MILESTONE_EVENT_TYPES: Final[frozenset[str]] = frozenset(
+    {
+        ActivityEventType.FIRST_EVER_AIRCRAFT.value,
+        ActivityEventType.NEW_TYPE.value,
+        ActivityEventType.RANGE_RECORD.value,
+        ActivityEventType.RECEIVER_RECORD.value,
+        ActivityEventType.MILESTONE.value,
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -130,6 +147,11 @@ class Summary:
     busiest_hour_source: str | None = None
     first_sighting_ms: int | None = None
     last_sighting_ms: int | None = None
+    #: Count of ``activity_events`` rows in :data:`MILESTONE_EVENT_TYPES`
+    #: whose ``ts_ms`` falls inside the window (SPEC §59's "new milestones/
+    #: records"). Not derivable from the rollups — milestones and records are
+    #: activity-feed facts, not per-sighting ones — so this is its own count.
+    new_milestones: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -363,6 +385,7 @@ class AnalyticsQueries:
         unique = await self.unique_aircraft(window)
         busiest, source = await self._busiest_hour(window, rows)
         span = await self._sighting_span(window)
+        milestones = await self.new_milestones(window)
         return Summary(
             unique_aircraft=unique,
             new_aircraft=sum(row.new_aircraft for row in rows),
@@ -378,7 +401,29 @@ class AnalyticsQueries:
             busiest_hour_source=source,
             first_sighting_ms=span[0],
             last_sighting_ms=span[1],
+            new_milestones=milestones,
         )
+
+    async def new_milestones(self, window: Window) -> int:
+        """Count of §59's "new milestones/records" struck inside the window.
+
+        A plain count over ``activity_events`` — the milestone/record vocabulary
+        is small and the table is not the write-heavy one, so this needs no
+        rollup of its own, unlike ``unique_aircraft``'s multi-day case.
+        """
+        if window.empty:
+            return 0
+        statement = (
+            select(func.count())
+            .select_from(ActivityEvent)
+            .where(
+                ActivityEvent.type.in_(MILESTONE_EVENT_TYPES),
+                ActivityEvent.ts_ms >= window.start_ms,
+                ActivityEvent.ts_ms < window.end_ms,
+            )
+        )
+        async with self._database.read_session() as session:
+            return int(await session.scalar(statement) or 0)
 
     async def unique_aircraft(self, window: Window) -> int:
         """Distinct airframes with a sighting that started inside the window.
@@ -746,6 +791,7 @@ __all__ = [
     "DEFAULT_RARE_MAX_TYPE_AIRCRAFT",
     "DEFAULT_TOP_LIMIT",
     "MAX_TOP_LIMIT",
+    "MILESTONE_EVENT_TYPES",
     "AircraftRank",
     "AnalyticsQueries",
     "ClassificationActivity",

--- a/backend/src/flightsite/api/schemas.py
+++ b/backend/src/flightsite/api/schemas.py
@@ -735,6 +735,11 @@ class AnalyticsSummary(_Model):
     busiest_hour_source: str | None = None
     first_sighting_at: IsoTimestamp | None = None
     last_sighting_at: IsoTimestamp | None = None
+    #: SPEC §59's "new milestones/records" — activity-feed milestone and
+    #: record events (``first_ever_aircraft``, ``new_type``, ``range_record``,
+    #: ``receiver_record``, ``milestone``) whose moment falls inside the
+    #: window.
+    new_milestones: int
 
 
 class AnalyticsSummaryResponse(_Model):

--- a/backend/src/flightsite/api/serializers.py
+++ b/backend/src/flightsite/api/serializers.py
@@ -950,6 +950,7 @@ def analytics_summary_payload(summary: Summary) -> dict[str, Any]:
         "busiest_hour_source": summary.busiest_hour_source,
         "first_sighting_at": _at(summary.first_sighting_ms),
         "last_sighting_at": _at(summary.last_sighting_ms),
+        "new_milestones": summary.new_milestones,
     }
 
 

--- a/backend/tests/analytics/test_api.py
+++ b/backend/tests/analytics/test_api.py
@@ -26,6 +26,12 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+from flightsite.activity import (
+    ActivityBatch,
+    ActivityEventType,
+    ActivityRepository,
+    NewActivityEvent,
+)
 from flightsite.analytics.bucketing import day_bounds_ms, local_day, local_hour, shift_days
 from flightsite.analytics.service import AnalyticsService
 from flightsite.api.serializers import iso_utc
@@ -356,6 +362,100 @@ async def test_a_closed_day_takes_its_busiest_hour_from_the_rollup(
 
     assert summary["busiest_hour_source"] == "daily_stats"
     assert summary["busiest_hour"] is not None
+
+
+# ------------------------------------------------------- new_milestones (036)
+
+
+async def test_every_summary_response_carries_a_new_milestones_key(
+    rest: AsyncClient,
+) -> None:
+    """§59's null-stable key: present and zero even on an empty install."""
+    summary = (await get(rest, "/api/v1/analytics/summary", preset="today"))["summary"]
+
+    assert summary["new_milestones"] == 0
+
+
+async def test_new_milestones_counts_milestone_and_record_events_today(
+    harness: Harness, rest: AsyncClient
+) -> None:
+    """Milestone and record event types count; routine ones do not."""
+    await seed(harness)
+    database: Database = harness.database
+    today_ms = harness.inside(harness.today, 0.4)
+    await ActivityRepository(database).record(
+        ActivityBatch(
+            events=(
+                NewActivityEvent(
+                    type=ActivityEventType.FIRST_EVER_AIRCRAFT,
+                    ts_ms=today_ms,
+                    dedupe_key="first_ever_aircraft:a00002",
+                ),
+                NewActivityEvent(
+                    type=ActivityEventType.NEW_TYPE,
+                    ts_ms=today_ms,
+                    dedupe_key="new_type:C130",
+                ),
+                NewActivityEvent(
+                    type=ActivityEventType.RANGE_RECORD,
+                    ts_ms=today_ms,
+                    dedupe_key="range_record:205.000",
+                ),
+                NewActivityEvent(
+                    type=ActivityEventType.RECEIVER_RECORD,
+                    ts_ms=today_ms,
+                    dedupe_key="receiver_record:max_simultaneous:5",
+                ),
+                NewActivityEvent(
+                    type=ActivityEventType.MILESTONE,
+                    ts_ms=today_ms,
+                    dedupe_key="unique_aircraft_100",
+                ),
+                # Routine events, and events outside the window: neither counts.
+                NewActivityEvent(
+                    type=ActivityEventType.METADATA_UPDATED,
+                    ts_ms=today_ms,
+                    dedupe_key="metadata_updated:a00001:1",
+                ),
+                NewActivityEvent(
+                    type=ActivityEventType.MILESTONE,
+                    ts_ms=harness.inside(harness.yesterday, 0.5),
+                    dedupe_key="unique_aircraft_500",
+                ),
+            )
+        )
+    )
+
+    summary = (await get(rest, "/api/v1/analytics/summary", preset="today"))["summary"]
+
+    assert summary["new_milestones"] == 5
+
+
+async def test_new_milestones_over_a_multi_day_window_counts_every_day(
+    harness: Harness, rest: AsyncClient
+) -> None:
+    await seed(harness)
+    database: Database = harness.database
+    await ActivityRepository(database).record(
+        ActivityBatch(
+            events=(
+                NewActivityEvent(
+                    type=ActivityEventType.MILESTONE,
+                    ts_ms=harness.inside(harness.today, 0.2),
+                    dedupe_key="unique_aircraft_100",
+                ),
+                NewActivityEvent(
+                    type=ActivityEventType.MILESTONE,
+                    ts_ms=harness.inside(harness.yesterday, 0.2),
+                    dedupe_key="unique_aircraft_500",
+                ),
+            )
+        )
+    )
+
+    summary = (await get(rest, "/api/v1/analytics/summary", preset="7d"))["summary"]
+
+    assert summary["new_milestones"] == 2
 
 
 def _local_hour(epoch_ms: int, zone: ZoneInfo) -> int:

--- a/backend/tests/analytics/test_queries.py
+++ b/backend/tests/analytics/test_queries.py
@@ -14,6 +14,8 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
+from flightsite.activity import ActivityBatch, ActivityEventType, NewActivityEvent
+from flightsite.activity import ActivityRepository as FeedRepository
 from flightsite.analytics.bucketing import Window, day_bounds_ms, local_day, shift_days
 from flightsite.analytics.model import DayRollup
 from flightsite.analytics.queries import AnalyticsQueries
@@ -197,3 +199,77 @@ async def test_the_windowed_group_rankings_report_days_seen_and_true_distincts(
         assert 1 <= row.days_seen <= len(world.days())
         assert 0 < row.unique_aircraft <= row.sightings
     assert all(row.label is not None for row in operators)
+
+
+# ----------------------------------------------------- new_milestones (036)
+
+#: A 23-hour local day in ``NEW_YORK`` — see ``tests.analytics.test_bucketing``.
+SPRING_FORWARD = "2026-03-08"
+
+
+async def test_new_milestones_is_zero_over_an_empty_window(
+    queries: AnalyticsQueries, zone: ZoneInfo
+) -> None:
+    assert await queries.new_milestones(backwards(zone, local_day(BASE_EPOCH_MS, zone))) == 0
+
+
+async def test_new_milestones_counts_only_the_milestone_and_record_types(
+    database: Database, queries: AnalyticsQueries, zone: ZoneInfo
+) -> None:
+    """§59's "new milestones/records" excludes routine operational events."""
+    day = local_day(BASE_EPOCH_MS, zone)
+    inside_ms = day_bounds_ms(day, zone)[0] + 1
+    await FeedRepository(database).record(
+        ActivityBatch(
+            events=(
+                NewActivityEvent(
+                    type=ActivityEventType.MILESTONE,
+                    ts_ms=inside_ms,
+                    dedupe_key="unique_aircraft_100",
+                ),
+                NewActivityEvent(
+                    type=ActivityEventType.RANGE_RECORD,
+                    ts_ms=inside_ms,
+                    dedupe_key="range_record:100.000",
+                ),
+                NewActivityEvent(
+                    type=ActivityEventType.RECEIVER_OFFLINE,
+                    ts_ms=inside_ms,
+                    dedupe_key="receiver_offline:1",
+                ),
+            )
+        )
+    )
+    span = window(zone, day, day)
+
+    assert await queries.new_milestones(span) == 2
+
+
+async def test_new_milestones_respects_the_spring_forward_days_true_bounds(
+    database: Database, queries: AnalyticsQueries, zone: ZoneInfo
+) -> None:
+    """A milestone struck just inside the 23-hour DST day counts; one struck
+    the instant it ends belongs to the next local day, not this one.
+    """
+    _, end_ms = day_bounds_ms(SPRING_FORWARD, zone)
+    just_inside = end_ms - 1
+    just_outside = end_ms
+    await FeedRepository(database).record(
+        ActivityBatch(
+            events=(
+                NewActivityEvent(
+                    type=ActivityEventType.MILESTONE,
+                    ts_ms=just_inside,
+                    dedupe_key="unique_aircraft_100",
+                ),
+                NewActivityEvent(
+                    type=ActivityEventType.MILESTONE,
+                    ts_ms=just_outside,
+                    dedupe_key="unique_aircraft_500",
+                ),
+            )
+        )
+    )
+    span = window(zone, SPRING_FORWARD, SPRING_FORWARD)
+
+    assert await queries.new_milestones(span) == 1

--- a/frontend/src/features/today/TodayPanel.test.tsx
+++ b/frontend/src/features/today/TodayPanel.test.tsx
@@ -1,0 +1,167 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { TodayPanel } from "@/features/today/TodayPanel";
+import {
+  analyticsSummaryResponse,
+  installAnalyticsApiMock,
+} from "@/test/analyticsApiMock";
+import { defaultReceiverInfo } from "@/test/aircraftApiMock";
+
+function renderPanel() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <TodayPanel />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+async function expand(): Promise<void> {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /today/i }));
+}
+
+describe("TodayPanel", () => {
+  it("is collapsed by default, with a sightings badge visible in the header", async () => {
+    installAnalyticsApiMock({
+      summary: analyticsSummaryResponse({ sightings: 18 }),
+    });
+    renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("today-sightings-badge")).toHaveTextContent(
+        "18 sightings",
+      ),
+    );
+    const header = screen.getByRole("button", { name: /today/i });
+    expect(header).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Unique aircraft")).not.toBeInTheDocument();
+  });
+
+  it("renders every §59 stat tile once expanded", async () => {
+    installAnalyticsApiMock({
+      summary: analyticsSummaryResponse({
+        unique_aircraft: 12,
+        sightings: 18,
+        interesting: 2,
+        military: 1,
+        government: 2,
+        law_enforcement: 3,
+        max_range_nm: 187.44,
+        busiest_hour: 14,
+        new_aircraft: 3,
+        new_milestones: 5,
+      }),
+    });
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByTestId("today-sightings-badge")).toBeInTheDocument(),
+    );
+
+    await expand();
+
+    expect(screen.getByText("Unique aircraft")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("Sightings")).toBeInTheDocument();
+    expect(screen.getByText("Interesting")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("Mil / gov / police")).toBeInTheDocument();
+    expect(screen.getByText("1 / 2 / 3")).toBeInTheDocument();
+    expect(screen.getByText("Max range")).toBeInTheDocument();
+    expect(screen.getByText("187.4 nm")).toBeInTheDocument();
+    expect(screen.getByText("Busiest hour")).toBeInTheDocument();
+    // Receiver-local hour, rendered as the clock range it covers.
+    expect(screen.getByText("14:00–15:00")).toBeInTheDocument();
+    expect(screen.getByText("New aircraft")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("New milestones")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("renders null figures as placeholders rather than blanks or errors", async () => {
+    installAnalyticsApiMock({
+      summary: analyticsSummaryResponse({
+        max_range_nm: null,
+        busiest_hour: null,
+        busiest_hour_source: null,
+        interesting: 0,
+      }),
+    });
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByTestId("today-sightings-badge")).toBeInTheDocument(),
+    );
+
+    await expand();
+
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getByText("No data yet")).toBeInTheDocument();
+  });
+
+  it("converts the max-range tile to kilometers when the receiver prefers metric units", async () => {
+    installAnalyticsApiMock({
+      receiver: defaultReceiverInfo({ units: "metric" }),
+      summary: analyticsSummaryResponse({ max_range_nm: 187.44 }),
+    });
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByTestId("today-sightings-badge")).toBeInTheDocument(),
+    );
+
+    await expand();
+
+    expect(screen.getByText("347.1 km")).toBeInTheDocument();
+  });
+
+  it("links the new-milestones tile to the activity page", async () => {
+    installAnalyticsApiMock({
+      summary: analyticsSummaryResponse({ new_milestones: 4 }),
+    });
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByTestId("today-sightings-badge")).toBeInTheDocument(),
+    );
+
+    await expand();
+
+    expect(screen.getByTestId("today-milestones-link")).toHaveAttribute(
+      "href",
+      "/activity",
+    );
+  });
+
+  it("collapses and expands from the header button", async () => {
+    installAnalyticsApiMock({ summary: analyticsSummaryResponse() });
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByTestId("today-sightings-badge")).toBeInTheDocument(),
+    );
+
+    await expand();
+    expect(screen.getByText("Unique aircraft")).toBeInTheDocument();
+
+    await expand();
+    expect(screen.queryByText("Unique aircraft")).not.toBeInTheDocument();
+  });
+
+  it("reports a failed fetch rather than rendering an empty grid", async () => {
+    installAnalyticsApiMock({ summaryStatus: 500 });
+    renderPanel();
+
+    await expand();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/could not load today's summary/i),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/features/today/TodayPanel.tsx
+++ b/frontend/src/features/today/TodayPanel.tsx
@@ -1,0 +1,141 @@
+/**
+ * "Today at a glance" (SPEC §59, roadmap slice 036): a compact, collapsible
+ * card on the Live Map summarizing the receiver's local day — unique
+ * aircraft, sightings, interesting aircraft, military/government/police,
+ * maximum range, busiest hour, new aircraft, and new milestones/records —
+ * all read from `GET /api/v1/analytics/summary` (roadmap slice 031's
+ * endpoint, extended here with `new_milestones`).
+ *
+ * Follows the `ActivityPanel`/`NonPositionedPanel` idiom (collapsed by
+ * default, header button carrying `aria-expanded`, a badge visible even
+ * collapsed, a bordered body once expanded), but takes the one corner none
+ * of them do: `left-1/2 top-3` with `-translate-x-1/2`, a top-center strip
+ * beside `ConnectionStatusChip` (`left-3 top-3`) rather than stacked in any
+ * of the four corners those panels already occupy. The map stays the hero —
+ * collapsed, this is a single-line strip; expanded, a stat-tile row that
+ * wraps under the map's own width rather than a modal over it.
+ *
+ * "Today" is the receiver's local calendar day, not the browser's
+ * (`docs/API.md` §3.7): `useReceiverLocalDate` (`features/today/lib/localDay.ts`)
+ * recomputes that date against the receiver's zone and feeds it into the
+ * query key, so a local-midnight rollover — which does not happen at the
+ * same wall-clock moment for a viewer in another timezone — forces a fresh
+ * fetch instead of the card quietly showing yesterday's figures past
+ * midnight.
+ */
+
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+import { StatTile } from "@/features/today/components/StatTile";
+import {
+  formatCount,
+  formatDistance,
+  formatHourRange,
+} from "@/features/today/lib/format";
+import { useReceiverLocalDate } from "@/features/today/lib/localDay";
+import { useAnalyticsSummaryQuery } from "@/lib/api/analytics";
+import { useReceiverQuery } from "@/lib/api/receiver";
+
+export function TodayPanel() {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const receiverQuery = useReceiverQuery();
+  const timezone = receiverQuery.data?.timezone ?? "UTC";
+  const units = receiverQuery.data?.units ?? "aviation";
+  const localDate = useReceiverLocalDate(timezone);
+  const summaryQuery = useAnalyticsSummaryQuery({ preset: "today" }, localDate);
+  const summary = summaryQuery.data?.summary;
+
+  return (
+    <div
+      data-testid="today-panel"
+      className="absolute left-1/2 top-3 z-10 w-[min(36rem,92vw)] -translate-x-1/2 overflow-hidden rounded-lg border border-border bg-card/95 shadow-md backdrop-blur-sm"
+    >
+      <button
+        type="button"
+        aria-expanded={isExpanded}
+        onClick={() => setIsExpanded((expanded) => !expanded)}
+        className="flex w-full items-center justify-between gap-2 px-3 py-2 text-xs font-medium"
+      >
+        <span className="flex items-center gap-1.5">
+          Today
+          {summary !== undefined && (
+            <span
+              data-testid="today-sightings-badge"
+              className="inline-flex min-w-4 items-center justify-center rounded-full bg-secondary px-1.5 text-[10px] font-semibold text-secondary-foreground"
+            >
+              {formatCount(summary.sightings)} sightings
+            </span>
+          )}
+        </span>
+        {isExpanded ? (
+          <ChevronUp className="size-3.5" aria-hidden="true" />
+        ) : (
+          <ChevronDown className="size-3.5" aria-hidden="true" />
+        )}
+      </button>
+
+      {isExpanded && (
+        <div className="border-t border-border p-2.5">
+          {summaryQuery.isPending ? (
+            <p className="px-0.5 py-1 text-xs text-muted-foreground">
+              Loading…
+            </p>
+          ) : summaryQuery.isError ? (
+            <p className="px-0.5 py-1 text-xs text-destructive">
+              Could not load today&apos;s summary: {summaryQuery.error.message}
+            </p>
+          ) : summary === undefined ? null : (
+            <div
+              role="group"
+              aria-label="Today at a glance"
+              className="grid grid-cols-2 gap-2 sm:grid-cols-4"
+            >
+              <StatTile
+                label="Unique aircraft"
+                value={formatCount(summary.unique_aircraft)}
+              />
+              <StatTile
+                label="Sightings"
+                value={formatCount(summary.sightings)}
+              />
+              <StatTile
+                label="Interesting"
+                value={formatCount(summary.interesting)}
+              />
+              <StatTile
+                label="Mil / gov / police"
+                value={`${summary.military} / ${summary.government} / ${summary.law_enforcement}`}
+              />
+              <StatTile
+                label="Max range"
+                value={formatDistance(summary.max_range_nm, units) ?? "—"}
+              />
+              <StatTile
+                label="Busiest hour"
+                value={formatHourRange(summary.busiest_hour)}
+              />
+              <StatTile
+                label="New aircraft"
+                value={formatCount(summary.new_aircraft)}
+              />
+              <Link
+                to="/activity"
+                data-testid="today-milestones-link"
+                className="rounded-md border border-border bg-card p-2.5 text-card-foreground outline-none transition-colors hover:bg-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+              >
+                <p className="text-[11px] text-muted-foreground">
+                  New milestones
+                </p>
+                <p className="mt-0.5 text-lg font-semibold tabular-nums">
+                  {formatCount(summary.new_milestones)}
+                </p>
+              </Link>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/today/components/StatTile.tsx
+++ b/frontend/src/features/today/components/StatTile.tsx
@@ -1,0 +1,26 @@
+/**
+ * One stat tile in the Today panel's grid — the same visual shape as
+ * `features/receiver/components/ReceiverScorecard.tsx`'s `StatTile`,
+ * duplicated rather than imported (that file is Receiver-page-local, and
+ * this feature stays a self-contained read of its own few small files, the
+ * convention `features/receiver/lib/format.ts`'s doc comment states).
+ */
+import type { ReactNode } from "react";
+
+export interface StatTileProps {
+  label: string;
+  value: ReactNode;
+  secondary?: ReactNode;
+}
+
+export function StatTile({ label, value, secondary }: StatTileProps) {
+  return (
+    <div className="rounded-md border border-border bg-card p-2.5 text-card-foreground">
+      <p className="text-[11px] text-muted-foreground">{label}</p>
+      <p className="mt-0.5 text-lg font-semibold tabular-nums">{value}</p>
+      {secondary !== undefined && (
+        <p className="mt-0.5 text-[11px] text-muted-foreground">{secondary}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/today/lib/format.test.ts
+++ b/frontend/src/features/today/lib/format.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatCount,
+  formatDistance,
+  formatHourRange,
+} from "@/features/today/lib/format";
+
+describe("formatCount", () => {
+  it("formats a plain count with locale grouping", () => {
+    expect(formatCount(0)).toBe("0");
+    expect(formatCount(1234)).toBe("1,234");
+  });
+});
+
+describe("formatDistance", () => {
+  it("renders nautical miles in aviation units", () => {
+    expect(formatDistance(187.44, "aviation")).toBe("187.4 nm");
+  });
+
+  it("converts to kilometers in metric units", () => {
+    expect(formatDistance(187.44, "metric")).toBe("347.1 km");
+  });
+
+  it("passes null through rather than formatting a placeholder", () => {
+    expect(formatDistance(null, "aviation")).toBeNull();
+  });
+});
+
+describe("formatHourRange", () => {
+  it("renders an hour as the receiver-local clock range it covers", () => {
+    expect(formatHourRange(14)).toBe("14:00–15:00");
+  });
+
+  it("zero-pads single-digit hours", () => {
+    expect(formatHourRange(9)).toBe("09:00–10:00");
+  });
+
+  it("wraps the last hour of the day into 00:00", () => {
+    expect(formatHourRange(23)).toBe("23:00–00:00");
+  });
+
+  it("reads as 'No data yet' rather than a blank tile", () => {
+    expect(formatHourRange(null)).toBe("No data yet");
+  });
+});

--- a/frontend/src/features/today/lib/format.ts
+++ b/frontend/src/features/today/lib/format.ts
@@ -1,0 +1,55 @@
+/**
+ * Formatting for the Today panel's stat tiles (roadmap slice 036).
+ *
+ * Distance/count formatting is deliberately duplicated from
+ * `features/receiver/lib/format.ts` rather than imported — the same
+ * self-contained-feature call that file's own doc comment makes relative to
+ * `features/aircraft-detail/lib/format.ts`. Storage and the wire format are
+ * always nm (`CLAUDE.md`); `formatDistance` converts to km only for display
+ * when the receiver's `units` preference (`docs/API.md` §3.2) is `"metric"`.
+ */
+import type { UnitSystem } from "@/lib/api/config";
+
+const NM_PER_KM = 1 / 1.852;
+
+function round(value: number, decimals = 0): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function localeNumber(value: number, decimals = 0): string {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}
+
+export function formatCount(count: number): string {
+  return localeNumber(count);
+}
+
+export function formatDistance(
+  distanceNm: number | null,
+  units: UnitSystem,
+): string | null {
+  if (distanceNm === null) {
+    return null;
+  }
+  return units === "metric"
+    ? `${localeNumber(round(distanceNm / NM_PER_KM, 1), 1)} km`
+    : `${localeNumber(round(distanceNm, 1), 1)} nm`;
+}
+
+/** `"14:00–15:00"` for `hour === 14` — the receiver-local clock hour
+ * `busiest_hour` names, spelled as the hour-long window it actually covers
+ * rather than a bare number a viewer would have to interpret. `null` (no
+ * traffic yet today, or the day has not accumulated an hourly sample) reads
+ * as `"No data yet"` rather than a blank tile. */
+export function formatHourRange(hour: number | null): string {
+  if (hour === null) {
+    return "No data yet";
+  }
+  const pad = (value: number) => String(value).padStart(2, "0");
+  const next = (hour + 1) % 24;
+  return `${pad(hour)}:00–${pad(next)}:00`;
+}

--- a/frontend/src/features/today/lib/localDay.test.ts
+++ b/frontend/src/features/today/lib/localDay.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  receiverLocalDate,
+  useReceiverLocalDate,
+} from "@/features/today/lib/localDay";
+
+describe("receiverLocalDate", () => {
+  it("resolves against the receiver's zone, not UTC", () => {
+    // 2026-09-01T02:00:00Z is already the 1st in UTC, but still the 31st in
+    // Los Angeles (UTC-7 in August/September DST) — the exact case §3.7's
+    // "today" must get right for a receiver west of the browser.
+    const at = new Date("2026-09-01T02:00:00Z");
+
+    expect(receiverLocalDate("America/Los_Angeles", at)).toBe("2026-08-31");
+    expect(receiverLocalDate("UTC", at)).toBe("2026-09-01");
+  });
+
+  it("resolves against a zone ahead of UTC the same way", () => {
+    // 2026-08-31T20:00:00Z is still the 31st in UTC but already the 1st in
+    // Kolkata (UTC+5:30).
+    const at = new Date("2026-08-31T20:00:00Z");
+
+    expect(receiverLocalDate("Asia/Kolkata", at)).toBe("2026-09-01");
+  });
+
+  it("falls back to UTC's date rather than throwing on an unrecognized zone", () => {
+    const at = new Date("2026-09-01T00:00:00Z");
+
+    expect(receiverLocalDate("Not/AZone", at)).toBe("2026-09-01");
+  });
+});
+
+describe("useReceiverLocalDate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the receiver-local date for the current instant", () => {
+    vi.setSystemTime(new Date("2026-08-31T12:00:00Z"));
+
+    const { result } = renderHook(() =>
+      useReceiverLocalDate("America/Los_Angeles"),
+    );
+
+    expect(result.current).toBe("2026-08-31");
+  });
+
+  it("rolls over once receiver-local midnight passes, on its own", () => {
+    // 2026-08-31T06:59:00Z is 2026-08-30T23:59 in Los Angeles; a minute
+    // later crosses receiver-local midnight into the 31st.
+    vi.setSystemTime(new Date("2026-08-31T06:59:00Z"));
+    const { result } = renderHook(() =>
+      useReceiverLocalDate("America/Los_Angeles"),
+    );
+    expect(result.current).toBe("2026-08-30");
+
+    act(() => {
+      vi.setSystemTime(new Date("2026-08-31T07:01:00Z"));
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(result.current).toBe("2026-08-31");
+  });
+
+  it("recomputes immediately when the timezone itself changes", () => {
+    vi.setSystemTime(new Date("2026-09-01T02:00:00Z"));
+    const { result, rerender } = renderHook(
+      ({ timezone }: { timezone: string }) => useReceiverLocalDate(timezone),
+      { initialProps: { timezone: "UTC" } },
+    );
+    expect(result.current).toBe("2026-09-01");
+
+    rerender({ timezone: "America/Los_Angeles" });
+
+    expect(result.current).toBe("2026-08-31");
+  });
+});

--- a/frontend/src/features/today/lib/localDay.ts
+++ b/frontend/src/features/today/lib/localDay.ts
@@ -1,0 +1,82 @@
+/**
+ * The receiver-local "today" date, computed client-side so the Today panel
+ * (roadmap slice 036) knows when to refetch across a local-midnight rollover.
+ *
+ * The backend resolves `preset=today` against the *receiver's* IANA zone,
+ * never the browser's (`docs/API.md` §3.7) — a card behind a browser in
+ * another timezone must not decide on its own that a new day has started, or
+ * ask for a fresh window when the receiver's day has not actually turned
+ * over. So the same computation happens here, against the same zone
+ * (`useReceiverQuery().data.timezone`), purely to know *when* to ask the
+ * server again — the server's response, not this module, is still the
+ * source of truth for what "today" contains.
+ */
+import { useEffect, useState } from "react";
+
+/** How often the local date is re-checked. Coarse on purpose — a card that
+ * is fresh within half a minute of receiver-local midnight is plenty, and
+ * `useAnalyticsSummaryQuery`'s 60 s `staleTime` and focus refetch are what
+ * keep the figures themselves current the rest of the time. */
+const POLL_INTERVAL_MS = 30_000;
+
+/** The receiver-local calendar date (`YYYY-MM-DD`) for `at`, in `timezone`.
+ *
+ * `Intl.DateTimeFormat`'s `en-CA` locale is picked only because it happens to
+ * format as ISO `YYYY-MM-DD` — the locale itself carries no other meaning
+ * here, the same trick `features/analytics/lib/format.ts` avoids needing by
+ * working from already-formatted day strings instead of computing one.
+ */
+export function receiverLocalDate(
+  timezone: string,
+  at: Date = new Date(),
+): string {
+  try {
+    return new Intl.DateTimeFormat("en-CA", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(at);
+  } catch {
+    // An unrecognized zone (a receiver mid-setup, or a stale cached value)
+    // must not crash the card — UTC's date is still a real, if imprecise,
+    // "today" to key a refetch on.
+    return new Intl.DateTimeFormat("en-CA", {
+      timeZone: "UTC",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(at);
+  }
+}
+
+/** The receiver-local "today" string, re-derived every {@link POLL_INTERVAL_MS}
+ * and whenever `timezone` itself changes. A component reading this value in a
+ * TanStack Query key (`analyticsQueryKeys.summary`) gets a fresh query the
+ * moment receiver-local midnight passes, without polling the summary
+ * endpoint itself any more often than its own `staleTime` already does. */
+export function useReceiverLocalDate(timezone: string): string {
+  // A changed `timezone` is adjusted for during render (React's documented
+  // pattern for state that must track a prop) rather than in an effect, so
+  // the corrected date is available on the very render that receives the new
+  // zone instead of one render behind it.
+  const [tracked, setTracked] = useState(() => ({
+    timezone,
+    date: receiverLocalDate(timezone),
+  }));
+  if (tracked.timezone !== timezone) {
+    setTracked({ timezone, date: receiverLocalDate(timezone) });
+  }
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setTracked((previous) => ({
+        ...previous,
+        date: receiverLocalDate(previous.timezone),
+      }));
+    }, POLL_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, []);
+
+  return tracked.date;
+}

--- a/frontend/src/lib/api/analytics.test.ts
+++ b/frontend/src/lib/api/analytics.test.ts
@@ -1,14 +1,19 @@
+import { renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   AnalyticsApiError,
+  analyticsQueryKeys,
   getAnalyticsClassificationActivity,
   getAnalyticsDaily,
   getAnalyticsRarity,
+  getAnalyticsSummary,
   getAnalyticsTopAircraft,
   getAnalyticsTopOperators,
   getAnalyticsTopTypes,
+  useAnalyticsSummaryQuery,
 } from "@/lib/api/analytics";
+import { createQueryWrapper } from "@/test/queryWrapper";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -86,6 +91,79 @@ describe("getAnalyticsDaily", () => {
     expect(error).toBeInstanceOf(AnalyticsApiError);
     expect((error as AnalyticsApiError).status).toBe(500);
     expect((error as AnalyticsApiError).code).toBeNull();
+  });
+});
+
+const EMPTY_SUMMARY_BODY = {
+  window: EMPTY_WINDOW,
+  summary: {
+    unique_aircraft: 0,
+    new_aircraft: 0,
+    sightings: 0,
+    interesting: 0,
+    military: 0,
+    government: 0,
+    law_enforcement: 0,
+    max_range_nm: null,
+    busiest_hour: null,
+    busiest_hour_source: null,
+    first_sighting_at: null,
+    last_sighting_at: null,
+    new_milestones: 0,
+  },
+};
+
+describe("getAnalyticsSummary", () => {
+  it("requests the summary path with the given preset", async () => {
+    const fetchMock = vi.fn((_input?: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(jsonResponse(EMPTY_SUMMARY_BODY)),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getAnalyticsSummary({ preset: "today" });
+
+    const url = new URL(
+      String(fetchMock.mock.calls[0]?.[0]),
+      "http://localhost",
+    );
+    expect(url.pathname).toBe("/api/v1/analytics/summary");
+    expect(url.searchParams.get("preset")).toBe("today");
+  });
+});
+
+describe("analyticsQueryKeys.summary", () => {
+  it("differs by local date, so a receiver-local day rollover is a different cache entry", () => {
+    const params = { preset: "today" } as const;
+
+    expect(analyticsQueryKeys.summary(params, "2026-08-31")).not.toEqual(
+      analyticsQueryKeys.summary(params, "2026-09-01"),
+    );
+  });
+});
+
+describe("useAnalyticsSummaryQuery", () => {
+  it("fetches again once the local-date key changes, without waiting on staleTime (roadmap slice 036's rollover contract)", async () => {
+    const fetchMock = vi.fn((_input?: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(jsonResponse(EMPTY_SUMMARY_BODY)),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, rerender } = renderHook(
+      ({ localDate }: { localDate: string }) =>
+        useAnalyticsSummaryQuery({ preset: "today" }, localDate),
+      {
+        wrapper: createQueryWrapper(),
+        initialProps: { localDate: "2026-08-31" },
+      },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // A fresh 60 s `staleTime` would ordinarily serve the cache; a changed
+    // local-date key must bypass that and fetch immediately regardless.
+    rerender({ localDate: "2026-09-01" });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
   });
 });
 

--- a/frontend/src/lib/api/analytics.ts
+++ b/frontend/src/lib/api/analytics.ts
@@ -1,8 +1,8 @@
 /**
  * Typed client for the Analytics endpoints — `GET /api/v1/analytics/*`
- * (`docs/API.md` §3.7, roadmap slice 031/032). Six of the seven §3.7
- * endpoints are covered here; `/analytics/summary` feeds a separate
- * today-at-a-glance widget (SPEC §59) outside this slice's scope.
+ * (`docs/API.md` §3.7, roadmap slice 031/032/036). All seven §3.7 endpoints
+ * are covered here; `/analytics/summary` (SPEC §59) is roadmap slice 036's —
+ * the Live Map's "Today at a glance" widget in `features/today/`.
  *
  * Every endpoint takes the same window parameters and echoes back the
  * `AnalyticsWindow` it actually resolved (§3.7: presets resolve against the
@@ -135,6 +135,40 @@ export interface AnalyticsRarityResponse {
   rare_types: AnalyticsRareType[];
 }
 
+/** SPEC §59's at-a-glance block. Every key here is always present — `null`
+ * only where a figure genuinely has nothing to report (`max_range_nm` with
+ * no positioned sighting yet, `busiest_hour` before any traffic) — so a
+ * client never has to guess whether a stat has "not started counting" versus
+ * "counted zero". `interesting` is real and live today, but reads `0` on
+ * every install until roadmap slice 038's alert engine starts setting
+ * `sightings.max_alert_severity` — the key itself never disappears. */
+export interface AnalyticsSummary {
+  unique_aircraft: number;
+  new_aircraft: number;
+  sightings: number;
+  interesting: number;
+  military: number;
+  government: number;
+  law_enforcement: number;
+  max_range_nm: number | null;
+  busiest_hour: number | null;
+  /** `"daily_stats"` for a closed day's finalized value, or
+   * `"receiver_metrics_hourly"` for the in-progress day (`docs/DATA_MODEL.md`
+   * §6.5's dual source) — `null` only alongside a `null` `busiest_hour`. */
+  busiest_hour_source: "daily_stats" | "receiver_metrics_hourly" | null;
+  first_sighting_at: string | null;
+  last_sighting_at: string | null;
+  /** SPEC §59's "new milestones/records": `activity_events` rows of type
+   * `first_ever_aircraft`, `new_type`, `range_record`, `receiver_record` or
+   * `milestone` whose moment falls inside the window. */
+  new_milestones: number;
+}
+
+export interface AnalyticsSummaryResponse {
+  window: AnalyticsWindow;
+  summary: AnalyticsSummary;
+}
+
 interface ApiV1ErrorBody {
   error?: { code?: string; message?: string; detail?: unknown };
 }
@@ -195,6 +229,14 @@ function topQuery(params: AnalyticsTopParams): URLSearchParams {
   return search;
 }
 
+export function getAnalyticsSummary(
+  params: AnalyticsWindowParams,
+): Promise<AnalyticsSummaryResponse> {
+  return apiV1Fetch<AnalyticsSummaryResponse>(
+    `/api/v1/analytics/summary?${windowQuery(params).toString()}`,
+  );
+}
+
 export function getAnalyticsDaily(
   params: AnalyticsWindowParams,
 ): Promise<AnalyticsDailyResponse> {
@@ -248,6 +290,13 @@ export function getAnalyticsRarity(
 }
 
 export const analyticsQueryKeys = {
+  /** `localDate` (the receiver-local `YYYY-MM-DD` "today") is part of the
+   * key so a day rollover — computed client-side by
+   * `features/today/lib/localDay.ts` against the receiver's zone — forces a
+   * fresh fetch instead of serving yesterday's cached figures past midnight,
+   * the same way `params` already forces one on a preset change. */
+  summary: (params: AnalyticsWindowParams, localDate: string) =>
+    ["analytics", "summary", params, localDate] as const,
   daily: (params: AnalyticsWindowParams) =>
     ["analytics", "daily", params] as const,
   classification: (params: AnalyticsWindowParams) =>
@@ -261,6 +310,23 @@ export const analyticsQueryKeys = {
   rarity: (params: AnalyticsRarityParams) =>
     ["analytics", "rarity", params] as const,
 };
+
+/** `staleTime`/`refetchOnWindowFocus` are overridden past the app-wide
+ * defaults (`lib/queryClient.ts`'s 30 s, no focus refetch): the Live Map's
+ * "Today at a glance" card is meant to look current when a user tabs back to
+ * it, and 60 s keeps a floating card that is visible far more often than the
+ * Analytics page from re-requesting on every render. */
+export function useAnalyticsSummaryQuery(
+  params: AnalyticsWindowParams,
+  localDate: string,
+): UseQueryResult<AnalyticsSummaryResponse> {
+  return useQuery({
+    queryKey: analyticsQueryKeys.summary(params, localDate),
+    queryFn: () => getAnalyticsSummary(params),
+    staleTime: 60_000,
+    refetchOnWindowFocus: true,
+  });
+}
 
 export function useAnalyticsDailyQuery(
   params: AnalyticsWindowParams,

--- a/frontend/src/pages/LiveMapPage.tsx
+++ b/frontend/src/pages/LiveMapPage.tsx
@@ -14,6 +14,7 @@ import { LayersControl } from "@/features/map/overlays/LayersControl";
 import { OverlaysLayer } from "@/features/map/overlays/OverlaysLayer";
 import { useBasemapStore } from "@/features/map/store/useBasemapStore";
 import { useMapConfigStore } from "@/features/map/store/useMapConfigStore";
+import { TodayPanel } from "@/features/today/TodayPanel";
 
 const item = requireNavItem("/");
 
@@ -23,9 +24,11 @@ const item = requireNavItem("/");
  * the live aircraft layer (slice 014), the aircraft detail panel (slice
  * 016), the live filters (drawer, quick chips, non-positioned list, and
  * the display-radius cap indicator — slice 017), all of which read and
- * write the same filtered set via `features/filters`, and the activity feed
+ * write the same filtered set via `features/filters`, the activity feed
  * panel (slice 035), which is the one floating control fed by the socket's
- * `activity` frames rather than by the live picture.
+ * `activity` frames rather than by the live picture, and the "Today at a
+ * glance" card (slice 036), a top-center strip fed by the analytics summary
+ * endpoint rather than by anything the live picture or the feed carry.
  *
  * The map configuration — including the display-radius default the
  * distance-cap filter falls back to — comes from `useMapConfigStore`, which
@@ -56,6 +59,7 @@ export function LiveMapPage() {
       <FilterDrawer />
       <NonPositionedPanel />
       <ActivityPanel />
+      <TodayPanel />
       <DisplayRadiusIndicator />
       <AircraftDetailPanel />
     </div>

--- a/frontend/src/test/analyticsApiMock.ts
+++ b/frontend/src/test/analyticsApiMock.ts
@@ -7,6 +7,7 @@ import type {
   AnalyticsGroupResponse,
   AnalyticsPreset,
   AnalyticsRarityResponse,
+  AnalyticsSummaryResponse,
   AnalyticsWindow,
 } from "@/lib/api/analytics";
 import type { ReceiverInfo } from "@/lib/api/live";
@@ -38,6 +39,9 @@ function jsonResponse(body: unknown, status = 200): Response {
 
 export interface MockAnalyticsApiOptions {
   receiver?: ReceiverInfo;
+  summary?: AnalyticsSummaryResponse;
+  /** Serve an error envelope from `GET /api/v1/analytics/summary` instead. */
+  summaryStatus?: number;
   daily?: AnalyticsDailyResponse;
   classification?: AnalyticsClassificationResponse;
   topAircraft?: AnalyticsAircraftResponse;
@@ -45,6 +49,51 @@ export interface MockAnalyticsApiOptions {
   topOperators?: AnalyticsGroupResponse;
   rarity?: AnalyticsRarityResponse;
 }
+
+/** A plausible SPEC §59 summary — every key present, matching what a real
+ * response always carries. */
+export function analyticsSummaryResponse(
+  overrides: Partial<AnalyticsSummaryResponse["summary"]> = {},
+): AnalyticsSummaryResponse {
+  return {
+    window: analyticsWindow("today"),
+    summary: {
+      unique_aircraft: 12,
+      new_aircraft: 3,
+      sightings: 18,
+      interesting: 0,
+      military: 1,
+      government: 0,
+      law_enforcement: 0,
+      max_range_nm: 187.4,
+      busiest_hour: 14,
+      busiest_hour_source: "receiver_metrics_hourly",
+      first_sighting_at: "2026-08-31T13:05:00.000Z",
+      last_sighting_at: "2026-08-31T20:41:00.000Z",
+      new_milestones: 2,
+      ...overrides,
+    },
+  };
+}
+
+const EMPTY_SUMMARY: AnalyticsSummaryResponse = {
+  window: analyticsWindow(),
+  summary: {
+    unique_aircraft: 0,
+    new_aircraft: 0,
+    sightings: 0,
+    interesting: 0,
+    military: 0,
+    government: 0,
+    law_enforcement: 0,
+    max_range_nm: null,
+    busiest_hour: null,
+    busiest_hour_source: null,
+    first_sighting_at: null,
+    last_sighting_at: null,
+    new_milestones: 0,
+  },
+};
 
 const EMPTY_DAILY: AnalyticsDailyResponse = {
   window: analyticsWindow(),
@@ -76,8 +125,9 @@ const EMPTY_RARITY: AnalyticsRarityResponse = {
 };
 
 /** Installs a `global.fetch` stub serving `GET /api/v1/receiver` and every
- * `/api/v1/analytics/*` endpoint the Analytics page (roadmap slice 032)
- * queries, so its tests exercise the real API clients and TanStack Query
+ * `/api/v1/analytics/*` endpoint — the six the Analytics page (roadmap slice
+ * 032) queries, plus `/summary` (SPEC §59, roadmap slice 036's Today panel) —
+ * so tests exercise the real API clients and TanStack Query
  * hooks without a running backend. Any other URL throws, surfacing an
  * un-mocked request as a test failure — the same contract
  * `installSightingsApiMock` establishes. */
@@ -90,6 +140,21 @@ export function installAnalyticsApiMock(options: MockAnalyticsApiOptions = {}) {
 
       if (url.pathname === "/api/v1/receiver" && method === "GET") {
         return jsonResponse(options.receiver ?? defaultReceiverInfo());
+      }
+      if (url.pathname === "/api/v1/analytics/summary" && method === "GET") {
+        if (options.summaryStatus !== undefined) {
+          return jsonResponse(
+            {
+              error: {
+                code: "internal_error",
+                message: "The daily summary is unavailable",
+                detail: null,
+              },
+            },
+            options.summaryStatus,
+          );
+        }
+        return jsonResponse(options.summary ?? EMPTY_SUMMARY);
       }
       if (url.pathname === "/api/v1/analytics/daily" && method === "GET") {
         return jsonResponse(options.daily ?? EMPTY_DAILY);

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -962,7 +962,7 @@ slices:
     title: "Today at a glance"
     phase: 5
     branch: "036-today-glance"
-    status: planned
+    status: merged
     depends_on: ["031", "033", "035"]
     objective: "Compact daily summary surfaced on the Live Map experience."
     scope:


### PR DESCRIPTION
## Slice
- **Slice ID:** 036 — Today at a glance
- **Roadmap:** `planning/roadmap.yaml` slice 036 (phase 5 — Phase 5 fully complete)
- **Issue:** Closes #89

## Objective
Compact daily summary on the Live Map experience.

## Implementation summary
- 031's summary endpoint extended additively with new_milestones (counting milestone/record activity types within the window); interesting already null-stable at 0 until 038
- Collapsible top-center Today card: the eight SPEC §59 tiles, unit-aware range, receiver-local busiest hour ('14:00–15:00') with the §6.5 dual-source split, milestone tile linking to /activity
- Receiver-local day folded into the query key — local-midnight rollover forces refetch; 60 s staleTime + focus refetch
- A react-hooks lint finding fixed via the documented render-time state-adjustment pattern

## Acceptance criteria
- [x] values match the analytics APIs for 'today' in receiver-local time; updates live
- [x] day-boundary behavior tested (rollover refetch key; DST fixtures upstream)

## Tests added/run
Backend 3148 passed (99.34%); frontend 1219 passed (97.5%). Reviewer re-ran gates on the reconciled tree.

## Performance / Security / Data considerations
One summary query per minute per client; no migration; no secrets.

## Documentation updates
None required.

## Known limitations
Interesting tile reads 0 until 038 lands (in flight).

## Follow-up work
None beyond roadmap.

## Fable self-review (SPEC §104)
- [x] Full diff inspected; additive endpoint extension verified; day-rollover design sound; no TODO/FIXME
- [x] Reconciled with dev (037/045); both suites green
- [ ] CI green on this PR (gate before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)