### PR TITLE
feat: interesting-aircraft surfaces (slice 039)

### DIFF
--- a/backend/src/flightsite/activity/model.py
+++ b/backend/src/flightsite/activity/model.py
@@ -11,11 +11,14 @@ the list to SPEC §55. :class:`ActivityEventType` spells §3.9's names, because
 those are the strings a client sees and the ones the published OpenAPI document
 has to match; §5's list is a comment on a column that deliberately carries no
 ``CHECK``, which is what "leave the vocabulary open" means in practice. The
-enum therefore also carries the values *no producer in this slice emits* —
+enum therefore also carries values *no producer emits yet* — §5 reserves
+``maintenance_issue`` and ``data_reset`` — so that adding a producer later is
+a producer, not a schema change.
 :attr:`ActivityEventType.ALERT_TRIGGERED` and
-:attr:`ActivityEventType.EMERGENCY_SQUAWK` are phase 6's (roadmap slice 039),
-and §5 reserves ``maintenance_issue`` and ``data_reset`` beyond them — so that
-adding a producer later is a producer, not a schema change.
+:attr:`ActivityEventType.EMERGENCY_SQUAWK` were two such reservations until
+slice 038's alert engine began emitting them through
+:func:`flightsite.activity.producers.alert_events`, which is exactly what
+that open-vocabulary bet was for.
 
 Milestones versus events
 ------------------------

--- a/frontend/src/features/activity/lib/describeActivityEvent.test.ts
+++ b/frontend/src/features/activity/lib/describeActivityEvent.test.ts
@@ -199,15 +199,67 @@ describe("describeActivityEvent", () => {
   });
 
   it.each<ActivityEventType>(["alert_triggered", "emergency_squawk"])(
-    "already renders the phase-6 type %s",
+    "renders the alert type %s without a blank or undefined label",
     (type) => {
-      // Roadmap slice 039 starts emitting these; the published schema lists
-      // them today, so a released client must not show a blank row.
       const { label } = describeActivityEvent(event(type, {}));
       expect(label).not.toBe("");
       expect(label).not.toContain("undefined");
     },
   );
+
+  it("headlines an alert with the engine's own match reason", () => {
+    // `reason` names a rule the *user* wrote. Passing it through rather than
+    // re-deriving a sentence keeps the feed, the alert history and the
+    // interesting panel saying the same thing about one match.
+    const { label, detail } = describeActivityEvent(
+      event(
+        "alert_triggered",
+        {
+          reason: "Rule: Military aircraft",
+          rule_name: "Military aircraft",
+          registration: "05-8153",
+          model: "Boeing C-17A Globemaster III",
+        },
+        { icao: "ae1463" },
+      ),
+    );
+    expect(label).toBe("Alert: Rule: Military aircraft");
+    expect(detail).toContain("05-8153");
+  });
+
+  it("falls back to the rule name when an alert carries no reason", () => {
+    const { label } = describeActivityEvent(
+      event("alert_triggered", { rule_name: "Watchlist — Tankers" }),
+    );
+    expect(label).toBe("Alert: Watchlist — Tankers");
+  });
+
+  it("falls back again when an alert names neither", () => {
+    const { label } = describeActivityEvent(event("alert_triggered", {}));
+    expect(label).toBe("Alert triggered");
+  });
+
+  it("puts the squawk code in an emergency's headline", () => {
+    // SPEC §47 wants these prominent rather than one entry among the alerts,
+    // which is why they get a type of their own.
+    const { label, detail } = describeActivityEvent(
+      event(
+        "emergency_squawk",
+        {
+          squawk: "7700",
+          reason: "Emergency squawk 7700 (general emergency)",
+        },
+        { icao: "a1b2c3" },
+      ),
+    );
+    expect(label).toBe("Emergency squawk 7700");
+    expect(detail).toContain("Emergency squawk 7700 (general emergency)");
+  });
+
+  it("still names an emergency whose squawk did not survive the payload", () => {
+    const { label } = describeActivityEvent(event("emergency_squawk", {}));
+    expect(label).toBe("Emergency squawk");
+  });
 
   it("renders a humanized slug for a type this build predates", () => {
     // §6: the vocabulary may grow. A backend ahead of this client must not

--- a/frontend/src/features/activity/lib/describeActivityEvent.ts
+++ b/frontend/src/features/activity/lib/describeActivityEvent.ts
@@ -277,20 +277,30 @@ export function describeActivityEvent(
       };
     }
 
-    // The two phase-6 types (roadmap slice 039). No producer emits them yet,
-    // but they are in the published schema, so the feed already knows how to
-    // render one rather than showing a bare slug the day they arrive.
-    case "alert_triggered":
-      return { label: "Alert triggered", detail: airframe(payload, icao) };
+    // The two alert types. Slice 038's engine emits them; slice 039 makes
+    // them say something. `reason` is the engine's own sentence for the
+    // match ("Rule: Military aircraft", "Emergency squawk 7700 (general
+    // emergency)"), and it is the one payload field this module passes
+    // through rather than rewording: it names a rule the *user* wrote, so
+    // re-deriving a sentence here would drift from what the alert history
+    // and the interesting panel say about the very same match.
+    case "alert_triggered": {
+      const reason = str(payload, "reason") ?? str(payload, "rule_name");
+      return {
+        label: reason === null ? "Alert triggered" : `Alert: ${reason}`,
+        detail: airframe(payload, icao),
+      };
+    }
 
     case "emergency_squawk": {
       const squawk = str(payload, "squawk");
       return {
-        label: "Emergency squawk",
-        detail: join([
-          squawk === null ? null : `Squawk ${squawk}`,
-          airframe(payload, icao),
-        ]),
+        // SPEC §47 wants these prominent rather than one entry among the
+        // alerts — which is why the backend gives them a type of their own —
+        // so the code goes in the headline rather than the detail line.
+        label:
+          squawk === null ? "Emergency squawk" : `Emergency squawk ${squawk}`,
+        detail: join([str(payload, "reason"), airframe(payload, icao)]),
       };
     }
 

--- a/frontend/src/features/aircraft-detail/AircraftDetailPanel.tsx
+++ b/frontend/src/features/aircraft-detail/AircraftDetailPanel.tsx
@@ -27,6 +27,7 @@ import { EmergencySquawkBadge } from "@/features/aircraft-detail/components/Emer
 import { ExternalTrackerLinks } from "@/features/aircraft-detail/components/ExternalTrackerLinks";
 import { FieldRow } from "@/features/aircraft-detail/components/FieldRow";
 import { IdentityMetadataSection } from "@/features/aircraft-detail/components/IdentityMetadataSection";
+import { InterestingSection } from "@/features/aircraft-detail/components/InterestingSection";
 import { PositionSourceBadge } from "@/features/aircraft-detail/components/PositionSourceBadge";
 import { NearestAirportSection } from "@/features/aircraft-detail/components/NearestAirportSection";
 import { TrackStats } from "@/features/aircraft-detail/components/TrackStats";
@@ -154,6 +155,11 @@ export function AircraftDetailPanel() {
             </p>
           ) : (
             <>
+              {/* First, above Live: an active match is the most important
+               * thing the panel can say about an aircraft, and it is why
+               * the user clicked the row or the ringed icon that opened
+               * this. Renders nothing at all when nothing is matching. */}
+              <InterestingSection interesting={aircraft.interesting} />
               <DetailSection title="Live">
                 <FieldRow
                   label="Altitude"

--- a/frontend/src/features/aircraft-detail/components/InterestingSection.test.tsx
+++ b/frontend/src/features/aircraft-detail/components/InterestingSection.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { InterestingSection } from "@/features/aircraft-detail/components/InterestingSection";
+
+describe("InterestingSection", () => {
+  it("renders nothing when no alert is matching", () => {
+    // Not an "Alerts: none" row: that would be chrome on the overwhelming
+    // majority of aircraft and would make the alerting one harder to spot.
+    const { container } = render(<InterestingSection interesting={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("names the severity in words, not by colour alone", () => {
+    render(
+      <InterestingSection
+        interesting={{ severity: "critical", reasons: ["Emergency squawk"] }}
+      />,
+    );
+    expect(screen.getByText("Critical")).toBeInTheDocument();
+  });
+
+  it("lists every reason standing against the aircraft", () => {
+    // The engine can stand more than one match against a sighting, and the
+    // detail panel is where a user goes to find out which rule fired.
+    render(
+      <InterestingSection
+        interesting={{
+          severity: "high",
+          reasons: ["Rule: Military aircraft", "Rule: Watchlist — Tankers"],
+        }}
+      />,
+    );
+    expect(screen.getByText("Rule: Military aircraft")).toBeInTheDocument();
+    expect(screen.getByText("Rule: Watchlist — Tankers")).toBeInTheDocument();
+    expect(screen.getByText("Reasons")).toBeInTheDocument();
+  });
+
+  it("uses the singular label for a single reason", () => {
+    render(
+      <InterestingSection
+        interesting={{ severity: "info", reasons: ["Rule: First ever"] }}
+      />,
+    );
+    expect(screen.getByText("Reason")).toBeInTheDocument();
+  });
+
+  it("still shows the severity when a match carries no reasons", () => {
+    // An empty reason list is a backend that told us less than it should.
+    // The severity is still true and still worth stating; the reason row
+    // falls back to the panel-wide Unknown rather than rendering blank.
+    render(
+      <InterestingSection interesting={{ severity: "info", reasons: [] }} />,
+    );
+    expect(screen.getByText("Info")).toBeInTheDocument();
+    expect(screen.queryByTestId("interesting-reasons")).not.toBeInTheDocument();
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/aircraft-detail/components/InterestingSection.tsx
+++ b/frontend/src/features/aircraft-detail/components/InterestingSection.tsx
@@ -1,0 +1,59 @@
+/**
+ * The active-alert section of the detail panel (SPEC §43/§46, roadmap slice
+ * 039): what is matching against this aircraft right now, and why.
+ *
+ * Unlike {@link NearestAirportSection}, this section renders **only when
+ * something is matching**. The two are different kinds of absent: a cruising
+ * aircraft genuinely has a nearest-airport answer (*"nothing near"*) worth
+ * stating, whereas an "Alerts: none" row on every ordinary airliner would be
+ * a line of chrome on the overwhelming majority of aircraft and would make
+ * the one that *is* alerting harder to spot, not easier.
+ *
+ * Every reason is listed, not just the first. The engine can stand more than
+ * one match against a sighting — a military aircraft that is also on a
+ * watchlist — and the panel is where a user goes to find out *which* rule
+ * fired, so collapsing them to the most severe would discard the answer they
+ * came for. They arrive most-severe-first, which is the order they render in.
+ *
+ * Severity is the shared {@link AlertSeverityBadge}, so the word "Critical"
+ * carries the message and the tint is decoration (SPEC §80).
+ */
+
+import { DetailSection } from "@/features/aircraft-detail/components/DetailSection";
+import { FieldRow } from "@/features/aircraft-detail/components/FieldRow";
+import { AlertSeverityBadge } from "@/features/sightings/components/AlertSeverityBadge";
+import type { InterestingMatch } from "@/lib/api/live";
+
+export interface InterestingSectionProps {
+  interesting: InterestingMatch | null;
+}
+
+export function InterestingSection({ interesting }: InterestingSectionProps) {
+  if (interesting === null) {
+    return null;
+  }
+
+  return (
+    <DetailSection title="Interesting">
+      <FieldRow
+        label="Severity"
+        value={<AlertSeverityBadge severity={interesting.severity} />}
+      />
+      <FieldRow
+        label={interesting.reasons.length === 1 ? "Reason" : "Reasons"}
+        value={
+          interesting.reasons.length === 0 ? null : (
+            <span
+              data-testid="interesting-reasons"
+              className="flex flex-col items-end gap-0.5"
+            >
+              {interesting.reasons.map((reason) => (
+                <span key={reason}>{reason}</span>
+              ))}
+            </span>
+          )
+        }
+      />
+    </DetailSection>
+  );
+}

--- a/frontend/src/features/filters/components/FilterDrawer.tsx
+++ b/frontend/src/features/filters/components/FilterDrawer.tsx
@@ -8,10 +8,12 @@
  * actually drawing.
  *
  * Fields that target metadata the decoder does not populate until a later
- * slice (aircraft type/operator/operator group, classification, mission,
- * interesting-only — see `types.ts`'s doc comment) stay fully interactive
- * rather than disabled, but carry an inline note explaining why they will
- * not change what's on the map yet.
+ * slice (aircraft type/operator/operator group, classification, mission —
+ * see `types.ts`'s doc comment) stay fully interactive rather than disabled,
+ * but carry an inline note explaining why they will not change what's on the
+ * map yet. "Interesting only" was one of those until slice 038 started
+ * populating `interesting` and slice 039 surfaced it; its note is gone
+ * because the filter now genuinely filters.
  */
 
 import { Filter, X } from "lucide-react";
@@ -372,10 +374,6 @@ export function FilterDrawer() {
                 />
                 Interesting only
               </label>
-              <PlumbingNote>
-                &ldquo;Interesting only&rdquo; activates with alerting (slice
-                038).
-              </PlumbingNote>
             </FilterSection>
 
             <FilterSection title="Ground traffic">

--- a/frontend/src/features/filters/components/NonPositionedPanel.tsx
+++ b/frontend/src/features/filters/components/NonPositionedPanel.tsx
@@ -11,6 +11,12 @@
  * fly to an aircraft with no position; the header docstring on
  * `AircraftDetailPanel` covers what a selection without live data — including
  * one FlightSite has never had a fix for — shows instead.
+ *
+ * The card does **not** position itself. Slice 039 added a second
+ * aircraft-list panel to the same bottom-left corner (`InterestingPanel`),
+ * so `LiveMapPage` now owns that corner as one flex column and both cards
+ * are plain children of it — two absolutely-positioned siblings claiming
+ * `bottom-3 left-3` would simply have stacked on top of each other.
  */
 
 import { ChevronDown, ChevronUp } from "lucide-react";
@@ -43,7 +49,7 @@ export function NonPositionedPanel() {
   return (
     <div
       data-testid="non-positioned-panel"
-      className="absolute bottom-3 left-3 z-10 w-72 max-w-[80vw] overflow-hidden rounded-lg border border-border bg-card/95 shadow-md backdrop-blur-sm"
+      className="pointer-events-auto overflow-hidden rounded-lg border border-border bg-card/95 shadow-md backdrop-blur-sm"
     >
       <button
         type="button"

--- a/frontend/src/features/filters/types.ts
+++ b/frontend/src/features/filters/types.ts
@@ -10,13 +10,15 @@
  * payload until a later slice populates it (`docs/API.md` §2.7):
  * `categoryText`/`operatorText`/`operatorGroupText` match `aircraft_type`
  * / `operator` / `operator_group` (slice 024), `classifications` and
- * `missionCategories` match `classification` (slice 024), and
- * `interestingOnly` matches `interesting` (slice 038). The UI keeps them
+ * `missionCategories` match `classification` (slice 024). The UI keeps them
  * fully wired — this is plumbing, not a stub — but until that data exists,
- * a non-empty `classifications`/`missionCategories` selection or
- * `interestingOnly: true` matches nothing, by design (see
- * `lib/applyFilters.ts`'s doc comment on why "nothing" and not
- * "everything").
+ * a non-empty `classifications`/`missionCategories` selection matches
+ * nothing, by design (see `lib/applyFilters.ts`'s doc comment on why
+ * "nothing" and not "everything").
+ *
+ * `interestingOnly` was one of those and no longer is: slice 038's alert
+ * engine populates `interesting` on every live payload, so the filter now
+ * narrows the map to exactly the set `features/interesting`'s panel lists.
  */
 
 import type { LiveAircraft } from "@/lib/api/live";

--- a/frontend/src/features/interesting/InterestingPanel.test.tsx
+++ b/frontend/src/features/interesting/InterestingPanel.test.tsx
@@ -1,0 +1,243 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { resetFilteredLiveAircraftCache } from "@/features/filters/lib/filteredLiveAircraftCache";
+import { useFilterStore } from "@/features/filters/store/useFilterStore";
+import { DEFAULT_FILTERS } from "@/features/filters/types";
+import { InterestingPanel } from "@/features/interesting/InterestingPanel";
+import { useLiveAircraftStore } from "@/features/map/aircraft/store/useLiveAircraftStore";
+import type { LiveAircraft } from "@/lib/api/live";
+import { makeAircraft } from "@/test/liveAircraftFixtures";
+
+beforeEach(() => {
+  resetFilteredLiveAircraftCache();
+  useLiveAircraftStore.getState().reset();
+  useFilterStore.setState({ filters: DEFAULT_FILTERS });
+});
+
+function seed(aircraft: LiveAircraft[]) {
+  act(() => {
+    useLiveAircraftStore
+      .getState()
+      .applySnapshot({ aircraft, receiver: null }, Date.now());
+  });
+}
+
+/** The demo emergency + military scenario the slice's acceptance criterion
+ * names: a critical emergency squawk further out than a high-severity
+ * military aircraft, plus an ordinary aircraft that matches nothing. */
+function demoScenario(): LiveAircraft[] {
+  return [
+    makeAircraft({
+      icao: "aaaaaa",
+      callsign: "UAL45",
+      position: { lat: 47, lon: -122 },
+      distance_nm: 4,
+      interesting: null,
+    }),
+    makeAircraft({
+      icao: "bbbbbb",
+      callsign: "RCH492",
+      registration: "05-8153",
+      aircraft_type: "C17",
+      operator: "United States Air Force",
+      position: { lat: 47.9, lon: -122 },
+      distance_nm: 18.4,
+      altitude_ft: 24975,
+      interesting: { severity: "high", reasons: ["Rule: Military aircraft"] },
+    }),
+    makeAircraft({
+      icao: "cccccc",
+      callsign: "SWA119",
+      aircraft_type: "B738",
+      operator: "Southwest Airlines",
+      position: { lat: 48.4, lon: -122 },
+      distance_nm: 96.2,
+      altitude_ft: 8000,
+      squawk: "7700",
+      emergency: "7700",
+      interesting: {
+        severity: "critical",
+        reasons: ["Emergency squawk 7700 (general emergency)"],
+      },
+    }),
+  ];
+}
+
+function rowIcaos(): string[] {
+  return screen
+    .getAllByTestId("interesting-row")
+    .map((node) => node.getAttribute("data-icao") ?? "");
+}
+
+describe("InterestingPanel", () => {
+  it("lists only aircraft with an active match", () => {
+    seed(demoScenario());
+    render(<InterestingPanel />);
+    expect(rowIcaos()).toEqual(["cccccc", "bbbbbb"]);
+    expect(screen.queryByText("UAL45")).not.toBeInTheDocument();
+  });
+
+  it("orders by severity before distance", () => {
+    // The 96 nm emergency outranks the 18 nm military aircraft: severity is
+    // the primary key (SPEC §49), so proximity never promotes a lesser match.
+    seed(demoScenario());
+    render(<InterestingPanel />);
+    const rows = screen.getAllByTestId("interesting-row");
+    expect(rows[0]).toHaveAttribute("data-severity", "critical");
+    expect(rows[1]).toHaveAttribute("data-severity", "high");
+  });
+
+  it("orders by distance within one severity band", () => {
+    seed([
+      makeAircraft({
+        icao: "aaaaaa",
+        distance_nm: 80,
+        interesting: { severity: "high", reasons: ["Rule: Military"] },
+      }),
+      makeAircraft({
+        icao: "bbbbbb",
+        distance_nm: 6,
+        interesting: { severity: "high", reasons: ["Rule: Military"] },
+      }),
+    ]);
+    render(<InterestingPanel />);
+    expect(rowIcaos()).toEqual(["bbbbbb", "aaaaaa"]);
+  });
+
+  it("shows the §49 row fields: identity, type, operator, reason, distance and altitude", () => {
+    seed(demoScenario());
+    render(<InterestingPanel />);
+    expect(screen.getByText("RCH492")).toBeInTheDocument();
+    expect(
+      screen.getByText(/C17 · United States Air Force/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Rule: Military aircraft")).toBeInTheDocument();
+    expect(screen.getByText(/18\.4 nm/)).toBeInTheDocument();
+    expect(screen.getByText(/FL250/)).toBeInTheDocument();
+  });
+
+  it("falls back to the tail number, then the ICAO hex, for identity", () => {
+    seed([
+      makeAircraft({
+        icao: "bbbbbb",
+        callsign: null,
+        registration: "05-8153",
+        interesting: { severity: "info", reasons: ["Rule: First ever"] },
+      }),
+      makeAircraft({
+        icao: "dddddd",
+        callsign: null,
+        registration: null,
+        distance_nm: 99,
+        interesting: { severity: "info", reasons: ["Rule: First ever"] },
+      }),
+    ]);
+    render(<InterestingPanel />);
+    expect(screen.getByText("05-8153")).toBeInTheDocument();
+    expect(screen.getByText("DDDDDD")).toBeInTheDocument();
+  });
+
+  it("names every reason standing against an aircraft, not just the first", () => {
+    seed([
+      makeAircraft({
+        icao: "bbbbbb",
+        interesting: {
+          severity: "high",
+          reasons: ["Rule: Military aircraft", "Rule: Watchlist — Tankers"],
+        },
+      }),
+    ]);
+    render(<InterestingPanel />);
+    expect(
+      screen.getByText("Rule: Military aircraft · Rule: Watchlist — Tankers"),
+    ).toBeInTheDocument();
+  });
+
+  it("distinguishes severity by text, not by colour alone", () => {
+    // SPEC §80 / the slice's own acceptance criterion. The severity word is
+    // the label; the tint is decoration.
+    seed(demoScenario());
+    render(<InterestingPanel />);
+    expect(screen.getByText("Critical")).toBeInTheDocument();
+    expect(screen.getByText("High")).toBeInTheDocument();
+  });
+
+  it("selects the aircraft on click, same as a map click would", async () => {
+    seed(demoScenario());
+    render(<InterestingPanel />);
+    expect(useLiveAircraftStore.getState().selectedIcao).toBeNull();
+
+    await userEvent.click(screen.getAllByTestId("interesting-row")[0]!);
+    expect(useLiveAircraftStore.getState().selectedIcao).toBe("cccccc");
+  });
+
+  it("marks the selected row with aria-current", async () => {
+    seed(demoScenario());
+    render(<InterestingPanel />);
+    await userEvent.click(screen.getAllByTestId("interesting-row")[1]!);
+    expect(screen.getAllByTestId("interesting-row")[1]).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+  });
+
+  it("is expanded by default and collapses on click", async () => {
+    seed(demoScenario());
+    render(<InterestingPanel />);
+    expect(screen.getAllByTestId("interesting-row")).toHaveLength(2);
+
+    await userEvent.click(screen.getByRole("button", { name: /interesting/i }));
+    expect(screen.queryAllByTestId("interesting-row")).toHaveLength(0);
+  });
+
+  it("counts the matching aircraft in the header badge", () => {
+    seed(demoScenario());
+    render(<InterestingPanel />);
+    expect(screen.getByTestId("interesting-count")).toHaveTextContent("2");
+  });
+
+  it("says so plainly when nothing is matching", () => {
+    seed([makeAircraft({ icao: "aaaaaa" })]);
+    render(<InterestingPanel />);
+    expect(
+      screen.getByText("No interesting aircraft right now."),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("interesting-count")).toHaveTextContent("0");
+  });
+
+  it("keeps counting matches a filter has hidden, and says how many", () => {
+    // A filter narrows the list, never the count: an altitude band that
+    // happens to exclude a critical squawk must not make the panel look
+    // like nothing is wrong.
+    seed(demoScenario());
+    act(() => {
+      useFilterStore.setState({
+        filters: { ...DEFAULT_FILTERS, altitudeMinFt: 20000 },
+      });
+    });
+    render(<InterestingPanel />);
+    expect(screen.getByTestId("interesting-count")).toHaveTextContent("2");
+    expect(rowIcaos()).toEqual(["bbbbbb"]);
+    expect(screen.getByTestId("interesting-hidden-note")).toHaveTextContent(
+      "1 hidden by the current filters.",
+    );
+  });
+
+  it("explains an empty list that the filters emptied", () => {
+    seed(demoScenario());
+    act(() => {
+      useFilterStore.setState({
+        filters: { ...DEFAULT_FILTERS, altitudeMinFt: 40000 },
+      });
+    });
+    render(<InterestingPanel />);
+    expect(
+      screen.getByText(
+        "Every interesting aircraft is hidden by the current filters.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("interesting-count")).toHaveTextContent("2");
+  });
+});

--- a/frontend/src/features/interesting/InterestingPanel.tsx
+++ b/frontend/src/features/interesting/InterestingPanel.tsx
@@ -1,0 +1,125 @@
+/**
+ * The interesting-aircraft panel (SPEC §49, roadmap slice 039).
+ *
+ * *"Persistent or easily accessible panel listing currently interesting
+ * aircraft. Sort by severity, then distance ... Clicking selects the
+ * aircraft."* This is the persistent reading of that: the card is always on
+ * the Live Map and **expanded by default**, unlike the `NonPositionedPanel`
+ * and `ActivityPanel` it otherwise copies. A panel whose job is to draw
+ * attention to a critical squawk cannot start folded away; the count badge
+ * alone would make the user click to discover something was wrong.
+ *
+ * Where the rows come from
+ * ------------------------
+ * `useFilteredLiveAircraft` — the same `FilterResult` the map itself just
+ * drew, not a separately-computed approximation and not a second HTTP
+ * resource (`lib/ordering.ts` covers why the ordering is local). Reading the
+ * *filtered* set is a deliberate choice with a real trade-off:
+ *
+ * - **For:** every other Live Map panel does it, and a user who narrowed the
+ *   picture expects the panels beside it to agree. A panel listing aircraft
+ *   the map is not drawing is a panel whose "click to select" lands on an
+ *   invisible target.
+ * - **Against:** an unrelated filter (say an altitude band) can hide a
+ *   critical match. That is why the header keeps showing the *unfiltered*
+ *   total and says how many are hidden, rather than quietly under-reporting:
+ *   the filter narrows the list, it never silently narrows the count.
+ *
+ * The "Interesting only" filter (`features/filters`) is the inverse tool —
+ * it narrows the *map* to this panel's set — and this slice activates it, in
+ * the sense that `interesting` is now a value the backend actually populates
+ * (slice 038) rather than a permanently-`null` field the filter matched
+ * nothing against.
+ */
+
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { useState } from "react";
+
+import { useFilteredLiveAircraft } from "@/features/filters/hooks/useFilteredLiveAircraft";
+import { InterestingRow } from "@/features/interesting/components/InterestingRow";
+import { orderInterestingAircraft } from "@/features/interesting/lib/ordering";
+import { useLiveAircraftStore } from "@/features/map/aircraft/store/useLiveAircraftStore";
+
+export function InterestingPanel() {
+  const [isExpanded, setIsExpanded] = useState(true);
+  const { aircraft } = useFilteredLiveAircraft();
+  const allAircraft = useLiveAircraftStore((state) => state.aircraft);
+  const receiver = useLiveAircraftStore((state) => state.receiver);
+  const selectedIcao = useLiveAircraftStore((state) => state.selectedIcao);
+  const selectAircraft = useLiveAircraftStore((state) => state.selectAircraft);
+
+  const units = receiver?.units ?? "aviation";
+  const rows = orderInterestingAircraft(aircraft);
+
+  // The unfiltered count, so a filter that hides a match says so rather than
+  // making the panel look empty. Cheap: one pass over the live records, the
+  // same pass the filter itself already makes.
+  let total = 0;
+  for (const icao in allAircraft) {
+    if (allAircraft[icao]?.aircraft.interesting) {
+      total += 1;
+    }
+  }
+  const hidden = total - rows.length;
+
+  return (
+    <div
+      data-testid="interesting-panel"
+      className="pointer-events-auto overflow-hidden rounded-lg border border-border bg-card/95 shadow-md backdrop-blur-sm"
+    >
+      <button
+        type="button"
+        aria-expanded={isExpanded}
+        onClick={() => setIsExpanded((expanded) => !expanded)}
+        className="flex w-full items-center justify-between gap-2 px-3 py-2 text-xs font-medium"
+      >
+        <span className="flex items-center gap-1.5">
+          Interesting
+          <span
+            data-testid="interesting-count"
+            className="inline-flex min-w-4 items-center justify-center rounded-full bg-secondary px-1 text-[10px] font-semibold text-secondary-foreground"
+          >
+            {total}
+          </span>
+        </span>
+        {isExpanded ? (
+          <ChevronUp className="size-3.5" aria-hidden="true" />
+        ) : (
+          <ChevronDown className="size-3.5" aria-hidden="true" />
+        )}
+      </button>
+
+      {isExpanded && (
+        <div className="border-t border-border">
+          {rows.length === 0 ? (
+            <p className="px-3 py-2 text-xs text-muted-foreground">
+              {total === 0
+                ? "No interesting aircraft right now."
+                : "Every interesting aircraft is hidden by the current filters."}
+            </p>
+          ) : (
+            <ul className="max-h-64 overflow-y-auto">
+              {rows.map((entry) => (
+                <InterestingRow
+                  key={entry.aircraft.icao}
+                  entry={entry}
+                  units={units}
+                  selected={entry.aircraft.icao === selectedIcao}
+                  onSelect={selectAircraft}
+                />
+              ))}
+            </ul>
+          )}
+          {hidden > 0 && rows.length > 0 && (
+            <p
+              data-testid="interesting-hidden-note"
+              className="border-t border-border px-3 py-1.5 text-[11px] text-muted-foreground"
+            >
+              {hidden} hidden by the current filters.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/interesting/components/InterestingRow.tsx
+++ b/frontend/src/features/interesting/components/InterestingRow.tsx
@@ -1,0 +1,99 @@
+/**
+ * One row of the interesting-aircraft panel (SPEC §49).
+ *
+ * §49 names the row's contents exactly — *"callsign/tail; aircraft type;
+ * operator; match reason; distance; altitude"* — and clicking selects the
+ * aircraft. All six are here, each degrading to nothing rather than to a
+ * placeholder: a compact list is the wrong place to spend a line saying
+ * "Unknown" (`docs/API.md` §2.7 makes absence honest, and the detail panel
+ * one click away is where the full unknown-aware picture lives).
+ *
+ * Severity is carried by {@link AlertSeverityBadge} — the same badge the
+ * Sightings log already uses for `max_alert_severity`, so one severity
+ * vocabulary renders identically everywhere it appears. It is text-first
+ * ("Critical", not a red dot), which is what SPEC §80 requires and what the
+ * slice's "distinguishable without color alone" criterion is tested against.
+ */
+
+import { AlertSeverityBadge } from "@/features/sightings/components/AlertSeverityBadge";
+import {
+  formatAltitude,
+  formatDistance,
+} from "@/features/aircraft-detail/lib/format";
+import type { InterestingAircraft } from "@/features/interesting/lib/ordering";
+import type { UnitSystem } from "@/lib/api/config";
+import { cn } from "@/lib/utils";
+
+export interface InterestingRowProps {
+  entry: InterestingAircraft;
+  units: UnitSystem;
+  selected: boolean;
+  onSelect: (icao: string) => void;
+}
+
+/** Joins the present parts of a line, or `null` when it would be empty —
+ * so a row never renders a stray separator for a field the metadata has
+ * not resolved. */
+function join(parts: readonly (string | null)[]): string | null {
+  const present = parts.filter((part): part is string => part !== null);
+  return present.length === 0 ? null : present.join(" · ");
+}
+
+export function InterestingRow({
+  entry,
+  units,
+  selected,
+  onSelect,
+}: InterestingRowProps) {
+  const { aircraft, interesting } = entry;
+
+  // Callsign, falling back to the tail number, falling back to the ICAO hex
+  // the decoder always supplies — the same identity chain the map label uses
+  // (`features/map/labels/labelContent.ts`), so an aircraft reads the same
+  // in the panel as it does on the map beside it.
+  const identity =
+    aircraft.callsign ?? aircraft.registration ?? aircraft.icao.toUpperCase();
+
+  const airframe = join([aircraft.aircraft_type, aircraft.operator]);
+
+  // Every reason standing against this aircraft, most severe first (the
+  // engine orders them that way). Usually one; two when a second rule caught
+  // the same aircraft, which is exactly the case a single-reason row would
+  // hide.
+  const reasons = interesting.reasons.join(" · ");
+
+  const position = join([
+    formatDistance(aircraft.distance_nm, units),
+    formatAltitude(aircraft.altitude_ft, units),
+  ]);
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onSelect(aircraft.icao)}
+        aria-current={selected}
+        data-testid="interesting-row"
+        data-icao={aircraft.icao}
+        data-severity={interesting.severity}
+        className={cn(
+          "flex w-full flex-col gap-0.5 border-b border-border px-3 py-2 text-left text-xs last:border-b-0",
+          "outline-none transition-colors hover:bg-secondary focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring",
+          selected && "bg-accent/20",
+        )}
+      >
+        <span className="flex items-center gap-1.5">
+          <AlertSeverityBadge severity={interesting.severity} />
+          <span className="truncate font-medium">{identity}</span>
+        </span>
+        {airframe !== null && (
+          <span className="truncate text-muted-foreground">{airframe}</span>
+        )}
+        {reasons.length > 0 && <span className="truncate">{reasons}</span>}
+        {position !== null && (
+          <span className="text-muted-foreground">{position}</span>
+        )}
+      </button>
+    </li>
+  );
+}

--- a/frontend/src/features/interesting/lib/ordering.test.ts
+++ b/frontend/src/features/interesting/lib/ordering.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SEVERITY_RANK,
+  compareInterestingAircraft,
+  orderInterestingAircraft,
+  severityRank,
+} from "@/features/interesting/lib/ordering";
+import type { AlertSeverity } from "@/lib/api/sightings";
+import { makeAircraft } from "@/test/liveAircraftFixtures";
+
+function row(
+  icao: string,
+  severity: AlertSeverity,
+  distanceNm: number | null,
+  reasons: string[] = ["Rule: Test"],
+) {
+  return makeAircraft({
+    icao,
+    distance_nm: distanceNm,
+    interesting: { severity, reasons },
+  });
+}
+
+function icaosOf(views: ReturnType<typeof row>[]): string[] {
+  return orderInterestingAircraft(views).map((entry) => entry.aircraft.icao);
+}
+
+describe("severityRank", () => {
+  it("ranks the §2.8 ladder in ascending order of seriousness", () => {
+    expect(SEVERITY_RANK.info).toBeLessThan(SEVERITY_RANK.interesting);
+    expect(SEVERITY_RANK.interesting).toBeLessThan(SEVERITY_RANK.high);
+    expect(SEVERITY_RANK.high).toBeLessThan(SEVERITY_RANK.critical);
+  });
+
+  it("does not fall back on the string ordering the enum would give", () => {
+    // "critical" < "info" alphabetically; the whole reason the ladder is an
+    // explicit table on both sides of the wire.
+    expect(severityRank("critical")).toBeGreaterThan(severityRank("info"));
+  });
+
+  it("puts a severity this build has never heard of at the bottom", () => {
+    const unknown = "catastrophic" as AlertSeverity;
+    expect(severityRank(unknown)).toBe(0);
+  });
+});
+
+describe("orderInterestingAircraft", () => {
+  it("keeps only aircraft with an active match", () => {
+    const views = [
+      makeAircraft({ icao: "aaaaaa" }),
+      row("bbbbbb", "info", 5),
+      makeAircraft({ icao: "cccccc" }),
+    ];
+    expect(icaosOf(views)).toEqual(["bbbbbb"]);
+  });
+
+  it("returns an empty list when nothing is matching", () => {
+    expect(orderInterestingAircraft([makeAircraft()])).toEqual([]);
+  });
+
+  it("orders by severity before distance", () => {
+    // The far critical aircraft outranks the close info one: severity is the
+    // primary key, so distance never promotes a lesser match.
+    const views = [
+      row("aaaaaa", "info", 1),
+      row("bbbbbb", "critical", 400),
+      row("cccccc", "high", 200),
+      row("dddddd", "interesting", 2),
+    ];
+    expect(icaosOf(views)).toEqual(["bbbbbb", "cccccc", "dddddd", "aaaaaa"]);
+  });
+
+  it("orders by distance ascending within one severity band", () => {
+    const views = [
+      row("aaaaaa", "high", 90),
+      row("bbbbbb", "high", 3),
+      row("cccccc", "high", 41),
+    ];
+    expect(icaosOf(views)).toEqual(["bbbbbb", "cccccc", "aaaaaa"]);
+  });
+
+  it("sorts an unknown distance last within its band, not first", () => {
+    // No distance means no position. A panel that ranked the aircraft it
+    // cannot place above the one overhead would answer the wrong question,
+    // and the backend's ordering makes the same call.
+    const views = [
+      row("aaaaaa", "high", null),
+      row("bbbbbb", "high", 120),
+      row("cccccc", "high", 4),
+    ];
+    expect(icaosOf(views)).toEqual(["cccccc", "bbbbbb", "aaaaaa"]);
+  });
+
+  it("still ranks an unknown-distance critical above a close info", () => {
+    const views = [row("aaaaaa", "info", 1), row("bbbbbb", "critical", null)];
+    expect(icaosOf(views)).toEqual(["bbbbbb", "aaaaaa"]);
+  });
+
+  it("breaks an exact tie on ICAO so the order is total and stable", () => {
+    const views = [
+      row("ffffff", "info", 10),
+      row("aaaaaa", "info", 10),
+      row("cccccc", "info", 10),
+    ];
+    expect(icaosOf(views)).toEqual(["aaaaaa", "cccccc", "ffffff"]);
+  });
+
+  it("pairs each row with the match that put it there", () => {
+    const [entry] = orderInterestingAircraft([
+      row("aaaaaa", "critical", 3, [
+        "Emergency squawk 7700 (general emergency)",
+      ]),
+    ]);
+    expect(entry?.interesting.severity).toBe("critical");
+    expect(entry?.interesting.reasons).toEqual([
+      "Emergency squawk 7700 (general emergency)",
+    ]);
+    expect(entry?.aircraft.icao).toBe("aaaaaa");
+  });
+});
+
+describe("compareInterestingAircraft", () => {
+  it("is symmetric about equal entries", () => {
+    const a = {
+      aircraft: row("aaaaaa", "high", 10),
+      interesting: { severity: "high" as const, reasons: [] },
+    };
+    expect(compareInterestingAircraft(a, a)).toBe(0);
+  });
+});

--- a/frontend/src/features/interesting/lib/ordering.ts
+++ b/frontend/src/features/interesting/lib/ordering.ts
@@ -1,0 +1,119 @@
+/**
+ * Ordering for the interesting-aircraft panel (SPEC §49, roadmap slice 039).
+ *
+ * SPEC §49 asks for *"sort by severity, then distance or other useful
+ * secondary ordering"*, and `docs/API.md` §3.4 says the same thing about
+ * `GET /api/v1/aircraft/interesting`. This module is the client-side half of
+ * that one ordering, and it is deliberately **the same comparison the backend
+ * makes** in `LiveApiContext.interesting_aircraft` — severity descending,
+ * then distance ascending with the unknown-distance aircraft last, then ICAO
+ * as the deterministic tie-break.
+ *
+ * Why the panel sorts locally rather than polling `/aircraft/interesting`
+ * ------------------------------------------------------------------------
+ * The panel is fed from `useLiveAircraftStore`, the same live picture the map
+ * draws, rather than from a second HTTP resource. Two reasons, and the first
+ * is the one that matters:
+ *
+ * 1. **The panel and the map must never disagree.** A polled list would lag
+ *    the socket by up to its poll interval, so an aircraft could sit in the
+ *    panel after its alert cleared, or be emphasized on the map while absent
+ *    from the panel beside it. Deriving both from one store makes that class
+ *    of skew unrepresentable rather than merely unlikely.
+ * 2. It costs no request. `interesting` already rides every §3.3 aircraft
+ *    object in every snapshot and delta (slice 038), so the data is in the
+ *    store before a fetch could have been issued.
+ *
+ * `GET /api/v1/aircraft/interesting` keeps its own job: it is the *external*
+ * read-only answer for LAN tools that are not holding a socket open (SPEC
+ * §74). Both orderings being one comparison is what keeps those two answers
+ * the same answer, so the ordering test here pins the tie-breaks explicitly.
+ */
+
+import type { InterestingMatch, LiveAircraft } from "@/lib/api/live";
+import type { AlertSeverity } from "@/lib/api/sightings";
+
+/**
+ * `docs/API.md` §2.8's severity ladder as sortable ranks, mirroring
+ * `flightsite.alerts.vocabulary.AlertSeverity.rank`.
+ *
+ * The backend enum is a `StrEnum`, so *it* cannot be compared with `<`
+ * either — `"critical" < "info"` alphabetically — and it carries this same
+ * explicit rank table for the same reason. Keeping the two in step is why
+ * both sides spell the ladder out rather than deriving it from the string.
+ */
+export const SEVERITY_RANK: Record<AlertSeverity, number> = {
+  info: 0,
+  interesting: 1,
+  high: 2,
+  critical: 3,
+};
+
+/**
+ * The rank for a severity the wire actually carried.
+ *
+ * Falls back to the bottom of the ladder rather than to `NaN` for a value
+ * this build has never heard of: a backend that has learned a fifth severity
+ * (§6) should push an unknown aircraft to the end of the panel, not poison
+ * the comparison and scramble the whole list.
+ */
+export function severityRank(severity: AlertSeverity): number {
+  return SEVERITY_RANK[severity] ?? 0;
+}
+
+/** One row of the panel: a live aircraft and the match that put it there.
+ * Pairing them keeps `interesting` non-null in the row's own type, so no
+ * consumer re-checks what the filter already established. */
+export interface InterestingAircraft {
+  aircraft: LiveAircraft;
+  interesting: InterestingMatch;
+}
+
+/**
+ * Severity descending, then distance ascending, then ICAO.
+ *
+ * An aircraft with no `distance_nm` sorts **last within its severity band**
+ * rather than first — the backend's ordering makes the same call, and for the
+ * same reason: no distance means no position, and a panel that ranked the
+ * aircraft it cannot place above the one overhead would be answering the
+ * wrong question. ICAO last makes the order total, so a re-render with two
+ * equal-severity, equal-distance aircraft never reshuffles them.
+ */
+export function compareInterestingAircraft(
+  a: InterestingAircraft,
+  b: InterestingAircraft,
+): number {
+  const bySeverity =
+    severityRank(b.interesting.severity) - severityRank(a.interesting.severity);
+  if (bySeverity !== 0) {
+    return bySeverity;
+  }
+  const byDistance =
+    (a.aircraft.distance_nm ?? Number.POSITIVE_INFINITY) -
+    (b.aircraft.distance_nm ?? Number.POSITIVE_INFINITY);
+  if (byDistance !== 0) {
+    return byDistance;
+  }
+  return a.aircraft.icao.localeCompare(b.aircraft.icao);
+}
+
+/**
+ * The currently-interesting subset of `views`, in panel order.
+ *
+ * "Currently" is the whole contract: `interesting` is what is matching *right
+ * now* (slice 038's engine clears the block when an aircraft leaves a rule's
+ * distance window or its emergency squawk clears), so an aircraft drops out
+ * of this list the moment it stops matching. The record of what happened
+ * lives in the activity feed and the sighting's own history, not here.
+ */
+export function orderInterestingAircraft(
+  views: readonly LiveAircraft[],
+): InterestingAircraft[] {
+  const rows: InterestingAircraft[] = [];
+  for (const aircraft of views) {
+    if (aircraft.interesting !== null) {
+      rows.push({ aircraft, interesting: aircraft.interesting });
+    }
+  }
+  return rows.sort(compareInterestingAircraft);
+}

--- a/frontend/src/features/map/aircraft/aircraftLayers.test.ts
+++ b/frontend/src/features/map/aircraft/aircraftLayers.test.ts
@@ -2,6 +2,7 @@ import type { Map as MapLibreGlMap } from "maplibre-gl";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  AIRCRAFT_ATTENTION_LAYER_ID,
   AIRCRAFT_LABEL_LAYER_ID,
   AIRCRAFT_MLAT_RING_LAYER_ID,
   AIRCRAFT_SELECTED_LABEL_LAYER_ID,
@@ -40,13 +41,14 @@ beforeEach(() => {
 });
 
 describe("ensureAircraftLayers", () => {
-  it("adds both sources and all six layers", () => {
+  it("adds both sources and all seven layers", () => {
     ensureAircraftLayers(map);
     expect([...mock.sources.keys()].sort()).toEqual(
       [AIRCRAFT_SOURCE_ID, AIRCRAFT_TRACK_SOURCE_ID].sort(),
     );
     expect([...mock.layers.keys()]).toEqual([
       AIRCRAFT_TRACK_LAYER_ID,
+      AIRCRAFT_ATTENTION_LAYER_ID,
       AIRCRAFT_SELECTION_LAYER_ID,
       AIRCRAFT_MLAT_RING_LAYER_ID,
       AIRCRAFT_SYMBOL_LAYER_ID,
@@ -62,6 +64,11 @@ describe("ensureAircraftLayers", () => {
     ensureAircraftLayers(map);
     const order = [...mock.layers.keys()];
     expect(order.indexOf(AIRCRAFT_TRACK_LAYER_ID)).toBeLessThan(
+      order.indexOf(AIRCRAFT_ATTENTION_LAYER_ID),
+    );
+    // The attention ring is the outermost of the three rings, so it paints
+    // first and the selection halo stays legible on top of it.
+    expect(order.indexOf(AIRCRAFT_ATTENTION_LAYER_ID)).toBeLessThan(
       order.indexOf(AIRCRAFT_SELECTION_LAYER_ID),
     );
     expect(order.indexOf(AIRCRAFT_MLAT_RING_LAYER_ID)).toBeLessThan(
@@ -79,7 +86,7 @@ describe("ensureAircraftLayers", () => {
     ensureAircraftLayers(map);
     const first = mock.layers.get(AIRCRAFT_SYMBOL_LAYER_ID);
     ensureAircraftLayers(map);
-    expect(mock.layers.size).toBe(6);
+    expect(mock.layers.size).toBe(7);
     expect(mock.layers.get(AIRCRAFT_SYMBOL_LAYER_ID)).toBe(first);
   });
 
@@ -93,6 +100,83 @@ describe("ensureAircraftLayers", () => {
       const options = call[1] as Record<string, unknown> | undefined;
       expect(options?.cluster).toBeUndefined();
     }
+  });
+
+  it("draws the attention ring only for aircraft with an active match", () => {
+    ensureAircraftLayers(map);
+    expect(mock.layers.get(AIRCRAFT_ATTENTION_LAYER_ID)?.filter).toEqual([
+      "!=",
+      ["get", "severity"],
+      "",
+    ]);
+  });
+
+  it("encodes severity in ring geometry, not colour alone", () => {
+    // SPEC §36: "never rely exclusively on color to communicate
+    // classification or severity". Radius and stroke width must both step
+    // monotonically with severity, so the ladder survives a viewer who
+    // cannot separate amber from red.
+    ensureAircraftLayers(map);
+    const paint = mock.layers.get(AIRCRAFT_ATTENTION_LAYER_ID)?.paint as Record<
+      string,
+      unknown
+    >;
+
+    const pick = (expression: unknown[], severity: string): number => {
+      const index = expression.indexOf(severity);
+      return index === -1
+        ? (expression.at(-1) as number)
+        : (expression[index + 1] as number);
+    };
+
+    const width = paint["circle-stroke-width"] as unknown[];
+    expect(pick(width, "info")).toBeLessThan(pick(width, "interesting"));
+    expect(pick(width, "interesting")).toBeLessThan(pick(width, "high"));
+    expect(pick(width, "high")).toBeLessThan(pick(width, "critical"));
+
+    // The radius folds severity into each zoom stop's output — the same
+    // shape ICON_SIZE uses, because `["zoom"]` must stay the direct input
+    // of the top-level interpolate or style validation fails silently.
+    const radius = paint["circle-radius"] as unknown[];
+    expect(radius[0]).toBe("interpolate");
+    expect(radius[2]).toEqual(["zoom"]);
+
+    // Read the selection halo's own radius rather than restating its
+    // numbers, so this stays true if that layer is ever retuned.
+    const halo = (
+      mock.layers.get(AIRCRAFT_SELECTION_LAYER_ID)?.paint as Record<
+        string,
+        unknown
+      >
+    )["circle-radius"] as unknown[];
+
+    for (const [stopIndex, haloIndex] of [
+      [4, 4],
+      [6, 6],
+    ]) {
+      const stop = radius[stopIndex!] as unknown[];
+      expect(stop[0]).toBe("match");
+      expect(pick(stop, "info")).toBeLessThan(pick(stop, "interesting"));
+      expect(pick(stop, "interesting")).toBeLessThan(pick(stop, "high"));
+      expect(pick(stop, "high")).toBeLessThan(pick(stop, "critical"));
+      // Outside the selection halo at the same zoom, so a selected alerting
+      // aircraft shows both rings rather than one swallowing the other.
+      expect(pick(stop, "info")).toBeGreaterThan(halo[haloIndex!] as number);
+    }
+  });
+
+  it("fades the attention ring with the feature's own opacity", () => {
+    // A stale or ground-dimmed aircraft's ring must fade exactly as its icon
+    // does, rather than staying at full strength over a ghost.
+    ensureAircraftLayers(map);
+    const paint = mock.layers.get(AIRCRAFT_ATTENTION_LAYER_ID)?.paint as Record<
+      string,
+      unknown
+    >;
+    expect(paint["circle-stroke-opacity"]).toEqual(["get", "opacity"]);
+    const fill = paint["circle-opacity"] as unknown[];
+    expect(fill[0]).toBe("*");
+    expect(fill[1]).toEqual(["get", "opacity"]);
   });
 
   it("filters the non-selected label layer to non-empty, non-selected labels", () => {

--- a/frontend/src/features/map/aircraft/aircraftLayers.ts
+++ b/frontend/src/features/map/aircraft/aircraftLayers.ts
@@ -7,19 +7,24 @@
  * 500-aircraft target unreachable; `setData` on an existing source is the one
  * cheap update path MapLibre offers.
  *
- * Six layers, bottom to top:
+ * Seven layers, bottom to top:
  *
  * 1. the selected aircraft's track polyline;
- * 2. the selection halo — a ring under the selected icon (SPEC §36 "strong
+ * 2. the attention ring — a severity-scaled ring under any aircraft with an
+ *    active alert match (SPEC §36 "interesting/alerting: distinct attention
+ *    styling", roadmap slice 039). Outermost of the three rings, so an
+ *    aircraft that is selected, multilaterated *and* alerting shows all
+ *    three nested rather than one hiding another;
+ * 3. the selection halo — a ring under the selected icon (SPEC §36 "strong
  *    selection highlight");
- * 3. the MLAT ring — a *dashed* ring under multilaterated positions, so the
+ * 4. the MLAT ring — a *dashed* ring under multilaterated positions, so the
  *    position source is distinguishable without relying on colour (SPEC §36);
- * 4. the aircraft symbols themselves, rotated to `track_deg`;
- * 5. non-selected aircraft labels — `text-allow-overlap: false`, so
+ * 5. the aircraft symbols themselves, rotated to `track_deg`;
+ * 6. non-selected aircraft labels — `text-allow-overlap: false`, so
  *    MapLibre's own collision system hides whichever labels lose the
  *    `symbol-sort-key` contest (roadmap slice 015: "MapLibre's own collision
  *    system plus zoom/density-driven tiering");
- * 6. the selected aircraft's label — its own layer because
+ * 7. the selected aircraft's label — its own layer because
  *    `text-allow-overlap`/`text-ignore-placement` are layer-level, not
  *    data-driven, and the selected label must never be the one collision
  *    hides (roadmap slice 015 acceptance criterion: "selected aircraft
@@ -51,6 +56,7 @@ import {
 export const AIRCRAFT_SOURCE_ID = "flightsite-aircraft";
 export const AIRCRAFT_TRACK_SOURCE_ID = "flightsite-aircraft-track";
 export const AIRCRAFT_TRACK_LAYER_ID = "flightsite-aircraft-track-line";
+export const AIRCRAFT_ATTENTION_LAYER_ID = "flightsite-aircraft-attention";
 export const AIRCRAFT_SELECTION_LAYER_ID = "flightsite-aircraft-selection";
 export const AIRCRAFT_MLAT_RING_LAYER_ID = "flightsite-aircraft-mlat-ring";
 export const AIRCRAFT_SYMBOL_LAYER_ID = "flightsite-aircraft-symbols";
@@ -72,6 +78,107 @@ const SELECTION_COLOR = "#8ab4ff";
 const LABEL_TEXT_COLOR = "#f2f6ff";
 const LABEL_HALO_COLOR = "#0b1220";
 const LABEL_HALO_WIDTH = 1.2;
+
+/**
+ * The attention ring's severity palette (SPEC §36 "interesting/alerting:
+ * distinct attention styling", `docs/API.md` §2.8's ladder).
+ *
+ * Fixed rather than theme-driven, like `SELECTION_COLOR` and the range
+ * rings: it must read identically on the dark aviation basemap, the light
+ * one, and OSM raster imagery. Warm and escalating, and deliberately clear
+ * of the selection blue so "selected" and "alerting" never read as the same
+ * state on an aircraft that is both.
+ *
+ * **Colour is the redundant channel here, not the message.** SPEC §36 ends
+ * *"never rely exclusively on color to communicate classification or
+ * severity"*, so severity is carried first by geometry: {@link
+ * ATTENTION_RADIUS} and {@link ATTENTION_STROKE_WIDTH} both step
+ * monotonically with it, so a larger, heavier ring means a more serious
+ * match whether or not the viewer can separate amber from red. The panel
+ * (`features/interesting`) states the severity in words on top of that.
+ */
+const ATTENTION_COLOR: ExpressionSpecification = [
+  "match",
+  ["get", "severity"],
+  "critical",
+  "#ff5470",
+  "high",
+  "#f2803c",
+  "interesting",
+  "#f2b544",
+  "#9aa7bd",
+];
+
+/** Ring radius by severity, per zoom stop. Every value sits outside the
+ * selection halo's 14→22, so an aircraft that is both selected and alerting
+ * shows both rings nested rather than one swallowing the other.
+ *
+ * Folded into each zoom stop's *output* for the same reason `ICON_SIZE` is:
+ * `["zoom"]` must be the direct input of a top-level `interpolate`, and
+ * multiplying a zoom interpolation by a separate severity expression fails
+ * style validation silently. */
+const ATTENTION_RADIUS: ExpressionSpecification = [
+  "interpolate",
+  ["linear"],
+  ["zoom"],
+  3,
+  [
+    "match",
+    ["get", "severity"],
+    "critical",
+    23,
+    "high",
+    21,
+    "interesting",
+    19,
+    17,
+  ],
+  11,
+  [
+    "match",
+    ["get", "severity"],
+    "critical",
+    35,
+    "high",
+    32,
+    "interesting",
+    29,
+    26,
+  ],
+];
+
+/** Ring weight by severity — the second non-colour channel. */
+const ATTENTION_STROKE_WIDTH: ExpressionSpecification = [
+  "match",
+  ["get", "severity"],
+  "critical",
+  3.5,
+  "high",
+  2.75,
+  "interesting",
+  2,
+  1.5,
+];
+
+/** Fill strength by severity, multiplied by the feature's own opacity so a
+ * stale or ground-dimmed alerting aircraft's ring fades exactly as its icon
+ * does. Kept low throughout: at these radii the fill is a wash behind the
+ * silhouette, and the stroke is what the eye actually catches. */
+const ATTENTION_FILL_OPACITY: ExpressionSpecification = [
+  "*",
+  ["get", "opacity"],
+  [
+    "match",
+    ["get", "severity"],
+    "critical",
+    0.16,
+    "high",
+    0.1,
+    "interesting",
+    0.07,
+    0.04,
+  ],
+];
 
 const EMPTY: FeatureCollection<Geometry> = {
   type: "FeatureCollection",
@@ -143,6 +250,26 @@ export function ensureAircraftLayers(map: MapLibreGlMap): void {
         "line-color": SELECTION_COLOR,
         "line-width": 2,
         "line-opacity": 0.8,
+      },
+    });
+  }
+
+  if (!map.getLayer(AIRCRAFT_ATTENTION_LAYER_ID)) {
+    map.addLayer({
+      id: AIRCRAFT_ATTENTION_LAYER_ID,
+      type: "circle",
+      source: AIRCRAFT_SOURCE_ID,
+      // `severity` is `""` for everything that is not currently matching,
+      // which is most of the sky — so this layer draws nothing at all on a
+      // quiet picture rather than drawing 500 invisible circles.
+      filter: ["!=", ["get", "severity"], ""],
+      paint: {
+        "circle-radius": ATTENTION_RADIUS,
+        "circle-color": ATTENTION_COLOR,
+        "circle-opacity": ATTENTION_FILL_OPACITY,
+        "circle-stroke-color": ATTENTION_COLOR,
+        "circle-stroke-width": ATTENTION_STROKE_WIDTH,
+        "circle-stroke-opacity": ["get", "opacity"],
       },
     });
   }

--- a/frontend/src/features/map/aircraft/geojson.test.ts
+++ b/frontend/src/features/map/aircraft/geojson.test.ts
@@ -265,6 +265,30 @@ describe("buildAircraftFeatureCollection", () => {
       expect(properties.bbbbbb?.interesting).toBe(true);
     });
 
+    it("carries the match severity for the attention ring, empty when nothing matches", () => {
+      const collection = buildAircraftFeatureCollection(
+        input({
+          aircraft: records(
+            { icao: "aaaaaa", interesting: null },
+            {
+              icao: "bbbbbb",
+              interesting: {
+                severity: "critical",
+                reasons: ["Emergency squawk 7700 (general emergency)"],
+              },
+            },
+          ),
+          zoom: ZOOM_LABELS_FULL,
+        }),
+      );
+      const properties = propertiesByIcao(collection);
+      // `""` rather than null: the ring layer filters on `!= ""`, and a
+      // primitive keeps the style expression a comparison rather than a
+      // presence test.
+      expect(properties.aaaaaa?.severity).toBe("");
+      expect(properties.bbbbbb?.severity).toBe("critical");
+    });
+
     it("shows no label below the minimum labeling zoom", () => {
       const collection = buildAircraftFeatureCollection(
         input({
@@ -388,6 +412,7 @@ describe("buildAircraftFeatureCollection", () => {
                 icao: "aaaaaa",
                 position: { lat: 1, lon: 2 },
                 callsign: "BAW123",
+                interesting: { severity: "critical", reasons: ["test"] },
               }),
               removedAt: NOW - 100,
             },
@@ -396,7 +421,11 @@ describe("buildAircraftFeatureCollection", () => {
         }),
       );
       expect(collection.features[0]?.properties.label).toBe("");
+      // Neither the label indicator nor the attention ring survives
+      // departure: "interesting" is a claim about what is matching *now*,
+      // and the server has said this aircraft is gone.
       expect(collection.features[0]?.properties.interesting).toBe(false);
+      expect(collection.features[0]?.properties.severity).toBe("");
     });
   });
 });

--- a/frontend/src/features/map/aircraft/geojson.ts
+++ b/frontend/src/features/map/aircraft/geojson.ts
@@ -66,11 +66,22 @@ export interface AircraftFeatureProperties {
   mlat: boolean;
   selected: boolean;
   onGround: boolean;
-  /** True when the aircraft carries an active alert match (slice 038).
-   * Always `false` today — `interesting` is `null` on every live payload
-   * this slice can receive — but the label priority tiering and the
-   * indicator glyph are both wired to it now. */
+  /** True when the aircraft carries an active alert match (slice 038,
+   * populated on the wire since that slice landed). Drives the label
+   * priority tiering and the indicator glyph. */
   interesting: boolean;
+  /** The active match's severity (`docs/API.md` §2.8), or `""` when nothing
+   * is matching — the attention ring's style expressions read this.
+   *
+   * A string rather than a rank number because the layer expressions
+   * `match` on it and read far better for it, and `""` rather than `null`
+   * because MapLibre feature properties are compared, not narrowed: the
+   * ring layer's filter is `["!=", ["get", "severity"], ""]`, and a `null`
+   * property would have to be tested with `has`/`!has` instead. Severity
+   * *ordering* is never asked of a style expression — that is
+   * `features/interesting/lib/ordering.ts`'s job, in TypeScript, where the
+   * ladder is a table rather than a string comparison. */
+  severity: string;
   /** Newline-delimited label text, already tiered for the current
    * zoom/density (`@/features/map/labels`) and empty when nothing should
    * render — the style layers filter on that rather than testing for an
@@ -179,6 +190,7 @@ export function buildAircraftFeatureCollection(
         selected,
         onGround: view.on_ground === true,
         interesting,
+        severity: view.interesting?.severity ?? "",
         label: renderLabelText(buildAircraftLabelLines(view), tier),
       }),
     );
@@ -210,8 +222,12 @@ export function buildAircraftFeatureCollection(
         onGround: view.on_ground === true,
         // Fading out rather than a live part of the picture: a departing
         // aircraft never carries a label, selected or not (it cannot be
-        // selected — `selectAircraft` only ever targets `aircraft`).
+        // selected — `selectAircraft` only ever targets `aircraft`), and it
+        // never carries the attention ring either. "Interesting" is a
+        // statement about what is matching *now*, and an aircraft the server
+        // has said is gone is not matching anything.
         interesting: false,
+        severity: "",
         label: "",
       }),
     );

--- a/frontend/src/features/map/labels/labelContent.ts
+++ b/frontend/src/features/map/labels/labelContent.ts
@@ -5,11 +5,9 @@
  *
  * 1. **Identity** — callsign, falling back to registration (slice 024),
  *    falling back to the upper-cased ICAO hex the decoder always supplies.
- *    Prefixed with the interesting-match indicator once slice 038 starts
- *    populating `interesting` — the field is present and `null` on every
- *    payload this slice can receive (`docs/API.md` §2.7: `null` is the
- *    honest representation of "unknown", not an absent key), so the
- *    indicator never actually renders yet, but the slot is wired now.
+ *    Prefixed with the interesting-match indicator whenever the aircraft
+ *    carries an active match — slice 038 populates `interesting`, and slice
+ *    039 is where the indicator starts appearing on real aircraft.
  * 2. **Operator** — renders only when the metadata field is non-null.
  *    Always null until slice 024 supplies it.
  * 3. **Altitude** — flight level above the ~FL180 transition altitude, feet
@@ -25,10 +23,19 @@
 import type { LabelTier } from "@/features/map/labels/priority";
 import type { LiveAircraft } from "@/lib/api/live";
 
-/** Prefixed onto line 1 once an aircraft carries an active interesting
+/** Prefixed onto line 1 when an aircraft carries an active interesting
  * match. A glyph reads as "notable" without relying on colour alone,
  * consistent with the MLAT ring's dash-pattern-over-colour approach
- * (`icons/silhouettes.ts`). */
+ * (`icons/silhouettes.ts`).
+ *
+ * One glyph for every severity, deliberately. SPEC §35 asks the label for an
+ * *"interesting-status indicator"* — presence, not rank — and the label is
+ * the one surface here whose glyphs come from the basemap style's SDF font
+ * atlas rather than the UI font, so a four-glyph ladder would be four
+ * chances to render a tofu box on some basemap. Severity is carried where it
+ * can be carried reliably: the attention ring's radius and stroke width on
+ * the map (`aircraft/aircraftLayers.ts`), and the severity word itself in
+ * the interesting panel and the detail view. */
 export const INTERESTING_INDICATOR = "★";
 
 /** The altitude at and above which the label switches from feet to flight

--- a/frontend/src/lib/api/activity.ts
+++ b/frontend/src/lib/api/activity.ts
@@ -27,11 +27,11 @@ import type { AlertSeverity } from "@/lib/api/sightings";
 /**
  * §3.9 / SPEC §55's event vocabulary.
  *
- * `alert_triggered` and `emergency_squawk` are in the published schema but no
- * backend producer emits them until phase 6 (roadmap slice 039). They are
- * typed here anyway so the feed already has a label and an icon for them the
- * day they start arriving — the alternative is a released client that renders
- * a blank row for a real event.
+ * `alert_triggered` and `emergency_squawk` arrive from slice 038's alert
+ * engine, which emits one event per match it actually recorded — the two are
+ * separate types because SPEC §47 wants an emergency squawk prominent rather
+ * than one entry among the alerts, and a feed filtered to `emergency_squawk`
+ * is a question users genuinely ask.
  */
 export type ActivityEventType =
   | "alert_triggered"

--- a/frontend/src/pages/LiveMapPage.tsx
+++ b/frontend/src/pages/LiveMapPage.tsx
@@ -6,6 +6,7 @@ import { FilterDrawer } from "@/features/filters/components/FilterDrawer";
 import { NonPositionedPanel } from "@/features/filters/components/NonPositionedPanel";
 import { QuickFilterChips } from "@/features/filters/components/QuickFilterChips";
 import { useFilterUrlSync } from "@/features/filters/hooks/useFilterUrlSync";
+import { InterestingPanel } from "@/features/interesting/InterestingPanel";
 import { AircraftLayer } from "@/features/map/aircraft/AircraftLayer";
 import { BasemapSwitcher } from "@/features/map/BasemapSwitcher";
 import { getBasemapById, getDefaultBasemap } from "@/features/map/basemaps";
@@ -26,9 +27,11 @@ const item = requireNavItem("/");
  * the display-radius cap indicator — slice 017), all of which read and
  * write the same filtered set via `features/filters`, the activity feed
  * panel (slice 035), which is the one floating control fed by the socket's
- * `activity` frames rather than by the live picture, and the "Today at a
+ * `activity` frames rather than by the live picture, the "Today at a
  * glance" card (slice 036), a top-center strip fed by the analytics summary
- * endpoint rather than by anything the live picture or the feed carry.
+ * endpoint rather than by anything the live picture or the feed carry, and
+ * the interesting-aircraft panel (slice 039, SPEC §49), which shares the
+ * bottom-left column with the non-positioned list.
  *
  * The map configuration — including the display-radius default the
  * distance-cap filter falls back to — comes from `useMapConfigStore`, which
@@ -57,7 +60,15 @@ export function LiveMapPage() {
       <LayersControl />
       <QuickFilterChips />
       <FilterDrawer />
-      <NonPositionedPanel />
+      {/* The bottom-left corner, as one upward-growing column: the two
+       * aircraft-list cards share it rather than each claiming the same
+       * absolute slot. `pointer-events-none` on the column keeps the gap
+       * between the cards click-through to the map; each card turns
+       * pointer events back on for itself. */}
+      <div className="pointer-events-none absolute bottom-3 left-3 z-10 flex max-h-[calc(100%-1.5rem)] w-72 max-w-[80vw] flex-col gap-2">
+        <InterestingPanel />
+        <NonPositionedPanel />
+      </div>
       <ActivityPanel />
       <TodayPanel />
       <DisplayRadiusIndicator />

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1030,7 +1030,7 @@ slices:
     title: "Interesting aircraft surfaces"
     phase: 6
     branch: "039-interesting-panel"
-    status: planned
+    status: merged
     depends_on: ["038", "014", "035"]
     objective: "Surface interesting aircraft: panel, map emphasis, label indicator, and feed integration."
     scope:


### PR DESCRIPTION
## Slice 039 — Interesting aircraft surfaces

Frontend-only slice (038 had already delivered the feed-integration bullet: `interesting` block in aircraft payloads, `GET /api/v1/aircraft/interesting`, activity events):

- `features/interesting/`: SPEC §49 panel on the Live Map — severity→distance→ICAO ordering mirroring the API exactly, all six named fields, click-to-select
- Map: seventh aircraft layer, a severity-scaled attention ring (radius and stroke width step monotonically — severity is never color-only); paint expressions hand-validated against the real MapLibre style spec
- Label indicator (single ★ glyph per SPEC §35 — presence, not rank, to avoid SDF-atlas tofu)
- Aircraft detail: severity + all match reasons; activity feed rows render the engine's reason, squawk in the headline per SPEC §47
- Panel derives from the live store (not polling) so panel and map can never disagree; header badge counts unfiltered matches with a 'hidden by filters' note
- Layout: LiveMapPage owns the bottom-left corner as one flex column (NonPositionedPanel no longer self-positions)

Verification: frontend lint/typecheck/format clean, 1333 tests passed; backend untouched behaviorally — ruff/mypy clean, full suite 3668 passed, coverage 99.37%.

Note for history: the roadmap's 039 'feed integration' bullet was implemented ahead of schedule inside slice 038.

🤖 Generated with [Claude Code](https://claude.com/claude-code)