### PR TITLE
feat: alerts page & rule builder (slice 041)

### DIFF
--- a/backend/src/flightsite/alerts/__init__.py
+++ b/backend/src/flightsite/alerts/__init__.py
@@ -47,6 +47,8 @@ from flightsite.alerts.errors import (
     AlertError,
     AlertRuleNotFoundError,
     AlertRuleValueError,
+    AlertTemplateConflictError,
+    AlertTemplateNotFoundError,
 )
 from flightsite.alerts.evaluator import evaluate, matches
 from flightsite.alerts.model import (
@@ -100,6 +102,8 @@ __all__ = [
     "AlertSeverity",
     "AlertSubject",
     "AlertTemplate",
+    "AlertTemplateConflictError",
+    "AlertTemplateNotFoundError",
     "ClassificationCondition",
     "CompiledRule",
     "CycleResult",

--- a/backend/src/flightsite/alerts/errors.py
+++ b/backend/src/flightsite/alerts/errors.py
@@ -21,4 +21,26 @@ class AlertRuleValueError(AlertError):
     """Raised when a rule's name, severity or condition set fails validation."""
 
 
-__all__ = ["AlertError", "AlertRuleNotFoundError", "AlertRuleValueError"]
+class AlertTemplateNotFoundError(AlertError):
+    """Raised for an operation naming a template key this build does not ship."""
+
+
+class AlertTemplateConflictError(AlertError):
+    """Raised when a shipped template has no rule left to create.
+
+    Two states reach it, and they are one error rather than two because the
+    answer a caller can act on is identical: *there is nothing here to
+    instantiate.* A built-in template (SPEC §47's emergency squawks) never had
+    a rule to create, and an already-instantiated one no longer does. The
+    template gallery renders both as "already on", which is what a user needs
+    to read either way.
+    """
+
+
+__all__ = [
+    "AlertError",
+    "AlertRuleNotFoundError",
+    "AlertRuleValueError",
+    "AlertTemplateConflictError",
+    "AlertTemplateNotFoundError",
+]

--- a/backend/src/flightsite/alerts/service.py
+++ b/backend/src/flightsite/alerts/service.py
@@ -48,10 +48,16 @@ from collections.abc import Callable, Sequence
 import structlog
 
 from flightsite.alerts.engine import AlertEngine
-from flightsite.alerts.errors import AlertRuleNotFoundError, AlertRuleValueError
+from flightsite.alerts.errors import (
+    AlertRuleNotFoundError,
+    AlertRuleValueError,
+    AlertTemplateConflictError,
+    AlertTemplateNotFoundError,
+)
 from flightsite.alerts.model import AlertRuleRecord, CompiledRule, RuleConditions
 from flightsite.alerts.repository import AlertRepository
 from flightsite.alerts.templates import (
+    TEMPLATES_BY_KEY,
     AlertTemplate,
     enabled_templates,
     unknown_template_keys,
@@ -288,6 +294,56 @@ class AlertService:
             now_ms=self._clock(),
         )
         await self.reload_rules()
+        return record
+
+    async def instantiate_template(self, key: str) -> AlertRuleRecord:
+        """Create the rule a shipped template describes, keeping its provenance.
+
+        The gallery's counterpart to start-up instantiation, and the reason it
+        is a separate method rather than a ``template_key`` argument on
+        :meth:`create_rule`: provenance is a statement about where a rule came
+        from, so it is set by the operation that *is* "instantiate this
+        template" and can never be asserted by a client posting an arbitrary
+        body. :func:`update_alert_rule` already refuses to replace it for the
+        same reason.
+
+        The conditions and severity come from the catalogue rather than from
+        the caller. A user who wants different thresholds edits the rule
+        afterwards — which is SPEC §45's "enable, then customize", and it keeps
+        the rule honest about having started as the shipped template.
+
+        Refusing a second instantiation is what lets the gallery show one
+        truthful state per template. Start-up instantiation's "no template row
+        at all" guard cannot serve here: it exists so a *deleted* shipped rule
+        stays deleted across restarts, and applying it to an explicit per-key
+        request would refuse every template the moment any one of them existed.
+
+        Raises:
+            AlertTemplateNotFoundError: this build ships no such template.
+            AlertTemplateConflictError: the template is built in, or a rule
+                already carries its provenance.
+        """
+        template = TEMPLATES_BY_KEY.get(key)
+        if template is None:
+            raise AlertTemplateNotFoundError(f"no alert template with key {key!r}")
+        conditions = template.conditions
+        if not template.instantiable or conditions is None:
+            raise AlertTemplateConflictError(
+                f"template {key!r} is built in and always on: it has no rule to create"
+            )
+        if any(rule.template_key == key for rule in await self._repository.list_rules()):
+            raise AlertTemplateConflictError(f"template {key!r} already has a rule")
+        record = await self._repository.create_rule(
+            name=template.name,
+            description=template.description,
+            severity=template.severity,
+            conditions=conditions,
+            enabled=True,
+            template_key=key,
+            now_ms=self._clock(),
+        )
+        await self.reload_rules()
+        logger.info("alert_template_instantiated", key=key, rule_id=record.id)
         return record
 
     async def update_rule(

--- a/backend/src/flightsite/api/alert_rules.py
+++ b/backend/src/flightsite/api/alert_rules.py
@@ -50,6 +50,8 @@ from flightsite.alerts import (
     AlertRuleWriteRequest,
     AlertService,
     AlertTemplate,
+    AlertTemplateConflictError,
+    AlertTemplateNotFoundError,
 )
 from flightsite.api.serializers import iso_utc
 from flightsite.db import from_epoch_ms
@@ -117,6 +119,33 @@ async def list_alert_templates() -> dict[str, Any]:
     below, where a shipped rule carries its ``template_key``.
     """
     return {"templates": [_template_payload(template) for template in SHIPPED_TEMPLATES]}
+
+
+@router.post("/alert-templates/{key}/rules", status_code=status.HTTP_201_CREATED)
+async def instantiate_alert_template(request: Request, key: str) -> dict[str, Any]:
+    """Turn one shipped template into a rule (SPEC §45, slice 041's gallery).
+
+    A ``POST`` to the template's *rules* collection rather than to the template
+    itself, because what this creates is a rule — the response is the same rule
+    payload the list returns, carrying ``template_key`` so provenance is
+    readable from the moment it exists.
+
+    The body is empty on purpose: everything the rule says comes from the
+    catalogue. Letting a client supply conditions here would be
+    ``POST /alert-rules`` with a provenance claim attached, which is the one
+    thing provenance must not be.
+
+    Statuses: ``404`` for a key this build does not ship, and ``409`` when the
+    template has no rule left to create — either because it is built in and
+    always on (SPEC §47) or because one already exists.
+    """
+    try:
+        record = await _service(request).instantiate_template(key)
+    except AlertTemplateNotFoundError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except AlertTemplateConflictError as exc:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    return _rule_payload(record)
 
 
 @router.get("/alert-rules")

--- a/backend/tests/api/test_alerts_api.py
+++ b/backend/tests/api/test_alerts_api.py
@@ -217,6 +217,149 @@ def test_an_instantiated_rule_is_in_force_for_the_next_live_read(
     assert client.get(INTERESTING_PATH).status_code == 200
 
 
+# ------------------------------------------------------- rule-builder round trip
+
+
+#: The condition documents slice 041's visual rule builder composes, one per
+#: kind it offers, exactly as ``conditionsToDocument`` emits them —
+#: ``frontend/src/features/alerts/lib/conditions.ts``, whose own tests pin the
+#: same shapes from the other side. Together the two halves are the contract
+#: the roadmap states as "rules created in the UI evaluate identically to
+#: API-created rules": the builder sends only these, and this file is where
+#: they are proved to be documents the engine accepts unchanged.
+BUILDER_CONDITION_BODIES: list[dict[str, Any]] = [
+    {
+        "version": 1,
+        "classification": {"military": True, "government": False, "law_enforcement": False},
+    },
+    {
+        "version": 1,
+        "classification": {
+            "military": False,
+            "government": False,
+            "law_enforcement": True,
+            "mission": "medical",
+        },
+    },
+    {"version": 1, "type_code": "C17"},
+    {"version": 1, "model": "Globemaster"},
+    {"version": 1, "watchlist_id": 1},
+    {"version": 1, "watchlist_any": True},
+    {"version": 1, "rare_aircraft": {"max_sightings": 2}},
+    {"version": 1, "rare_type": {"max_sightings": 4}},
+    {"version": 1, "min_distance_nm": 5, "max_distance_nm": 40},
+    {"version": 1, "max_distance_nm": 40},
+    {"version": 1, "min_alt_ft": 500, "max_alt_ft": 10000},
+    {"version": 1, "max_alt_ft": 5000, "applies_on_ground": True},
+    {
+        "version": 1,
+        "classification": {"military": True, "government": False, "law_enforcement": False},
+        "max_alt_ft": 5000,
+        "max_distance_nm": 40,
+        "applies_on_ground": True,
+    },
+]
+
+
+@pytest.mark.parametrize("conditions", BUILDER_CONDITION_BODIES)
+def test_a_document_the_rule_builder_composes_is_accepted_unchanged(
+    client: TestClient, conditions: dict[str, Any]
+) -> None:
+    """Every condition the builder can emit survives the round trip intact.
+
+    Not merely "is accepted": each key the builder sent must come back
+    carrying the value it sent, because a document quietly normalized on the
+    way in would be a rule that does something other than what the user built.
+    """
+    created = _create(
+        client,
+        {
+            "name": "Built in the UI",
+            "description": None,
+            "severity": "interesting",
+            "conditions": conditions,
+        },
+    )
+
+    echoed = created["conditions"]
+    for key, value in conditions.items():
+        assert echoed[key] == value, key
+    assert created["describes"] != []
+
+
+@pytest.mark.parametrize("conditions", BUILDER_CONDITION_BODIES)
+def test_replaying_what_the_api_echoed_changes_nothing(
+    client: TestClient, conditions: dict[str, Any]
+) -> None:
+    """Editing one field of a rule cannot silently reword the others.
+
+    The builder loads a rule by parsing the *echoed* document back into its
+    drafts and sends whatever those drafts compose. So the echo has to be a
+    fixed point: send it back unchanged and the stored rule, and the prose it
+    describes itself with, must be identical.
+    """
+    created = _create(
+        client,
+        {
+            "name": "Built in the UI",
+            "description": None,
+            "severity": "interesting",
+            "conditions": conditions,
+        },
+    )
+
+    response = client.put(
+        f"{RULES_PATH}/{created['id']}",
+        json={
+            "name": "Built in the UI",
+            "description": None,
+            "severity": "interesting",
+            "conditions": created["conditions"],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["conditions"] == created["conditions"]
+    assert response.json()["describes"] == created["describes"]
+
+
+def test_the_builder_cannot_compose_a_rule_the_api_refuses(client: TestClient) -> None:
+    """The two validators agree on the cases the builder guards locally.
+
+    Each of these is a rule that could never match anything, which the
+    builder refuses to submit — this pins that the backend refuses it too, so
+    the local check is a saved round trip rather than the only thing standing
+    between a user and a rule that silently does nothing.
+    """
+    never_matching: list[dict[str, Any]] = [
+        {"version": 1},
+        {"version": 1, "applies_on_ground": True},
+        {"version": 1, "min_distance_nm": 40, "max_distance_nm": 10},
+        {"version": 1, "min_alt_ft": 10000, "max_alt_ft": 500},
+        {"version": 1, "rare_aircraft": {"max_sightings": 0}},
+        {
+            "version": 1,
+            "classification": {
+                "military": False,
+                "government": False,
+                "law_enforcement": False,
+            },
+        },
+    ]
+
+    for conditions in never_matching:
+        response = client.post(
+            RULES_PATH,
+            json={
+                "name": "Never matches",
+                "description": None,
+                "severity": "info",
+                "conditions": conditions,
+            },
+        )
+        assert response.status_code == 422, conditions
+
+
 # ------------------------------------------------------------------ rule CRUD
 
 

--- a/backend/tests/api/test_alerts_api.py
+++ b/backend/tests/api/test_alerts_api.py
@@ -101,6 +101,122 @@ def test_every_other_template_reports_the_conditions_it_would_create(
             assert template["conditions"]["version"] == 1
 
 
+# ------------------------------------------------------- template instantiation
+
+
+def test_instantiating_a_template_creates_a_rule_carrying_its_provenance(
+    client: TestClient,
+) -> None:
+    response = client.post(f"{TEMPLATES_PATH}/military/rules")
+
+    assert response.status_code == 201, response.text
+    rule = response.json()
+    assert rule["template_key"] == "military"
+    assert rule["name"] == "Military aircraft"
+    assert rule["severity"] == "high"
+    assert rule["enabled"] is True
+    assert rule["describes"] == ["military"]
+    assert client.get(RULES_PATH).json()["rules"] == [rule]
+
+
+def test_an_instantiated_template_says_exactly_what_the_gallery_showed(
+    client: TestClient,
+) -> None:
+    """The gallery's preview and the rule it creates are one document.
+
+    Slice 041's gallery renders ``GET /alert-templates``'s ``conditions``; this
+    pins that the rule the ``POST`` creates carries that same document rather
+    than a re-derivation of it.
+    """
+    templates = client.get(TEMPLATES_PATH).json()["templates"]
+
+    for template in templates:
+        if template["builtin"]:
+            continue
+        rule = client.post(f"{TEMPLATES_PATH}/{template['key']}/rules").json()
+        assert rule["conditions"] == template["conditions"]
+        assert rule["severity"] == template["severity"]
+        assert rule["name"] == template["name"]
+
+
+def test_instantiating_a_template_twice_is_refused(client: TestClient) -> None:
+    assert client.post(f"{TEMPLATES_PATH}/military/rules").status_code == 201
+
+    response = client.post(f"{TEMPLATES_PATH}/military/rules")
+
+    assert response.status_code == 409
+    assert len(client.get(RULES_PATH).json()["rules"]) == 1
+
+
+def test_instantiating_the_built_in_emergency_template_is_refused(
+    client: TestClient,
+) -> None:
+    """SPEC §47: emergency alerting is already on and has no rule to create."""
+    response = client.post(f"{TEMPLATES_PATH}/emergency_squawk/rules")
+
+    assert response.status_code == 409
+    assert client.get(RULES_PATH).json()["rules"] == []
+
+
+def test_instantiating_an_unknown_template_answers_404(client: TestClient) -> None:
+    response = client.post(f"{TEMPLATES_PATH}/no_such_template/rules")
+
+    assert response.status_code == 404
+
+
+def test_a_deleted_template_rule_can_be_instantiated_again(client: TestClient) -> None:
+    """Deleting a shipped rule is not a permanent ban on the template.
+
+    Start-up instantiation deliberately never re-creates a deleted shipped rule
+    (:mod:`flightsite.alerts.templates`); an explicit request from the gallery
+    is the user asking for it back, which is a different act.
+    """
+    rule = client.post(f"{TEMPLATES_PATH}/military/rules").json()
+    assert client.delete(f"{RULES_PATH}/{rule['id']}").status_code == 204
+
+    response = client.post(f"{TEMPLATES_PATH}/military/rules")
+
+    assert response.status_code == 201
+    assert response.json()["template_key"] == "military"
+
+
+def test_a_template_rule_keeps_its_provenance_when_customized(
+    client: TestClient,
+) -> None:
+    """SPEC §45's "enable, then customize": tuning does not erase where it came from."""
+    rule = client.post(f"{TEMPLATES_PATH}/locally_rare/rules").json()
+
+    response = client.put(
+        f"{RULES_PATH}/{rule['id']}",
+        json={
+            "name": "Rare here",
+            "description": None,
+            "severity": "high",
+            "conditions": {"version": 1, "rare_aircraft": {"max_sightings": 5}},
+            "enabled": False,
+        },
+    )
+
+    assert response.status_code == 200
+    updated = response.json()
+    assert updated["template_key"] == "locally_rare"
+    assert updated["severity"] == "high"
+    assert updated["enabled"] is False
+    assert updated["conditions"]["rare_aircraft"] == {"max_sightings": 5}
+
+
+def test_an_instantiated_rule_is_in_force_for_the_next_live_read(
+    client: TestClient,
+) -> None:
+    """The gallery's "enable" recompiles the engine, like every other mutation."""
+    client.post(f"{TEMPLATES_PATH}/watchlist/rules")
+
+    rules = client.get(RULES_PATH).json()["rules"]
+
+    assert [rule["template_key"] for rule in rules] == ["watchlist"]
+    assert client.get(INTERESTING_PATH).status_code == 200
+
+
 # ------------------------------------------------------------------ rule CRUD
 
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -480,7 +480,7 @@ config/domain models the backend uses.
 | Config | `GET /config` (secrets fully masked as `"•••"`; per-secret set/unset reported via `secrets_set`), `PUT /config` (masked values ignored unless replaced; secrets never echoed back) | 004/019 |
 | Connection test | `POST /decoder/test` → reachability, parse result, sample aircraft count | 007/018 |
 | Watchlists | `GET/POST /watchlists`, `PUT/DELETE /watchlists/{id}`, entries CRUD | 037 |
-| Alert rules | `GET/POST /alert-rules`, `PUT/DELETE /alert-rules/{id}`, `GET /alert-templates` | 038/041 |
+| Alert rules | `GET/POST /alert-rules`, `PUT/DELETE /alert-rules/{id}`, `GET /alert-templates`, `POST /alert-templates/{key}/rules` (instantiates a shipped template as a rule carrying its `template_key`; empty body — the conditions come from the catalogue, never from the caller; `404` unknown key, `409` built-in or already instantiated) | 038/041 |
 | Metadata update | `POST /metadata/update` (starts run), `GET /metadata/status` (per-source status, last success, versions) | 025 |
 | Backup status | `GET /backup/info` (last backup manifest summary; backup/restore themselves are CLI operations) | 043 |
 | Reset | `POST /reset/data` (requires `confirm` token), `POST /reset/metadata-cache` | 045 |

--- a/frontend/src/features/alerts/components/AlertHistorySection.test.tsx
+++ b/frontend/src/features/alerts/components/AlertHistorySection.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AlertHistorySection } from "@/features/alerts/components/AlertHistorySection";
+import type { AlertMatch } from "@/lib/api/alertMatches";
+import { alertMatch, installAlertsApiMock } from "@/test/alertsApiMock";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/** The history links an airframe, so it needs a router as well as a query
+ * client — the pairing `ActivityRow`'s own test uses. */
+function renderHistory() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <AlertHistorySection />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+/** 26 matches — one more than a page — newest first. */
+function manyMatches(): AlertMatch[] {
+  return Array.from({ length: 26 }, (_entry, index) =>
+    alertMatch({ id: 100 - index, reason: `Rule: Number ${index}` }),
+  );
+}
+
+describe("AlertHistorySection", () => {
+  it("says so when nothing has fired", async () => {
+    installAlertsApiMock();
+
+    renderHistory();
+
+    expect(
+      await screen.findByText("No alerts have fired yet."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a match with the reason recorded at the time", async () => {
+    installAlertsApiMock({
+      matches: [
+        alertMatch({ reason: "Rule: Military aircraft", severity: "high" }),
+      ],
+    });
+
+    renderHistory();
+
+    const list = await screen.findByRole("list", { name: "Alert history" });
+    const row = within(list).getByRole("listitem");
+    // The stored reason, never one recomposed from the rule as it stands
+    // now: the history says what the user was actually shown.
+    expect(within(row).getByText("Rule: Military aircraft")).toBeInTheDocument();
+    expect(within(row).getByText("High")).toBeInTheDocument();
+    expect(within(row).getByRole("link", { name: "AE1463" })).toHaveAttribute(
+      "href",
+      "/aircraft/ae1463",
+    );
+  });
+
+  it("names the built-in detector behind a match that has no rule", async () => {
+    installAlertsApiMock({
+      matches: [
+        alertMatch({
+          severity: "critical",
+          reason: "Emergency squawk 7700",
+          rule: null,
+          builtin_key: "emergency_7700",
+        }),
+      ],
+    });
+
+    renderHistory();
+
+    // SPEC §47's emergency detections fire without a rule, so the row names
+    // the detector instead of leaving the source blank.
+    expect(
+      await screen.findByText("Squawk 7700 — general emergency"),
+    ).toBeInTheDocument();
+  });
+
+  it("filters to one severity", async () => {
+    const user = userEvent.setup();
+    installAlertsApiMock({
+      matches: [
+        alertMatch({ id: 1, severity: "high", reason: "Rule: Military" }),
+        alertMatch({ id: 2, severity: "info", reason: "Rule: First ever" }),
+      ],
+    });
+
+    renderHistory();
+    await screen.findByText("Rule: Military");
+
+    await user.selectOptions(screen.getByLabelText("Severity"), "info");
+
+    expect(await screen.findByText("Rule: First ever")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("Rule: Military")).toBeNull();
+    });
+  });
+
+  it("pages older and back again", async () => {
+    const user = userEvent.setup();
+    installAlertsApiMock({ matches: manyMatches() });
+
+    renderHistory();
+    await screen.findByText("Rule: Number 0");
+
+    // "Newer" has nowhere to go from the first page.
+    expect(screen.getByRole("button", { name: "Newer" })).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: "Older" }));
+
+    expect(await screen.findByText("Rule: Number 25")).toBeInTheDocument();
+    // A page that comes back short of the page size is the end — the
+    // endpoint reports no total, so this is the only signal there is.
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Older" })).toBeDisabled();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Newer" }));
+
+    expect(await screen.findByText("Rule: Number 0")).toBeInTheDocument();
+  });
+
+  it("reports a failure to load the history", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({ error: { code: "boom", message: "no history" } }),
+            { status: 500, headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    );
+
+    renderHistory();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /could not load the alert history/i,
+    );
+  });
+});

--- a/frontend/src/features/alerts/components/AlertHistorySection.test.tsx
+++ b/frontend/src/features/alerts/components/AlertHistorySection.test.tsx
@@ -59,7 +59,9 @@ describe("AlertHistorySection", () => {
     const row = within(list).getByRole("listitem");
     // The stored reason, never one recomposed from the rule as it stands
     // now: the history says what the user was actually shown.
-    expect(within(row).getByText("Rule: Military aircraft")).toBeInTheDocument();
+    expect(
+      within(row).getByText("Rule: Military aircraft"),
+    ).toBeInTheDocument();
     expect(within(row).getByText("High")).toBeInTheDocument();
     expect(within(row).getByRole("link", { name: "AE1463" })).toHaveAttribute(
       "href",

--- a/frontend/src/features/alerts/components/AlertHistorySection.tsx
+++ b/frontend/src/features/alerts/components/AlertHistorySection.tsx
@@ -1,0 +1,172 @@
+import { useId, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { AlertSeverityBadge } from "@/features/sightings/components/AlertSeverityBadge";
+import { builtinKeyLabel, SEVERITY_OPTIONS } from "@/features/alerts/lib/vocabulary";
+import { formatReceiverLocalDateTime } from "@/features/aircraft-detail/lib/format";
+import { useAlertMatchesQuery, type AlertMatch } from "@/lib/api/alertMatches";
+import { useConfigQuery } from "@/lib/api/config";
+import type { AlertSeverity } from "@/lib/api/sightings";
+
+const SELECT_CLASSES =
+  "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring disabled:cursor-not-allowed disabled:opacity-50";
+
+const PAGE_SIZE = 25;
+
+/** What produced a match, in one phrase: the rule's name, or the built-in
+ * detector's meaning for a match no rule produced (SPEC §47). */
+function sourceLabel(match: AlertMatch): string {
+  if (match.rule !== null) {
+    return match.rule.name ?? `Rule ${match.rule.id}`;
+  }
+  return match.builtin_key !== null
+    ? builtinKeyLabel(match.builtin_key)
+    : "Built-in detector";
+}
+
+interface MatchRowProps {
+  match: AlertMatch;
+  timezone: string;
+}
+
+function MatchRow({ match, timezone }: MatchRowProps) {
+  return (
+    <li className="flex flex-wrap items-baseline gap-x-3 gap-y-1 rounded-md border border-border bg-card px-3 py-2">
+      <time
+        dateTime={match.at}
+        className="font-mono text-xs text-muted-foreground"
+      >
+        {formatReceiverLocalDateTime(match.at, timezone)}
+      </time>
+      <AlertSeverityBadge severity={match.severity} />
+      <span className="text-sm text-foreground">{match.reason}</span>
+      <Link
+        to={`/aircraft/${match.icao}`}
+        className="font-mono text-xs text-accent hover:underline"
+      >
+        {match.icao.toUpperCase()}
+      </Link>
+      <span className="text-xs text-muted-foreground">
+        {sourceLabel(match)}
+      </span>
+      {match.notified && (
+        <span className="text-xs text-muted-foreground">Notified</span>
+      )}
+    </li>
+  );
+}
+
+/**
+ * The alert match history (docs/API.md §3.9, roadmap slice 041): every alert
+ * that has actually fired, newest first.
+ *
+ * A record rather than a re-derivation. Each row shows the `reason` that was
+ * stored when the match happened, so renaming or retuning a rule afterwards
+ * does not rewrite what the user was told at the time — and a match whose
+ * rule has since been deleted is simply gone, because deleting a rule
+ * deletes the matches it produced.
+ *
+ * Paging is "older/newer" rather than numbered: the endpoint deliberately
+ * reports no total, the history growing without bound over a multi-year
+ * install, so a page count would be a number nobody can compute. A page
+ * that comes back short of `PAGE_SIZE` is the end.
+ */
+export function AlertHistorySection() {
+  const [severity, setSeverity] = useState<AlertSeverity | "">("");
+  const [offset, setOffset] = useState(0);
+  const severityId = useId();
+
+  const configQuery = useConfigQuery();
+  const timezone = configQuery.data?.config.timezone ?? "UTC";
+
+  const matchesQuery = useAlertMatchesQuery({
+    limit: PAGE_SIZE,
+    offset,
+    ...(severity === "" ? {} : { severity }),
+  });
+
+  const items = matchesQuery.data?.items ?? [];
+  const hasOlder = items.length === PAGE_SIZE;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1.5 sm:max-w-56">
+        <Label htmlFor={severityId}>Severity</Label>
+        <select
+          id={severityId}
+          className={SELECT_CLASSES}
+          value={severity}
+          onChange={(event) => {
+            setSeverity(event.target.value as AlertSeverity | "");
+            setOffset(0);
+          }}
+        >
+          <option value="">All severities</option>
+          {SEVERITY_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {matchesQuery.isPending && (
+        <p className="text-sm text-muted-foreground">Loading alert history…</p>
+      )}
+
+      {matchesQuery.isError && (
+        <p role="alert" className="text-sm text-destructive">
+          Could not load the alert history
+          {matchesQuery.error instanceof Error
+            ? `: ${matchesQuery.error.message}`
+            : "."}
+        </p>
+      )}
+
+      {matchesQuery.data && items.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          {offset > 0
+            ? "No more alerts in this direction."
+            : severity === ""
+              ? "No alerts have fired yet."
+              : "No alerts have fired at this severity."}
+        </p>
+      )}
+
+      {items.length > 0 && (
+        <ul aria-label="Alert history" className="flex flex-col gap-2">
+          {items.map((match) => (
+            <MatchRow key={match.id} match={match} timezone={timezone} />
+          ))}
+        </ul>
+      )}
+
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={offset === 0}
+          onClick={() => {
+            setOffset((current) => Math.max(0, current - PAGE_SIZE));
+          }}
+        >
+          Newer
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!hasOlder}
+          onClick={() => {
+            setOffset((current) => current + PAGE_SIZE);
+          }}
+        >
+          Older
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/alerts/components/AlertHistorySection.tsx
+++ b/frontend/src/features/alerts/components/AlertHistorySection.tsx
@@ -4,7 +4,10 @@ import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { AlertSeverityBadge } from "@/features/sightings/components/AlertSeverityBadge";
-import { builtinKeyLabel, SEVERITY_OPTIONS } from "@/features/alerts/lib/vocabulary";
+import {
+  builtinKeyLabel,
+  SEVERITY_OPTIONS,
+} from "@/features/alerts/lib/vocabulary";
 import { formatReceiverLocalDateTime } from "@/features/aircraft-detail/lib/format";
 import { useAlertMatchesQuery, type AlertMatch } from "@/lib/api/alertMatches";
 import { useConfigQuery } from "@/lib/api/config";

--- a/frontend/src/features/alerts/components/AlertRulesSection.test.tsx
+++ b/frontend/src/features/alerts/components/AlertRulesSection.test.tsx
@@ -17,9 +17,7 @@ describe("AlertRulesSection", () => {
 
     renderWithProviders(<AlertRulesSection />);
 
-    expect(
-      await screen.findByText(/no alert rules yet/i),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/no alert rules yet/i)).toBeInTheDocument();
   });
 
   it("lists a rule with its severity, status and conditions", async () => {
@@ -48,7 +46,9 @@ describe("AlertRulesSection", () => {
 
   it("names the template a shipped rule came from", async () => {
     installAlertsApiMock({
-      rules: [alertRule({ name: "Military aircraft", template_key: "military" })],
+      rules: [
+        alertRule({ name: "Military aircraft", template_key: "military" }),
+      ],
     });
 
     renderWithProviders(<AlertRulesSection />);
@@ -85,7 +85,9 @@ describe("AlertRulesSection", () => {
       within(card).getByText("seen at most 2 time(s) here"),
     ).toBeInTheDocument();
     // The builder closes once the rule exists.
-    expect(screen.getByRole("button", { name: "New rule" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "New rule" }),
+    ).toBeInTheDocument();
   });
 
   it("turns a rule off and on again", async () => {
@@ -188,7 +190,9 @@ describe("AlertRulesSection", () => {
         const method = (init?.method ?? "GET").toUpperCase();
         if (url === "/api/internal/alert-rules" && method === "GET") {
           return new Response(
-            JSON.stringify({ rules: [alertRule({ name: "Military aircraft" })] }),
+            JSON.stringify({
+              rules: [alertRule({ name: "Military aircraft" })],
+            }),
             { status: 200, headers: { "Content-Type": "application/json" } },
           );
         }

--- a/frontend/src/features/alerts/components/AlertRulesSection.test.tsx
+++ b/frontend/src/features/alerts/components/AlertRulesSection.test.tsx
@@ -1,0 +1,232 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AlertRulesSection } from "@/features/alerts/components/AlertRulesSection";
+import { alertRule, installAlertsApiMock } from "@/test/alertsApiMock";
+import { renderWithProviders } from "@/test/test-utils";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("AlertRulesSection", () => {
+  it("invites a first rule when there are none", async () => {
+    installAlertsApiMock();
+
+    renderWithProviders(<AlertRulesSection />);
+
+    expect(
+      await screen.findByText(/no alert rules yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it("lists a rule with its severity, status and conditions", async () => {
+    installAlertsApiMock({
+      rules: [
+        alertRule({
+          name: "Military aircraft",
+          severity: "high",
+          description: "Anything military",
+        }),
+      ],
+    });
+
+    renderWithProviders(<AlertRulesSection />);
+
+    const card = await screen.findByRole("article", {
+      name: "Military aircraft",
+    });
+    expect(within(card).getByText("High")).toBeInTheDocument();
+    expect(within(card).getByText("Enabled")).toBeInTheDocument();
+    expect(within(card).getByText("Anything military")).toBeInTheDocument();
+    // The conditions are the backend's own prose, so this card, a
+    // notification and the history all say the same thing about the rule.
+    expect(within(card).getByText("military")).toBeInTheDocument();
+  });
+
+  it("names the template a shipped rule came from", async () => {
+    installAlertsApiMock({
+      rules: [alertRule({ name: "Military aircraft", template_key: "military" })],
+    });
+
+    renderWithProviders(<AlertRulesSection />);
+
+    expect(
+      await screen.findByText("From template: Military aircraft"),
+    ).toBeInTheDocument();
+  });
+
+  it("creates a rule from the builder and shows it in the list", async () => {
+    const user = userEvent.setup();
+    installAlertsApiMock();
+
+    renderWithProviders(<AlertRulesSection />);
+    await screen.findByText(/no alert rules yet/i);
+
+    await user.click(screen.getByRole("button", { name: "New rule" }));
+    await user.type(screen.getByLabelText("Name"), "Rare visitors");
+    await user.selectOptions(
+      screen.getByLabelText("Add a condition"),
+      screen.getByRole("option", { name: "Rare airframe" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Add condition" }));
+    await user.type(
+      screen.getByLabelText("At most this many sightings here"),
+      "2",
+    );
+    await user.click(screen.getByRole("button", { name: "Create rule" }));
+
+    // The round trip the roadmap asks for: what the builder composed is what
+    // the API stored, described back in the API's own words.
+    const card = await screen.findByRole("article", { name: "Rare visitors" });
+    expect(
+      within(card).getByText("seen at most 2 time(s) here"),
+    ).toBeInTheDocument();
+    // The builder closes once the rule exists.
+    expect(screen.getByRole("button", { name: "New rule" })).toBeInTheDocument();
+  });
+
+  it("turns a rule off and on again", async () => {
+    const user = userEvent.setup();
+    installAlertsApiMock({ rules: [alertRule({ name: "Military aircraft" })] });
+
+    renderWithProviders(<AlertRulesSection />);
+    await screen.findByRole("article", { name: "Military aircraft" });
+
+    await user.click(
+      screen.getByRole("button", { name: "Disable Military aircraft" }),
+    );
+
+    // Status is a word, never a colour alone (SPEC §80).
+    expect(await screen.findByText("Disabled")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Enable Military aircraft" }),
+    );
+
+    expect(await screen.findByText("Enabled")).toBeInTheDocument();
+  });
+
+  it("keeps a shipped rule's provenance when it is retuned", async () => {
+    const user = userEvent.setup();
+    installAlertsApiMock({
+      rules: [
+        alertRule({
+          name: "Locally rare",
+          template_key: "locally_rare",
+          conditions: { version: 1, rare_aircraft: { max_sightings: 2 } },
+        }),
+      ],
+    });
+
+    renderWithProviders(<AlertRulesSection />);
+    await screen.findByRole("article", { name: "Locally rare" });
+
+    await user.click(screen.getByRole("button", { name: "Edit Locally rare" }));
+    await user.clear(screen.getByLabelText("At most this many sightings here"));
+    await user.type(
+      screen.getByLabelText("At most this many sightings here"),
+      "5",
+    );
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(
+      await screen.findByText("seen at most 5 time(s) here"),
+    ).toBeInTheDocument();
+    // SPEC §45's "enable, then customize": tuning does not erase where the
+    // rule came from.
+    expect(screen.getByText(/from template/i)).toBeInTheDocument();
+  });
+
+  it("deletes a rule once the warning is accepted", async () => {
+    const user = userEvent.setup();
+    installAlertsApiMock({ rules: [alertRule({ name: "Military aircraft" })] });
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderWithProviders(<AlertRulesSection />);
+    await screen.findByRole("article", { name: "Military aircraft" });
+
+    await user.click(
+      screen.getByRole("button", { name: "Delete Military aircraft" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("article", { name: "Military aircraft" }),
+      ).toBeNull();
+    });
+  });
+
+  it("keeps a rule when the deletion warning is declined", async () => {
+    const user = userEvent.setup();
+    installAlertsApiMock({ rules: [alertRule({ name: "Military aircraft" })] });
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    renderWithProviders(<AlertRulesSection />);
+    await screen.findByRole("article", { name: "Military aircraft" });
+
+    await user.click(
+      screen.getByRole("button", { name: "Delete Military aircraft" }),
+    );
+
+    expect(
+      screen.getByRole("article", { name: "Military aircraft" }),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces the backend's own rejection of a write", async () => {
+    const user = userEvent.setup();
+    // A rule the list still shows but the backend no longer has — what a
+    // second browser tab deleting it looks like from here. The backend stays
+    // authoritative and its answer is shown rather than swallowed.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (url === "/api/internal/alert-rules" && method === "GET") {
+          return new Response(
+            JSON.stringify({ rules: [alertRule({ name: "Military aircraft" })] }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        if (url === "/api/internal/alert-templates") {
+          return new Response(JSON.stringify({ templates: [] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response(
+          JSON.stringify({ detail: "no alert rule with id 1" }),
+          { status: 404, headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+
+    renderWithProviders(<AlertRulesSection />);
+    await screen.findByRole("article", { name: "Military aircraft" });
+
+    await user.click(
+      screen.getByRole("button", { name: "Disable Military aircraft" }),
+    );
+
+    expect(
+      await screen.findByText("no alert rule with id 1"),
+    ).toBeInTheDocument();
+  });
+
+  it("reports a failure to load the rules", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 500 })),
+    );
+
+    renderWithProviders(<AlertRulesSection />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /could not load alert rules/i,
+    );
+  });
+});

--- a/frontend/src/features/alerts/components/AlertRulesSection.tsx
+++ b/frontend/src/features/alerts/components/AlertRulesSection.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { RuleBuilderForm } from "@/features/alerts/components/RuleBuilderForm";
+import { RuleCard } from "@/features/alerts/components/RuleCard";
+import {
+  useAlertRulesQuery,
+  useAlertTemplatesQuery,
+  useCreateAlertRuleMutation,
+  type AlertRuleWriteInput,
+} from "@/lib/api/alertRules";
+
+function errorMessage(error: unknown): string | null {
+  if (!error) {
+    return null;
+  }
+  return error instanceof Error ? error.message : "Something went wrong.";
+}
+
+/**
+ * Alert rule management (SPEC §43, roadmap slice 041): the rule list, and
+ * the visual builder that creates one.
+ *
+ * The builder is behind a button rather than always open, the way the
+ * Watchlists tab keeps its create form: the list is what a returning user
+ * came for, and a permanently-open form pushes it below the fold.
+ *
+ * Template provenance is resolved here, from the catalogue, because a
+ * `template_key` is a key and a card wants a name. The catalogue is static
+ * data compiled into the backend, so this costs one cached read for the
+ * whole list rather than a lookup per rule.
+ */
+export function AlertRulesSection() {
+  const [creating, setCreating] = useState(false);
+
+  const rulesQuery = useAlertRulesQuery();
+  const templatesQuery = useAlertTemplatesQuery();
+  const createMutation = useCreateAlertRuleMutation();
+
+  const rules = rulesQuery.data?.rules ?? [];
+  const templateNames = new Map(
+    (templatesQuery.data?.templates ?? []).map((template) => [
+      template.key,
+      template.name,
+    ]),
+  );
+
+  function handleCreate(input: AlertRuleWriteInput): void {
+    createMutation.mutate(input, {
+      onSuccess: () => {
+        setCreating(false);
+      },
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {creating ? (
+        <RuleBuilderForm
+          submitLabel="Create rule"
+          isPending={createMutation.isPending}
+          serverError={errorMessage(createMutation.error)}
+          onSubmit={handleCreate}
+          onCancel={() => {
+            setCreating(false);
+          }}
+        />
+      ) : (
+        <div>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => {
+              setCreating(true);
+            }}
+          >
+            New rule
+          </Button>
+        </div>
+      )}
+
+      {rulesQuery.isPending && (
+        <p className="text-sm text-muted-foreground">Loading alert rules…</p>
+      )}
+
+      {rulesQuery.isError && (
+        <p role="alert" className="text-sm text-destructive">
+          Could not load alert rules
+          {rulesQuery.error instanceof Error
+            ? `: ${rulesQuery.error.message}`
+            : "."}
+        </p>
+      )}
+
+      {rulesQuery.data && rules.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          No alert rules yet. Build one above, or enable a shipped template on
+          the Templates tab.
+        </p>
+      )}
+
+      {rules.length > 0 && (
+        <ul className="flex flex-col gap-3">
+          {rules.map((rule) => (
+            <li key={rule.id}>
+              <RuleCard
+                rule={rule}
+                templateName={
+                  rule.template_key === null
+                    ? null
+                    : (templateNames.get(rule.template_key) ??
+                      rule.template_key)
+                }
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/alerts/components/ConditionEditor.tsx
+++ b/frontend/src/features/alerts/components/ConditionEditor.tsx
@@ -1,0 +1,251 @@
+import { useId } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldError } from "@/features/setup/components/FieldError";
+import {
+  conditionKindMeta,
+  type ConditionDraft,
+} from "@/features/alerts/lib/conditions";
+import { MISSION_OPTIONS } from "@/features/alerts/lib/vocabulary";
+import type { AlertMissionCategory } from "@/lib/api/alertRules";
+import type { Watchlist } from "@/lib/api/watchlists";
+
+/** Shared with `EntryForm` in the watchlists feature — a native `<select>`
+ * dressed to match the `Input` primitive, there being no shadcn select in
+ * this build. */
+const SELECT_CLASSES =
+  "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring disabled:cursor-not-allowed disabled:opacity-50";
+
+const CHECKBOX_CLASSES =
+  "size-4 rounded border-input accent-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring";
+
+export interface ConditionEditorProps {
+  draft: ConditionDraft;
+  /** What is wrong with this condition right now, or `null`. Passed in
+   * rather than derived here so the builder decides *when* to show it —
+   * an error on a field the user has not reached yet is noise. */
+  error: string | null;
+  /** The watchlists a `watchlist` condition may name. Empty while the list
+   * is still loading, or on an install that has none. */
+  watchlists: readonly Watchlist[];
+  onChange: (next: ConditionDraft) => void;
+  onRemove: () => void;
+}
+
+/**
+ * One condition of a rule, edited in place.
+ *
+ * A `<fieldset>` with a `<legend>` rather than a styled `<div>`: a condition
+ * is a group of inputs that only means anything together, which is what a
+ * fieldset is for, and it gives the group an accessible name without any
+ * ARIA. Numeric fields are plain text inputs holding strings — the form owns
+ * parsing and its own error messages, so the browser's native number
+ * validation cannot refuse a submit before this build's messages are shown.
+ */
+export function ConditionEditor({
+  draft,
+  error,
+  watchlists,
+  onChange,
+  onRemove,
+}: ConditionEditorProps) {
+  const fieldId = useId();
+  const meta = conditionKindMeta(draft.kind);
+  const errorId = `${fieldId}-error`;
+  const describedBy = error ? errorId : undefined;
+
+  return (
+    <fieldset className="flex flex-col gap-3 rounded-md border border-border bg-background p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <legend className="text-sm font-medium text-foreground">
+            {meta.label}
+          </legend>
+          <p className="text-xs text-muted-foreground">{meta.summary}</p>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-label={`Remove the ${meta.label} condition`}
+          onClick={onRemove}
+        >
+          Remove
+        </Button>
+      </div>
+
+      {draft.kind === "classification" && (
+        <div className="flex flex-col gap-3">
+          <div
+            role="group"
+            aria-label="Required classifications"
+            className="flex flex-wrap gap-4"
+          >
+            {(
+              [
+                ["military", "Military", draft.military],
+                ["government", "Government", draft.government],
+                ["lawEnforcement", "Law enforcement", draft.lawEnforcement],
+              ] as const
+            ).map(([field, label, checked]) => (
+              <label
+                key={field}
+                className="flex items-center gap-2 text-sm text-foreground"
+              >
+                <input
+                  type="checkbox"
+                  className={CHECKBOX_CLASSES}
+                  checked={checked}
+                  aria-describedby={describedBy}
+                  onChange={(event) => {
+                    onChange({ ...draft, [field]: event.target.checked });
+                  }}
+                />
+                {label}
+              </label>
+            ))}
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor={fieldId}>Mission category</Label>
+            <select
+              id={fieldId}
+              className={SELECT_CLASSES}
+              value={draft.mission}
+              aria-describedby={describedBy}
+              onChange={(event) => {
+                onChange({
+                  ...draft,
+                  mission: event.target.value as AlertMissionCategory | "",
+                });
+              }}
+            >
+              <option value="">No mission requirement</option>
+              {MISSION_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      )}
+
+      {(draft.kind === "type_code" || draft.kind === "model") && (
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={fieldId}>
+            {draft.kind === "type_code" ? "Type designator" : "Model contains"}
+          </Label>
+          <Input
+            id={fieldId}
+            value={draft.text}
+            placeholder={draft.kind === "type_code" ? "C17" : "Globemaster"}
+            aria-invalid={error !== null}
+            aria-describedby={describedBy}
+            onChange={(event) => {
+              onChange({ ...draft, text: event.target.value });
+            }}
+          />
+        </div>
+      )}
+
+      {draft.kind === "watchlist" && (
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={fieldId}>Watchlist</Label>
+          <select
+            id={fieldId}
+            className={SELECT_CLASSES}
+            value={draft.watchlistId}
+            aria-invalid={error !== null}
+            aria-describedby={describedBy}
+            onChange={(event) => {
+              onChange({ ...draft, watchlistId: event.target.value });
+            }}
+          >
+            <option value="" disabled>
+              Choose a watchlist…
+            </option>
+            {watchlists.map((list) => (
+              <option key={list.id} value={String(list.id)}>
+                {list.name}
+              </option>
+            ))}
+          </select>
+          {watchlists.length === 0 && (
+            <p className="text-xs text-muted-foreground">
+              No watchlists yet. Create one on the Watchlists tab, or use “On
+              any watchlist” instead.
+            </p>
+          )}
+        </div>
+      )}
+
+      {draft.kind === "watchlist_any" && (
+        <p className="text-xs text-muted-foreground">
+          Nothing to configure — this matches an aircraft on any watchlist.
+        </p>
+      )}
+
+      {(draft.kind === "rare_aircraft" || draft.kind === "rare_type") && (
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={fieldId}>
+            {draft.kind === "rare_aircraft"
+              ? "At most this many sightings here"
+              : "At most this many airframes of the type here"}
+          </Label>
+          <Input
+            id={fieldId}
+            inputMode="numeric"
+            value={draft.maxSightings}
+            placeholder="2"
+            aria-invalid={error !== null}
+            aria-describedby={describedBy}
+            onChange={(event) => {
+              onChange({ ...draft, maxSightings: event.target.value });
+            }}
+          />
+        </div>
+      )}
+
+      {(draft.kind === "distance" || draft.kind === "altitude") && (
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor={`${fieldId}-min`}>
+              {draft.kind === "distance" ? "At least (nm)" : "At or above (ft)"}
+            </Label>
+            <Input
+              id={`${fieldId}-min`}
+              inputMode="decimal"
+              value={draft.min}
+              placeholder="Any"
+              aria-invalid={error !== null}
+              aria-describedby={describedBy}
+              onChange={(event) => {
+                onChange({ ...draft, min: event.target.value });
+              }}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor={`${fieldId}-max`}>
+              {draft.kind === "distance" ? "Within (nm)" : "At or below (ft)"}
+            </Label>
+            <Input
+              id={`${fieldId}-max`}
+              inputMode="decimal"
+              value={draft.max}
+              placeholder="Any"
+              aria-invalid={error !== null}
+              aria-describedby={describedBy}
+              onChange={(event) => {
+                onChange({ ...draft, max: event.target.value });
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      <FieldError id={errorId} message={error} />
+    </fieldset>
+  );
+}

--- a/frontend/src/features/alerts/components/RuleBuilderForm.test.tsx
+++ b/frontend/src/features/alerts/components/RuleBuilderForm.test.tsx
@@ -92,9 +92,7 @@ describe("RuleBuilderForm", () => {
     await user.click(screen.getByRole("button", { name: "Create rule" }));
 
     expect(onSubmit).not.toHaveBeenCalled();
-    expect(
-      await screen.findByText(/can never match/i),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/can never match/i)).toBeInTheDocument();
   });
 
   it("stays quiet about errors until the first submit attempt", async () => {

--- a/frontend/src/features/alerts/components/RuleBuilderForm.test.tsx
+++ b/frontend/src/features/alerts/components/RuleBuilderForm.test.tsx
@@ -1,0 +1,226 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RuleBuilderForm } from "@/features/alerts/components/RuleBuilderForm";
+import { CONDITION_KINDS } from "@/features/alerts/lib/conditions";
+import type { AlertRule } from "@/lib/api/alertRules";
+import { installAlertsApiMock, alertRule } from "@/test/alertsApiMock";
+import { watchlist } from "@/test/watchlistsApiMock";
+import { renderWithProviders } from "@/test/test-utils";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function renderBuilder(rule?: AlertRule) {
+  const onSubmit = vi.fn();
+  installAlertsApiMock({
+    watchlists: [watchlist({ id: 3, name: "Police Helicopters" })],
+  });
+  renderWithProviders(
+    <RuleBuilderForm
+      rule={rule}
+      submitLabel={rule ? "Save changes" : "Create rule"}
+      isPending={false}
+      serverError={null}
+      onSubmit={onSubmit}
+    />,
+  );
+  return { onSubmit, user: userEvent.setup() };
+}
+
+/** Adds one condition through the picker, the way a user does. */
+async function addCondition(
+  user: ReturnType<typeof userEvent.setup>,
+  label: string,
+): Promise<void> {
+  await user.selectOptions(
+    screen.getByLabelText("Add a condition"),
+    screen.getByRole("option", { name: label }),
+  );
+  await user.click(screen.getByRole("button", { name: "Add condition" }));
+}
+
+describe("RuleBuilderForm", () => {
+  it("offers every condition kind the engine supports", () => {
+    renderBuilder();
+
+    const picker = screen.getByLabelText("Add a condition");
+
+    for (const meta of CONDITION_KINDS) {
+      expect(
+        screen.getByRole("option", { name: meta.label }),
+      ).toBeInTheDocument();
+    }
+    // Plus the "choose one" placeholder.
+    expect(picker).toHaveDisplayValue("Choose a condition…");
+  });
+
+  it("refuses to submit a rule with no conditions", async () => {
+    const { onSubmit, user } = renderBuilder();
+
+    await user.type(screen.getByLabelText("Name"), "Everything");
+    await user.click(screen.getByRole("button", { name: "Create rule" }));
+
+    // A rule with no conditions would match every aircraft in the sky, so it
+    // must never reach the API — the builder says so instead.
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText(/add at least one condition/i),
+    ).toBeInTheDocument();
+  });
+
+  it("refuses to submit a rule with no name", async () => {
+    const { onSubmit, user } = renderBuilder();
+
+    await addCondition(user, "On any watchlist");
+    await user.click(screen.getByRole("button", { name: "Create rule" }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(await screen.findByText("Enter a name.")).toBeInTheDocument();
+  });
+
+  it("refuses an inverted distance window and says why", async () => {
+    const { onSubmit, user } = renderBuilder();
+
+    await user.type(screen.getByLabelText("Name"), "Far but near");
+    await addCondition(user, "Distance");
+    await user.type(screen.getByLabelText("At least (nm)"), "40");
+    await user.type(screen.getByLabelText("Within (nm)"), "10");
+    await user.click(screen.getByRole("button", { name: "Create rule" }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText(/can never match/i),
+    ).toBeInTheDocument();
+  });
+
+  it("stays quiet about errors until the first submit attempt", async () => {
+    const { user } = renderBuilder();
+
+    await addCondition(user, "Type code");
+
+    // The type-code field is empty and therefore invalid, but arguing with a
+    // field nobody has reached yet is noise.
+    expect(screen.queryByText("Enter a type designator.")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Create rule" }));
+
+    expect(
+      await screen.findByText("Enter a type designator."),
+    ).toBeInTheDocument();
+  });
+
+  it("composes the document the API stores", async () => {
+    const { onSubmit, user } = renderBuilder();
+
+    await user.type(screen.getByLabelText("Name"), "  Low military  ");
+    await user.selectOptions(screen.getByLabelText("Severity"), "critical");
+    await addCondition(user, "Classification");
+    await user.click(screen.getByRole("checkbox", { name: "Military" }));
+    await addCondition(user, "Altitude");
+    await user.type(screen.getByLabelText("At or below (ft)"), "5000");
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: "Also alert for aircraft on the ground",
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: "Create rule" }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      name: "Low military",
+      description: null,
+      severity: "critical",
+      enabled: true,
+      conditions: {
+        version: 1,
+        classification: {
+          military: true,
+          government: false,
+          law_enforcement: false,
+        },
+        max_alt_ft: 5000,
+        applies_on_ground: true,
+      },
+    });
+  });
+
+  it("does not offer a condition kind twice", async () => {
+    const { user } = renderBuilder();
+
+    await addCondition(user, "Type code");
+
+    // The stored document is flat, so a second type_code would have nowhere
+    // to go — the picker stops offering it rather than silently overwriting.
+    expect(screen.queryByRole("option", { name: "Type code" })).toBeNull();
+  });
+
+  it("removes a condition again", async () => {
+    const { user } = renderBuilder();
+
+    await addCondition(user, "Model");
+    expect(screen.getByLabelText("Model contains")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Remove the Model condition" }),
+    );
+
+    expect(screen.queryByLabelText("Model contains")).toBeNull();
+    expect(screen.getByRole("option", { name: "Model" })).toBeInTheDocument();
+  });
+
+  it("offers the watchlists a 'on a watchlist' condition can name", async () => {
+    const { user } = renderBuilder();
+
+    await addCondition(user, "On a watchlist");
+
+    expect(
+      await screen.findByRole("option", { name: "Police Helicopters" }),
+    ).toBeInTheDocument();
+  });
+
+  it("loads an existing rule's conditions for editing", async () => {
+    const { user, onSubmit } = renderBuilder(
+      alertRule({
+        id: 7,
+        name: "Rare here",
+        severity: "interesting",
+        conditions: { version: 1, rare_aircraft: { max_sightings: 2 } },
+      }),
+    );
+
+    expect(screen.getByLabelText("Name")).toHaveValue("Rare here");
+    expect(
+      screen.getByLabelText("At most this many sightings here"),
+    ).toHaveValue("2");
+
+    await user.clear(screen.getByLabelText("At most this many sightings here"));
+    await user.type(
+      screen.getByLabelText("At most this many sightings here"),
+      "5",
+    );
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    // Only the threshold moved: the rest of the rule round-tripped untouched.
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Rare here",
+        severity: "interesting",
+        conditions: { version: 1, rare_aircraft: { max_sightings: 5 } },
+      }),
+    );
+  });
+
+  it("names the severity in words, not by colour alone", () => {
+    renderBuilder();
+
+    // SPEC §80: the level is readable as text, and the selector explains what
+    // choosing it means.
+    expect(screen.getByLabelText("Severity")).toHaveDisplayValue("Interesting");
+    expect(
+      screen.getByText(/worth a glance when you are already looking/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/alerts/components/RuleBuilderForm.tsx
+++ b/frontend/src/features/alerts/components/RuleBuilderForm.tsx
@@ -65,9 +65,15 @@ export function RuleBuilderForm({
   serverError,
   submitLabel,
 }: RuleBuilderFormProps) {
-  const initial = rule
-    ? documentToConditions(rule.conditions)
-    : { drafts: [] as ConditionDraft[], appliesOnGround: false };
+  // Parsed once, on mount: this is the *initial* state of an edit, and
+  // re-deriving it from the prop on every render would quietly discard what
+  // the user has typed since. A caller re-keys the form to edit a different
+  // rule, which is what makes mount-time the right and only time.
+  const [initial] = useState(() =>
+    rule
+      ? documentToConditions(rule.conditions)
+      : { drafts: [] as ConditionDraft[], appliesOnGround: false },
+  );
 
   const [name, setName] = useState(rule?.name ?? "");
   const [description, setDescription] = useState(rule?.description ?? "");

--- a/frontend/src/features/alerts/components/RuleBuilderForm.tsx
+++ b/frontend/src/features/alerts/components/RuleBuilderForm.tsx
@@ -1,0 +1,314 @@
+import { useId, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldError } from "@/features/setup/components/FieldError";
+import { ConditionEditor } from "@/features/alerts/components/ConditionEditor";
+import {
+  availableKinds,
+  conditionsToDocument,
+  documentToConditions,
+  emptyCondition,
+  isRuleDraftValid,
+  validateCondition,
+  validateConditionList,
+  validateRuleDescription,
+  validateRuleName,
+  type ConditionDraft,
+  type ConditionKind,
+} from "@/features/alerts/lib/conditions";
+import { SEVERITY_OPTIONS } from "@/features/alerts/lib/vocabulary";
+import type { AlertRule, AlertRuleWriteInput } from "@/lib/api/alertRules";
+import type { AlertSeverity } from "@/lib/api/sightings";
+import { useWatchlistsQuery } from "@/lib/api/watchlists";
+
+const SELECT_CLASSES =
+  "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring disabled:cursor-not-allowed disabled:opacity-50";
+
+const CHECKBOX_CLASSES =
+  "size-4 rounded border-input accent-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring";
+
+export interface RuleBuilderFormProps {
+  /** The rule to edit. Absent when building a new one. */
+  rule?: AlertRule;
+  onSubmit: (input: AlertRuleWriteInput) => void;
+  onCancel?: () => void;
+  isPending: boolean;
+  /** The backend's own rejection of the last submission, shown beside the
+   * builder's checks rather than instead of them — the backend stays
+   * authoritative even where this form has mirrored one of its rules. */
+  serverError: string | null;
+  submitLabel: string;
+}
+
+/**
+ * The visual rule builder (SPEC §43, roadmap slice 041).
+ *
+ * Conditions are added one at a time from the v1 set and combined with
+ * `AND` — every one must hold — which is the only combinator v1 has; there
+ * are deliberately no OR groups or nested expressions to build here.
+ *
+ * Validation runs continuously but is only *shown* after the first submit
+ * attempt: an error on a field nobody has reached yet is noise, and a form
+ * that argues while it is being filled in is worse than one that answers
+ * when asked. The submit button stays enabled for the same reason — a
+ * disabled button explains nothing, whereas a click that reveals exactly
+ * what is missing does. An invalid rule is never sent either way, which is
+ * what "the builder prevents invalid rules" means.
+ */
+export function RuleBuilderForm({
+  rule,
+  onSubmit,
+  onCancel,
+  isPending,
+  serverError,
+  submitLabel,
+}: RuleBuilderFormProps) {
+  const initial = rule
+    ? documentToConditions(rule.conditions)
+    : { drafts: [] as ConditionDraft[], appliesOnGround: false };
+
+  const [name, setName] = useState(rule?.name ?? "");
+  const [description, setDescription] = useState(rule?.description ?? "");
+  const [severity, setSeverity] = useState<AlertSeverity>(
+    rule?.severity ?? "interesting",
+  );
+  const [enabled, setEnabled] = useState(rule?.enabled ?? true);
+  const [drafts, setDrafts] = useState<ConditionDraft[]>(initial.drafts);
+  const [appliesOnGround, setAppliesOnGround] = useState(
+    initial.appliesOnGround,
+  );
+  const [nextKind, setNextKind] = useState<ConditionKind | "">("");
+  const [submitted, setSubmitted] = useState(false);
+
+  const watchlistsQuery = useWatchlistsQuery();
+  const watchlists = watchlistsQuery.data?.watchlists ?? [];
+
+  const nameId = useId();
+  const descriptionId = useId();
+  const severityId = useId();
+  const addId = useId();
+
+  const remaining = availableKinds(drafts);
+  const nameError = submitted ? validateRuleName(name) : null;
+  const descriptionError = submitted
+    ? validateRuleDescription(description)
+    : null;
+  const listError = submitted ? validateConditionList(drafts) : null;
+  const severityHint = SEVERITY_OPTIONS.find(
+    (option) => option.value === severity,
+  )?.hint;
+
+  function updateDraft(index: number, next: ConditionDraft): void {
+    setDrafts((current) =>
+      current.map((draft, position) => (position === index ? next : draft)),
+    );
+  }
+
+  function removeDraft(index: number): void {
+    setDrafts((current) =>
+      current.filter((_draft, position) => position !== index),
+    );
+  }
+
+  function addCondition(): void {
+    if (nextKind === "") {
+      return;
+    }
+    setDrafts((current) => [...current, emptyCondition(nextKind)]);
+    setNextKind("");
+  }
+
+  function handleSubmit(event: React.FormEvent): void {
+    event.preventDefault();
+    setSubmitted(true);
+    if (!isRuleDraftValid(name, description, drafts)) {
+      return;
+    }
+    onSubmit({
+      name: name.trim(),
+      description:
+        description.trim().length > 0 ? description.trim() : null,
+      severity,
+      conditions: conditionsToDocument(drafts, appliesOnGround),
+      enabled,
+    });
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      aria-label={rule ? `Edit rule ${rule.name}` : "Create an alert rule"}
+      className="flex flex-col gap-4 rounded-lg border border-border bg-card p-4"
+    >
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={nameId}>Name</Label>
+          <Input
+            id={nameId}
+            value={name}
+            placeholder="Military aircraft"
+            aria-invalid={nameError !== null}
+            aria-describedby={nameError ? `${nameId}-error` : undefined}
+            onChange={(event) => {
+              setName(event.target.value);
+            }}
+          />
+          <FieldError id={`${nameId}-error`} message={nameError} />
+          <p className="text-xs text-muted-foreground">
+            Shown in notifications and in the alert history, so name it after
+            what it detects.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={severityId}>Severity</Label>
+          <select
+            id={severityId}
+            className={SELECT_CLASSES}
+            value={severity}
+            onChange={(event) => {
+              setSeverity(event.target.value as AlertSeverity);
+            }}
+          >
+            {SEVERITY_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-muted-foreground">{severityHint}</p>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor={descriptionId}>Description (optional)</Label>
+        <Input
+          id={descriptionId}
+          value={description}
+          aria-invalid={descriptionError !== null}
+          aria-describedby={
+            descriptionError ? `${descriptionId}-error` : undefined
+          }
+          onChange={(event) => {
+            setDescription(event.target.value);
+          }}
+        />
+        <FieldError
+          id={`${descriptionId}-error`}
+          message={descriptionError}
+        />
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <div className="space-y-1">
+          <h4 className="text-sm font-medium text-foreground">Conditions</h4>
+          <p className="text-xs text-muted-foreground">
+            Every condition must hold for the rule to match.
+          </p>
+        </div>
+
+        {drafts.map((draft, index) => (
+          <ConditionEditor
+            key={draft.kind}
+            draft={draft}
+            error={submitted ? validateCondition(draft) : null}
+            watchlists={watchlists}
+            onChange={(next) => {
+              updateDraft(index, next);
+            }}
+            onRemove={() => {
+              removeDraft(index);
+            }}
+          />
+        ))}
+
+        <FieldError id={`${addId}-list-error`} message={listError} />
+
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="flex min-w-48 flex-1 flex-col gap-1.5">
+            <Label htmlFor={addId}>Add a condition</Label>
+            <select
+              id={addId}
+              className={SELECT_CLASSES}
+              value={nextKind}
+              disabled={remaining.length === 0}
+              onChange={(event) => {
+                setNextKind(event.target.value as ConditionKind | "");
+              }}
+            >
+              <option value="">
+                {remaining.length === 0
+                  ? "Every condition is already in use"
+                  : "Choose a condition…"}
+              </option>
+              {remaining.map((meta) => (
+                <option key={meta.kind} value={meta.kind}>
+                  {meta.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={nextKind === ""}
+            onClick={addCondition}
+          >
+            Add condition
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="flex items-center gap-2 text-sm text-foreground">
+          <input
+            type="checkbox"
+            className={CHECKBOX_CLASSES}
+            checked={appliesOnGround}
+            onChange={(event) => {
+              setAppliesOnGround(event.target.checked);
+            }}
+          />
+          Also alert for aircraft on the ground
+        </label>
+        <p className="text-xs text-muted-foreground">
+          Off by default: a rule about military aircraft usually means ones
+          that are flying, not one parked on a ramp the receiver hears all
+          day.
+        </p>
+
+        <label className="flex items-center gap-2 text-sm text-foreground">
+          <input
+            type="checkbox"
+            className={CHECKBOX_CLASSES}
+            checked={enabled}
+            onChange={(event) => {
+              setEnabled(event.target.checked);
+            }}
+          />
+          Enabled
+        </label>
+      </div>
+
+      {serverError && (
+        <p role="alert" className="text-xs text-destructive">
+          {serverError}
+        </p>
+      )}
+
+      <div className="flex gap-2">
+        <Button type="submit" size="sm" disabled={isPending}>
+          {isPending ? "Saving…" : submitLabel}
+        </Button>
+        {onCancel && (
+          <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+            Cancel
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/features/alerts/components/RuleBuilderForm.tsx
+++ b/frontend/src/features/alerts/components/RuleBuilderForm.tsx
@@ -134,8 +134,7 @@ export function RuleBuilderForm({
     }
     onSubmit({
       name: name.trim(),
-      description:
-        description.trim().length > 0 ? description.trim() : null,
+      description: description.trim().length > 0 ? description.trim() : null,
       severity,
       conditions: conditionsToDocument(drafts, appliesOnGround),
       enabled,
@@ -201,10 +200,7 @@ export function RuleBuilderForm({
             setDescription(event.target.value);
           }}
         />
-        <FieldError
-          id={`${descriptionId}-error`}
-          message={descriptionError}
-        />
+        <FieldError id={`${descriptionId}-error`} message={descriptionError} />
       </div>
 
       <div className="flex flex-col gap-3">
@@ -281,9 +277,8 @@ export function RuleBuilderForm({
           Also alert for aircraft on the ground
         </label>
         <p className="text-xs text-muted-foreground">
-          Off by default: a rule about military aircraft usually means ones
-          that are flying, not one parked on a ramp the receiver hears all
-          day.
+          Off by default: a rule about military aircraft usually means ones that
+          are flying, not one parked on a ramp the receiver hears all day.
         </p>
 
         <label className="flex items-center gap-2 text-sm text-foreground">

--- a/frontend/src/features/alerts/components/RuleCard.tsx
+++ b/frontend/src/features/alerts/components/RuleCard.tsx
@@ -81,7 +81,11 @@ export function RuleCard({ rule, templateName }: RuleCardProps) {
   function handleSave(input: AlertRuleWriteInput): void {
     updateMutation.mutate(
       { ruleId: rule.id, input },
-      { onSuccess: () => { setEditing(false); } },
+      {
+        onSuccess: () => {
+          setEditing(false);
+        },
+      },
     );
   }
 

--- a/frontend/src/features/alerts/components/RuleCard.tsx
+++ b/frontend/src/features/alerts/components/RuleCard.tsx
@@ -1,0 +1,192 @@
+import { useId, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { RuleBuilderForm } from "@/features/alerts/components/RuleBuilderForm";
+import { AlertSeverityBadge } from "@/features/sightings/components/AlertSeverityBadge";
+import {
+  useDeleteAlertRuleMutation,
+  useUpdateAlertRuleMutation,
+  type AlertRule,
+  type AlertRuleWriteInput,
+} from "@/lib/api/alertRules";
+
+function errorMessage(error: unknown): string | null {
+  if (!error) {
+    return null;
+  }
+  return error instanceof Error ? error.message : "Something went wrong.";
+}
+
+/** The whole of a rule as a write body — what "toggle enabled" and "save an
+ * edit" both send, because `PUT` is a full replace rather than a patch. A
+ * partial update of an `AND` condition set would be ambiguous about whether
+ * an omitted condition was meant to be removed. */
+function writeBodyFor(
+  rule: AlertRule,
+  overrides: Partial<AlertRuleWriteInput> = {},
+): AlertRuleWriteInput {
+  return {
+    name: rule.name,
+    description: rule.description,
+    severity: rule.severity,
+    conditions: rule.conditions,
+    enabled: rule.enabled,
+    ...overrides,
+  };
+}
+
+export interface RuleCardProps {
+  rule: AlertRule;
+  /** The shipped template this rule came from, by name; `null` for a
+   * user-written rule, or for a `template_key` this build no longer ships. */
+  templateName: string | null;
+}
+
+/**
+ * One alert rule: what it is called, how loudly it fires, where it came
+ * from, what it actually asks, and whether it is on.
+ *
+ * Status is text first (SPEC §80, never colour alone): a disabled rule says
+ * "Disabled", and severity is the badge's own word rather than a tint. The
+ * conditions are rendered from the backend's `describes`, so this card and a
+ * notification and the alert history all say the same thing about a rule
+ * instead of three renderings that drift.
+ */
+export function RuleCard({ rule, templateName }: RuleCardProps) {
+  const [editing, setEditing] = useState(false);
+  const headingId = useId();
+
+  const updateMutation = useUpdateAlertRuleMutation();
+  const deleteMutation = useDeleteAlertRuleMutation();
+
+  const actionError =
+    errorMessage(updateMutation.error) ?? errorMessage(deleteMutation.error);
+
+  function toggleEnabled(): void {
+    updateMutation.mutate({
+      ruleId: rule.id,
+      input: writeBodyFor(rule, { enabled: !rule.enabled }),
+    });
+  }
+
+  function handleDelete(): void {
+    const confirmed = window.confirm(
+      `Delete “${rule.name}”? The alerts it has already recorded are deleted with it.`,
+    );
+    if (confirmed) {
+      deleteMutation.mutate(rule.id);
+    }
+  }
+
+  function handleSave(input: AlertRuleWriteInput): void {
+    updateMutation.mutate(
+      { ruleId: rule.id, input },
+      { onSuccess: () => { setEditing(false); } },
+    );
+  }
+
+  return (
+    <article
+      aria-labelledby={headingId}
+      className="flex flex-col gap-3 rounded-lg border border-border bg-card p-4"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h3 id={headingId} className="text-sm font-semibold text-foreground">
+            {rule.name}
+          </h3>
+          <div className="flex flex-wrap items-center gap-2">
+            <AlertSeverityBadge severity={rule.severity} />
+            <span
+              className={
+                rule.enabled
+                  ? "inline-flex items-center rounded-full border border-border px-2 py-0.5 text-xs font-semibold text-muted-foreground"
+                  : "inline-flex items-center rounded-full border border-amber-500/60 px-2 py-0.5 text-xs font-semibold text-amber-600 dark:text-amber-400"
+              }
+            >
+              {rule.enabled ? "Enabled" : "Disabled"}
+            </span>
+            {templateName !== null && (
+              <span className="inline-flex items-center rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground">
+                From template: {templateName}
+              </span>
+            )}
+          </div>
+          {rule.description !== null && (
+            <p className="text-xs text-muted-foreground">{rule.description}</p>
+          )}
+        </div>
+
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={updateMutation.isPending}
+            aria-label={`${rule.enabled ? "Disable" : "Enable"} ${rule.name}`}
+            onClick={toggleEnabled}
+          >
+            {rule.enabled ? "Disable" : "Enable"}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-expanded={editing}
+            aria-label={`Edit ${rule.name}`}
+            onClick={() => {
+              setEditing((current) => !current);
+            }}
+          >
+            {editing ? "Close" : "Edit"}
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            disabled={deleteMutation.isPending}
+            aria-label={`Delete ${rule.name}`}
+            onClick={handleDelete}
+          >
+            Delete
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <h4 className="text-xs font-medium text-muted-foreground">
+          Matches aircraft that are
+        </h4>
+        <ul className="flex flex-col gap-0.5 text-xs text-foreground">
+          {rule.describes.map((phrase) => (
+            <li key={phrase}>{phrase}</li>
+          ))}
+        </ul>
+        {rule.conditions.applies_on_ground === true && (
+          <p className="text-xs text-muted-foreground">
+            Includes aircraft on the ground.
+          </p>
+        )}
+      </div>
+
+      {actionError && (
+        <p role="alert" className="text-xs text-destructive">
+          {actionError}
+        </p>
+      )}
+
+      {editing && (
+        <RuleBuilderForm
+          rule={rule}
+          submitLabel="Save changes"
+          isPending={updateMutation.isPending}
+          serverError={errorMessage(updateMutation.error)}
+          onSubmit={handleSave}
+          onCancel={() => {
+            setEditing(false);
+          }}
+        />
+      )}
+    </article>
+  );
+}

--- a/frontend/src/features/alerts/components/TemplateGallery.test.tsx
+++ b/frontend/src/features/alerts/components/TemplateGallery.test.tsx
@@ -70,7 +70,9 @@ describe("TemplateGallery", () => {
     // Not from local state: a template is added exactly when a rule with its
     // key exists, which is what makes a first-run instantiation show here too.
     installAlertsApiMock({
-      rules: [alertRule({ name: "Watchlist match", template_key: "watchlist" })],
+      rules: [
+        alertRule({ name: "Watchlist match", template_key: "watchlist" }),
+      ],
     });
 
     renderWithProviders(<TemplateGallery />);
@@ -117,9 +119,7 @@ describe("TemplateGallery", () => {
           );
         }
         if (url === "/api/internal/alert-rules" && method === "GET") {
-          const rules = served
-            ? [alertRule({ template_key: "military" })]
-            : [];
+          const rules = served ? [alertRule({ template_key: "military" })] : [];
           return json({ rules }, 200);
         }
         served = true;

--- a/frontend/src/features/alerts/components/TemplateGallery.test.tsx
+++ b/frontend/src/features/alerts/components/TemplateGallery.test.tsx
@@ -1,0 +1,158 @@
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TemplateGallery } from "@/features/alerts/components/TemplateGallery";
+import { alertRule, installAlertsApiMock } from "@/test/alertsApiMock";
+import { renderWithProviders } from "@/test/test-utils";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("TemplateGallery", () => {
+  it("shows every shipped template with its severity in words", async () => {
+    installAlertsApiMock();
+
+    renderWithProviders(<TemplateGallery />);
+
+    const card = await screen.findByRole("article", {
+      name: "Military aircraft",
+    });
+    expect(within(card).getByText("High")).toBeInTheDocument();
+    expect(
+      screen.getByRole("article", { name: "First-ever aircraft" }),
+    ).toBeInTheDocument();
+  });
+
+  it("presents the emergency template as a statement, not a switch", async () => {
+    installAlertsApiMock();
+
+    renderWithProviders(<TemplateGallery />);
+
+    const card = await screen.findByRole("article", {
+      name: "Emergency squawk",
+    });
+    // SPEC §47: emergency squawks alert without a rule and cannot be turned
+    // off, so there is nothing here to enable — not even a disabled button,
+    // which would read as "not yet" rather than "never".
+    expect(within(card).getByText("Always on")).toBeInTheDocument();
+    expect(within(card).queryByRole("button")).toBeNull();
+  });
+
+  it("adds a rule from a template and marks it added", async () => {
+    const user = userEvent.setup();
+    installAlertsApiMock();
+
+    renderWithProviders(<TemplateGallery />);
+    const card = await screen.findByRole("article", {
+      name: "Military aircraft",
+    });
+
+    await user.click(
+      within(card).getByRole("button", {
+        name: "Add a rule from the Military aircraft template",
+      }),
+    );
+
+    expect(await within(card).findByText("Added")).toBeInTheDocument();
+    // The action is gone rather than disabled: the rule now lives on the
+    // Rules tab, and there is nothing left to do here.
+    expect(
+      within(card).queryByRole("button", {
+        name: "Add a rule from the Military aircraft template",
+      }),
+    ).toBeNull();
+  });
+
+  it("reads 'added' from the rule that carries the provenance", async () => {
+    // Not from local state: a template is added exactly when a rule with its
+    // key exists, which is what makes a first-run instantiation show here too.
+    installAlertsApiMock({
+      rules: [alertRule({ name: "Watchlist match", template_key: "watchlist" })],
+    });
+
+    renderWithProviders(<TemplateGallery />);
+
+    const card = await screen.findByRole("article", {
+      name: "Watchlist match",
+    });
+    expect(within(card).getByText("Added")).toBeInTheDocument();
+    expect(
+      screen.getByRole("article", { name: "Military aircraft" }),
+    ).not.toHaveTextContent("Added");
+  });
+
+  it("surfaces the backend's refusal to instantiate twice", async () => {
+    const user = userEvent.setup();
+    // The rule exists but this gallery has not seen it yet — the backend
+    // refuses the second instantiation and says so.
+    let served = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method ?? "GET").toUpperCase();
+        const json = (body: unknown, status: number) =>
+          new Response(JSON.stringify(body), {
+            status,
+            headers: { "Content-Type": "application/json" },
+          });
+        if (url === "/api/internal/alert-templates") {
+          return json(
+            {
+              templates: [
+                {
+                  key: "military",
+                  name: "Military aircraft",
+                  description: "Any military aircraft.",
+                  severity: "high",
+                  builtin: false,
+                  conditions: { version: 1 },
+                },
+              ],
+            },
+            200,
+          );
+        }
+        if (url === "/api/internal/alert-rules" && method === "GET") {
+          const rules = served
+            ? [alertRule({ template_key: "military" })]
+            : [];
+          return json({ rules }, 200);
+        }
+        served = true;
+        return json({ detail: "template 'military' already has a rule" }, 409);
+      }),
+    );
+
+    renderWithProviders(<TemplateGallery />);
+    const card = await screen.findByRole("article", {
+      name: "Military aircraft",
+    });
+
+    await user.click(
+      within(card).getByRole("button", {
+        name: "Add a rule from the Military aircraft template",
+      }),
+    );
+
+    expect(
+      await screen.findByText("template 'military' already has a rule"),
+    ).toBeInTheDocument();
+  });
+
+  it("reports a failure to load the catalogue", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 500 })),
+    );
+
+    renderWithProviders(<TemplateGallery />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /could not load templates/i,
+    );
+  });
+});

--- a/frontend/src/features/alerts/components/TemplateGallery.tsx
+++ b/frontend/src/features/alerts/components/TemplateGallery.tsx
@@ -82,8 +82,8 @@ function TemplateCard({
 
       {!template.builtin && instantiated && (
         <p className="text-xs text-muted-foreground">
-          A rule from this template is on the Rules tab, where it can be
-          retuned or turned off.
+          A rule from this template is on the Rules tab, where it can be retuned
+          or turned off.
         </p>
       )}
 

--- a/frontend/src/features/alerts/components/TemplateGallery.tsx
+++ b/frontend/src/features/alerts/components/TemplateGallery.tsx
@@ -1,0 +1,172 @@
+import { useId, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { AlertSeverityBadge } from "@/features/sightings/components/AlertSeverityBadge";
+import {
+  useAlertRulesQuery,
+  useAlertTemplatesQuery,
+  useInstantiateAlertTemplateMutation,
+  type AlertTemplate,
+} from "@/lib/api/alertRules";
+
+function errorMessage(error: unknown): string | null {
+  if (!error) {
+    return null;
+  }
+  return error instanceof Error ? error.message : "Something went wrong.";
+}
+
+interface TemplateCardProps {
+  template: AlertTemplate;
+  /** Whether a rule already carries this template's provenance. */
+  instantiated: boolean;
+  isPending: boolean;
+  error: string | null;
+  onAdd: () => void;
+}
+
+function TemplateCard({
+  template,
+  instantiated,
+  isPending,
+  error,
+  onAdd,
+}: TemplateCardProps) {
+  const headingId = useId();
+
+  return (
+    <article
+      aria-labelledby={headingId}
+      className="flex flex-col gap-2 rounded-lg border border-border bg-card p-4"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h3 id={headingId} className="text-sm font-semibold text-foreground">
+            {template.name}
+          </h3>
+          <div className="flex flex-wrap items-center gap-2">
+            <AlertSeverityBadge severity={template.severity} />
+            {template.builtin && (
+              <span className="inline-flex items-center rounded-full border border-accent/60 px-2 py-0.5 text-xs font-semibold text-accent">
+                Always on
+              </span>
+            )}
+            {!template.builtin && instantiated && (
+              <span className="inline-flex items-center rounded-full border border-border px-2 py-0.5 text-xs font-semibold text-muted-foreground">
+                Added
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* A card carries a button only while there is something to do with
+            it. A built-in template never has one — SPEC §47 makes emergency
+            alerting fire without a rule and gives a user nothing to switch —
+            and an added one no longer does, its rule having moved to the
+            Rules tab. A disabled button in either place would read as "not
+            yet" when the answer is "never" and "already". */}
+        {!template.builtin && !instantiated && (
+          <Button
+            type="button"
+            size="sm"
+            disabled={isPending}
+            aria-label={`Add a rule from the ${template.name} template`}
+            onClick={onAdd}
+          >
+            {isPending ? "Adding…" : "Add rule"}
+          </Button>
+        )}
+      </div>
+
+      <p className="text-xs text-muted-foreground">{template.description}</p>
+
+      {!template.builtin && instantiated && (
+        <p className="text-xs text-muted-foreground">
+          A rule from this template is on the Rules tab, where it can be
+          retuned or turned off.
+        </p>
+      )}
+
+      {error && (
+        <p role="alert" className="text-xs text-destructive">
+          {error}
+        </p>
+      )}
+    </article>
+  );
+}
+
+/**
+ * The shipped-template gallery (SPEC §45, roadmap slice 041).
+ *
+ * Adding a template creates a real rule carrying its `template_key`, so a
+ * template is "added" exactly when a rule with that provenance exists —
+ * which is read from the rule list rather than tracked here. That is what
+ * lets a user delete a shipped rule and see the template offer itself again,
+ * rather than the gallery insisting it is still enabled.
+ *
+ * The emergency template is the odd one out and is shown anyway: a user
+ * opening this gallery must be able to see that emergency alerting exists.
+ * It is rendered as a statement rather than as a switch, because SPEC §47
+ * makes 7500/7600/7700 fire without any rule and with nothing to disable.
+ */
+export function TemplateGallery() {
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
+
+  const templatesQuery = useAlertTemplatesQuery();
+  const rulesQuery = useAlertRulesQuery();
+  const instantiateMutation = useInstantiateAlertTemplateMutation();
+
+  const instantiatedKeys = new Set(
+    (rulesQuery.data?.rules ?? [])
+      .map((rule) => rule.template_key)
+      .filter((key): key is string => key !== null),
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-muted-foreground">
+        Ready-made rules for the things most receivers are set up to catch.
+        Adding one creates a normal rule you can retune on the Rules tab.
+      </p>
+
+      {templatesQuery.isPending && (
+        <p className="text-sm text-muted-foreground">Loading templates…</p>
+      )}
+
+      {templatesQuery.isError && (
+        <p role="alert" className="text-sm text-destructive">
+          Could not load templates
+          {templatesQuery.error instanceof Error
+            ? `: ${templatesQuery.error.message}`
+            : "."}
+        </p>
+      )}
+
+      {templatesQuery.data && (
+        <ul className="flex flex-col gap-3">
+          {templatesQuery.data.templates.map((template) => (
+            <li key={template.key}>
+              <TemplateCard
+                template={template}
+                instantiated={instantiatedKeys.has(template.key)}
+                isPending={
+                  instantiateMutation.isPending && pendingKey === template.key
+                }
+                error={
+                  pendingKey === template.key
+                    ? errorMessage(instantiateMutation.error)
+                    : null
+                }
+                onAdd={() => {
+                  setPendingKey(template.key);
+                  instantiateMutation.mutate(template.key);
+                }}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/alerts/lib/conditions.test.ts
+++ b/frontend/src/features/alerts/lib/conditions.test.ts
@@ -76,7 +76,9 @@ describe("conditionsToDocument", () => {
   it("writes applies_on_ground only when it is asked for", () => {
     const drafts: ConditionDraft[] = [{ kind: "watchlist_any" }];
 
-    expect(conditionsToDocument(drafts, false).applies_on_ground).toBeUndefined();
+    expect(
+      conditionsToDocument(drafts, false).applies_on_ground,
+    ).toBeUndefined();
     expect(conditionsToDocument(drafts, true).applies_on_ground).toBe(true);
   });
 });
@@ -147,7 +149,10 @@ describe("documentToConditions", () => {
       type_code: "C17",
     });
 
-    expect(drafts.map((draft) => draft.kind)).toEqual(["type_code", "altitude"]);
+    expect(drafts.map((draft) => draft.kind)).toEqual([
+      "type_code",
+      "altitude",
+    ]);
   });
 
   it("reads an absent watchlist_any as no condition", () => {

--- a/frontend/src/features/alerts/lib/conditions.test.ts
+++ b/frontend/src/features/alerts/lib/conditions.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  availableKinds,
+  conditionsToDocument,
+  documentToConditions,
+  emptyCondition,
+  isRuleDraftValid,
+  validateCondition,
+  validateConditionList,
+  validateRuleDescription,
+  validateRuleName,
+  CONDITION_KINDS,
+  MAX_ALTITUDE_FT,
+  MAX_DISTANCE_NM,
+  MAX_NAME_LENGTH,
+  MAX_RARITY_THRESHOLD,
+  type ConditionDraft,
+} from "@/features/alerts/lib/conditions";
+import type { AlertRuleConditions } from "@/lib/api/alertRules";
+
+describe("conditionsToDocument", () => {
+  it("writes only the conditions that were added", () => {
+    const document = conditionsToDocument(
+      [{ kind: "type_code", text: " c17 " }],
+      false,
+    );
+
+    // An unset condition is an absent key, never a null or a zero — adding a
+    // condition kind in a later document version must not be able to change
+    // what an existing rule means.
+    expect(document).toEqual({ version: 1, type_code: "c17" });
+  });
+
+  it("splits a distance window into its two document fields", () => {
+    const document = conditionsToDocument(
+      [{ kind: "distance", min: "5", max: "40" }],
+      false,
+    );
+
+    expect(document.min_distance_nm).toBe(5);
+    expect(document.max_distance_nm).toBe(40);
+  });
+
+  it("leaves an open end of a window absent", () => {
+    const document = conditionsToDocument(
+      [{ kind: "altitude", min: "", max: "10000" }],
+      false,
+    );
+
+    expect(document.min_alt_ft).toBeUndefined();
+    expect(document.max_alt_ft).toBe(10000);
+  });
+
+  it("omits a classification's mission when none is required", () => {
+    const document = conditionsToDocument(
+      [
+        {
+          kind: "classification",
+          military: true,
+          government: false,
+          lawEnforcement: false,
+          mission: "",
+        },
+      ],
+      false,
+    );
+
+    expect(document.classification).toEqual({
+      military: true,
+      government: false,
+      law_enforcement: false,
+    });
+  });
+
+  it("writes applies_on_ground only when it is asked for", () => {
+    const drafts: ConditionDraft[] = [{ kind: "watchlist_any" }];
+
+    expect(conditionsToDocument(drafts, false).applies_on_ground).toBeUndefined();
+    expect(conditionsToDocument(drafts, true).applies_on_ground).toBe(true);
+  });
+});
+
+describe("documentToConditions", () => {
+  it("round-trips every condition kind this build can write", () => {
+    // The property the rule builder rests on: a rule can be opened, changed
+    // in one place and saved without the untouched conditions being reworded
+    // on the way through.
+    const document: AlertRuleConditions = {
+      version: 1,
+      classification: {
+        military: true,
+        government: false,
+        law_enforcement: true,
+        mission: "medical",
+      },
+      type_code: "C17",
+      model: "Globemaster",
+      watchlist_id: 3,
+      watchlist_any: true,
+      rare_aircraft: { max_sightings: 2 },
+      rare_type: { max_sightings: 4 },
+      min_distance_nm: 5,
+      max_distance_nm: 40,
+      min_alt_ft: 500,
+      max_alt_ft: 10000,
+      applies_on_ground: true,
+    };
+
+    const { drafts, appliesOnGround } = documentToConditions(document);
+
+    expect(appliesOnGround).toBe(true);
+    expect(conditionsToDocument(drafts, appliesOnGround)).toEqual(document);
+  });
+
+  it("covers every kind the builder offers", () => {
+    const document: AlertRuleConditions = {
+      version: 1,
+      classification: {
+        military: true,
+        government: false,
+        law_enforcement: false,
+      },
+      type_code: "C17",
+      model: "Globemaster",
+      watchlist_id: 3,
+      watchlist_any: true,
+      rare_aircraft: { max_sightings: 2 },
+      rare_type: { max_sightings: 4 },
+      max_distance_nm: 40,
+      max_alt_ft: 10000,
+    };
+
+    const kinds = documentToConditions(document).drafts.map(
+      (draft) => draft.kind,
+    );
+
+    expect(new Set(kinds)).toEqual(
+      new Set(CONDITION_KINDS.map((meta) => meta.kind)),
+    );
+  });
+
+  it("returns drafts in catalogue order whatever order the document lists", () => {
+    const { drafts } = documentToConditions({
+      version: 1,
+      max_alt_ft: 10000,
+      type_code: "C17",
+    });
+
+    expect(drafts.map((draft) => draft.kind)).toEqual(["type_code", "altitude"]);
+  });
+
+  it("reads an absent watchlist_any as no condition", () => {
+    const { drafts } = documentToConditions({ version: 1, type_code: "C17" });
+
+    expect(drafts.map((draft) => draft.kind)).toEqual(["type_code"]);
+  });
+});
+
+describe("availableKinds", () => {
+  it("offers every kind for an empty rule", () => {
+    expect(availableKinds([])).toHaveLength(CONDITION_KINDS.length);
+  });
+
+  it("stops offering a kind already in use", () => {
+    // The document is flat, so a second `type_code` would have nowhere to go.
+    const remaining = availableKinds([{ kind: "type_code", text: "C17" }]);
+
+    expect(remaining.map((meta) => meta.kind)).not.toContain("type_code");
+  });
+});
+
+describe("validateCondition", () => {
+  it("refuses a classification that requires nothing", () => {
+    expect(validateCondition(emptyCondition("classification"))).toMatch(
+      /at least one/i,
+    );
+  });
+
+  it("accepts a classification asking only for a mission", () => {
+    expect(
+      validateCondition({
+        kind: "classification",
+        military: false,
+        government: false,
+        lawEnforcement: false,
+        mission: "firefighting",
+      }),
+    ).toBeNull();
+  });
+
+  it("refuses blank text conditions", () => {
+    expect(validateCondition({ kind: "type_code", text: "  " })).not.toBeNull();
+    expect(validateCondition({ kind: "model", text: "" })).not.toBeNull();
+  });
+
+  it("refuses a watchlist condition with nothing chosen", () => {
+    expect(validateCondition(emptyCondition("watchlist"))).toMatch(/choose/i);
+  });
+
+  it("accepts 'on any watchlist', which has nothing to fill in", () => {
+    expect(validateCondition({ kind: "watchlist_any" })).toBeNull();
+  });
+
+  it.each([
+    ["", /enter a threshold/i],
+    ["0", /between 1 and/i],
+    ["1.5", /whole number/i],
+    ["abc", /whole number/i],
+    [String(MAX_RARITY_THRESHOLD + 1), /between 1 and/i],
+  ])("refuses the rarity threshold %j", (raw, expected) => {
+    expect(
+      validateCondition({ kind: "rare_aircraft", maxSightings: raw }),
+    ).toMatch(expected);
+  });
+
+  it("accepts a rarity threshold of 1 — never seen here before", () => {
+    expect(
+      validateCondition({ kind: "rare_type", maxSightings: "1" }),
+    ).toBeNull();
+  });
+
+  it("refuses a distance window with neither end", () => {
+    expect(validateCondition(emptyCondition("distance"))).toMatch(
+      /minimum, a maximum, or both/i,
+    );
+  });
+
+  it("refuses an inverted distance window, which can never match", () => {
+    expect(
+      validateCondition({ kind: "distance", min: "40", max: "10" }),
+    ).toMatch(/below the maximum/i);
+  });
+
+  it("refuses a distance beyond the bound the backend enforces", () => {
+    expect(
+      validateCondition({
+        kind: "distance",
+        min: "",
+        max: String(MAX_DISTANCE_NM + 1),
+      }),
+    ).toMatch(/at most/i);
+  });
+
+  it("refuses a zero maximum distance, which can never match", () => {
+    expect(validateCondition({ kind: "distance", min: "", max: "0" })).toMatch(
+      /above 0/i,
+    );
+  });
+
+  it("accepts an open-ended distance window", () => {
+    expect(
+      validateCondition({ kind: "distance", min: "", max: "40" }),
+    ).toBeNull();
+    expect(
+      validateCondition({ kind: "distance", min: "5", max: "" }),
+    ).toBeNull();
+  });
+
+  it("refuses an inverted altitude window", () => {
+    expect(
+      validateCondition({ kind: "altitude", min: "10000", max: "500" }),
+    ).toMatch(/below the ceiling/i);
+  });
+
+  it("refuses an altitude outside the bounds the backend enforces", () => {
+    expect(
+      validateCondition({
+        kind: "altitude",
+        min: "",
+        max: String(MAX_ALTITUDE_FT + 1),
+      }),
+    ).toMatch(/between/i);
+  });
+
+  it("accepts a negative floor, the Dead Sea being below sea level", () => {
+    expect(
+      validateCondition({ kind: "altitude", min: "-500", max: "1000" }),
+    ).toBeNull();
+  });
+});
+
+describe("rule-level validation", () => {
+  it("refuses a blank name", () => {
+    expect(validateRuleName("   ")).toMatch(/enter a name/i);
+  });
+
+  it("refuses an over-long name", () => {
+    expect(validateRuleName("x".repeat(MAX_NAME_LENGTH + 1))).toMatch(
+      /at most/i,
+    );
+  });
+
+  it("accepts an empty description", () => {
+    expect(validateRuleDescription("")).toBeNull();
+  });
+
+  it("refuses an empty condition list", () => {
+    // An empty condition set would match every aircraft in the sky at
+    // whatever severity it declared.
+    expect(validateConditionList([])).toMatch(/at least one condition/i);
+  });
+
+  it("is invalid while any single condition is", () => {
+    expect(
+      isRuleDraftValid("Rule", "", [{ kind: "type_code", text: "" }]),
+    ).toBe(false);
+  });
+
+  it("is valid once the name and every condition are", () => {
+    expect(
+      isRuleDraftValid("Rule", "", [{ kind: "type_code", text: "C17" }]),
+    ).toBe(true);
+  });
+});

--- a/frontend/src/features/alerts/lib/conditions.ts
+++ b/frontend/src/features/alerts/lib/conditions.ts
@@ -525,7 +525,10 @@ export function documentToConditions(conditions: AlertRuleConditions): {
       maxSightings: String(conditions.rare_type.max_sightings),
     });
   }
-  if (conditions.min_distance_nm != null || conditions.max_distance_nm != null) {
+  if (
+    conditions.min_distance_nm != null ||
+    conditions.max_distance_nm != null
+  ) {
     drafts.push({
       kind: "distance",
       min: numericText(conditions.min_distance_nm),

--- a/frontend/src/features/alerts/lib/conditions.ts
+++ b/frontend/src/features/alerts/lib/conditions.ts
@@ -1,0 +1,543 @@
+/**
+ * The rule builder's working model: one editable draft per condition, and
+ * the two conversions between a list of drafts and the flat
+ * `AlertRuleConditions` document the API stores (docs/DATA_MODEL.md §4.2).
+ *
+ * Why drafts rather than the document itself
+ * ------------------------------------------
+ *
+ * The stored document is a *flat record* of optional conditions combined with
+ * `AND` (SPEC §43 gives v1 no nested boolean trees). That is the right shape
+ * to store and the wrong shape to edit: a form bound directly to it would
+ * have to render every condition kind at once, most of them empty, and could
+ * not distinguish "no distance condition" from "a distance condition I have
+ * not finished typing". A list of drafts the user adds and removes is what
+ * makes the builder visual, and it makes the flatness enforceable — a kind
+ * already in the list is not offered again, because a second `type_code`
+ * has nowhere to go in the document.
+ *
+ * Two kinds here are one condition apiece but two document fields:
+ * `distance` writes `min_distance_nm`/`max_distance_nm` and `altitude`
+ * writes `min_alt_ft`/`max_alt_ft`. They are paired deliberately — a window
+ * is one idea to a user, and the backend validates the pair together
+ * (an inverted window can never match, so it is refused at write time). Two
+ * separate rows would put those halves where the inverted-window check
+ * cannot be shown against either of them.
+ *
+ * Validation mirrors, and does not replace, the backend
+ * ----------------------------------------------------
+ *
+ * Every bound below is the bound `flightsite.alerts.model` enforces, so a
+ * rule the builder accepts is one the API accepts and the roadmap's "builder
+ * prevents invalid rules" holds before a round trip is spent on it. The
+ * backend stays authoritative: its rejection is surfaced the same way a
+ * local one is, and this module is never consulted about a rule that already
+ * exists.
+ */
+import type {
+  AlertMissionCategory,
+  AlertRuleConditions,
+} from "@/lib/api/alertRules";
+
+/** Longest a rule name may be — `MAX_NAME_LENGTH` in `alerts/model.py`. */
+export const MAX_NAME_LENGTH = 120;
+/** Longest a rule description may be — `MAX_DESCRIPTION_LENGTH`. */
+export const MAX_DESCRIPTION_LENGTH = 500;
+/** Longest an ICAO type designator may be — `RuleConditions.type_code`. */
+export const MAX_TYPE_CODE_LENGTH = 16;
+/** Longest a model substring may be — `RuleConditions.model`. */
+export const MAX_MODEL_LENGTH = 120;
+/** Upper bound on a rarity threshold — `MAX_RARITY_THRESHOLD`. A
+ * receiver-relative "rare" count in the thousands is not rarity, it is every
+ * aircraft. */
+export const MAX_RARITY_THRESHOLD = 1000;
+/** Upper bound on a distance condition, in nautical miles —
+ * `MAX_DISTANCE_NM`. */
+export const MAX_DISTANCE_NM = 10000;
+/** Bounds on an altitude condition, in feet — `MIN_ALTITUDE_FT` /
+ * `MAX_ALTITUDE_FT`. Both exist to catch a typo (a user meaning metres, or a
+ * stray digit) rather than to express a real aviation limit. */
+export const MIN_ALTITUDE_FT = -2000;
+export const MAX_ALTITUDE_FT = 100000;
+
+/**
+ * The condition kinds the builder offers, which together cover every member
+ * of the v1 document.
+ *
+ * `watchlist` and `watchlist_any` are separate kinds because they are
+ * separate document fields answering different questions — "on *this* list"
+ * versus "on any list at all" — and a first-run template can only ask the
+ * second, having no list to name yet.
+ */
+export type ConditionKind =
+  | "classification"
+  | "type_code"
+  | "model"
+  | "watchlist"
+  | "watchlist_any"
+  | "rare_aircraft"
+  | "rare_type"
+  | "distance"
+  | "altitude";
+
+export interface ClassificationConditionDraft {
+  kind: "classification";
+  military: boolean;
+  government: boolean;
+  lawEnforcement: boolean;
+  /** `""` for "no mission requirement". */
+  mission: AlertMissionCategory | "";
+}
+
+export interface TextConditionDraft {
+  kind: "type_code" | "model";
+  text: string;
+}
+
+export interface WatchlistConditionDraft {
+  kind: "watchlist";
+  /** The chosen watchlist's id as a string, `""` while none is chosen — a
+   * `<select>`'s value is always a string. */
+  watchlistId: string;
+}
+
+export interface WatchlistAnyConditionDraft {
+  kind: "watchlist_any";
+}
+
+export interface RarityConditionDraft {
+  kind: "rare_aircraft" | "rare_type";
+  maxSightings: string;
+}
+
+/** A `distance` (nm) or `altitude` (ft) window. Either bound may be left
+ * blank for an open-ended one; both blank is not a condition. */
+export interface RangeConditionDraft {
+  kind: "distance" | "altitude";
+  min: string;
+  max: string;
+}
+
+export type ConditionDraft =
+  | ClassificationConditionDraft
+  | TextConditionDraft
+  | WatchlistConditionDraft
+  | WatchlistAnyConditionDraft
+  | RarityConditionDraft
+  | RangeConditionDraft;
+
+export interface ConditionKindMeta {
+  kind: ConditionKind;
+  /** The name the "Add condition" picker and the condition's own legend
+   * show. */
+  label: string;
+  /** One line saying what the condition asks, shown under the legend so the
+   * builder explains itself without a manual. */
+  summary: string;
+}
+
+/** Every kind, in the order the builder offers and re-renders them. Broadly
+ * "what the aircraft is" before "where it is", which is the order the
+ * conditions read in as a sentence. */
+export const CONDITION_KINDS: ConditionKindMeta[] = [
+  {
+    kind: "classification",
+    label: "Classification",
+    summary:
+      "Require what the aircraft is: military, government, law enforcement, or a mission category (SPEC §39).",
+  },
+  {
+    kind: "type_code",
+    label: "Type code",
+    summary:
+      "Match one ICAO type designator exactly, ignoring case — for example C17.",
+  },
+  {
+    kind: "model",
+    label: "Model",
+    summary:
+      "Match part of the model name, ignoring case — 'Globemaster' matches 'Boeing C-17A Globemaster III'.",
+  },
+  {
+    kind: "watchlist",
+    label: "On a watchlist",
+    summary: "Require membership of one specific watchlist.",
+  },
+  {
+    kind: "watchlist_any",
+    label: "On any watchlist",
+    summary: "Require membership of any watchlist at all.",
+  },
+  {
+    kind: "rare_aircraft",
+    label: "Rare airframe",
+    summary:
+      "Require that this receiver has recorded the airframe at most this many times, the current sighting included. 1 means never seen here before.",
+  },
+  {
+    kind: "rare_type",
+    label: "Rare type",
+    summary:
+      "Require that this receiver has recorded the aircraft's type on at most this many different airframes.",
+  },
+  {
+    kind: "distance",
+    label: "Distance",
+    summary:
+      "Require the aircraft to be within a distance window of the receiver, in nautical miles.",
+  },
+  {
+    kind: "altitude",
+    label: "Altitude",
+    summary: "Require the aircraft to be in an altitude window, in feet.",
+  },
+];
+
+const KIND_META: Record<ConditionKind, ConditionKindMeta> = Object.fromEntries(
+  CONDITION_KINDS.map((meta) => [meta.kind, meta]),
+) as Record<ConditionKind, ConditionKindMeta>;
+
+export function conditionKindMeta(kind: ConditionKind): ConditionKindMeta {
+  return KIND_META[kind];
+}
+
+/** A blank draft of `kind`, as the "Add condition" button produces it. */
+export function emptyCondition(kind: ConditionKind): ConditionDraft {
+  switch (kind) {
+    case "classification":
+      return {
+        kind,
+        military: false,
+        government: false,
+        lawEnforcement: false,
+        mission: "",
+      };
+    case "type_code":
+    case "model":
+      return { kind, text: "" };
+    case "watchlist":
+      return { kind, watchlistId: "" };
+    case "watchlist_any":
+      return { kind };
+    case "rare_aircraft":
+    case "rare_type":
+      return { kind, maxSightings: "" };
+    case "distance":
+    case "altitude":
+      return { kind, min: "", max: "" };
+  }
+}
+
+/**
+ * The kinds not yet used, in catalogue order.
+ *
+ * The document is flat, so each kind can appear at most once — this is what
+ * makes that visible in the UI rather than discovered when a second
+ * `type_code` silently overwrites the first.
+ */
+export function availableKinds(
+  drafts: readonly ConditionDraft[],
+): ConditionKindMeta[] {
+  const used = new Set(drafts.map((draft) => draft.kind));
+  return CONDITION_KINDS.filter((meta) => !used.has(meta.kind));
+}
+
+/** `null` for a blank field, `NaN` for something that is not a number, the
+ * number otherwise — so a caller can tell "not filled in" from "filled in
+ * wrongly" and say something different about each. */
+function parseNumeric(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const value = Number(trimmed);
+  return Number.isFinite(value) ? value : Number.NaN;
+}
+
+function validateRarity(raw: string): string | null {
+  const value = parseNumeric(raw);
+  if (value === null) {
+    return "Enter a threshold.";
+  }
+  if (Number.isNaN(value) || !Number.isInteger(value)) {
+    return "Enter a whole number.";
+  }
+  if (value < 1 || value > MAX_RARITY_THRESHOLD) {
+    return `Enter a threshold between 1 and ${MAX_RARITY_THRESHOLD}.`;
+  }
+  return null;
+}
+
+function validateDistance(draft: RangeConditionDraft): string | null {
+  const min = parseNumeric(draft.min);
+  const max = parseNumeric(draft.max);
+  if (min === null && max === null) {
+    return "Enter a minimum, a maximum, or both.";
+  }
+  if (Number.isNaN(min) || Number.isNaN(max)) {
+    return "Enter distances in nautical miles.";
+  }
+  if (min !== null && (min < 0 || min > MAX_DISTANCE_NM)) {
+    return `A minimum distance must be between 0 and ${MAX_DISTANCE_NM} nm.`;
+  }
+  if (max !== null && (max <= 0 || max > MAX_DISTANCE_NM)) {
+    return `A maximum distance must be above 0 and at most ${MAX_DISTANCE_NM} nm.`;
+  }
+  if (min !== null && max !== null && min >= max) {
+    return "The minimum must be below the maximum, or the rule can never match.";
+  }
+  return null;
+}
+
+function validateAltitude(draft: RangeConditionDraft): string | null {
+  const min = parseNumeric(draft.min);
+  const max = parseNumeric(draft.max);
+  if (min === null && max === null) {
+    return "Enter a floor, a ceiling, or both.";
+  }
+  if (Number.isNaN(min) || Number.isNaN(max)) {
+    return "Enter altitudes in feet.";
+  }
+  const outOfRange = (value: number): boolean =>
+    value < MIN_ALTITUDE_FT || value > MAX_ALTITUDE_FT;
+  if ((min !== null && outOfRange(min)) || (max !== null && outOfRange(max))) {
+    return `Altitudes must be between ${MIN_ALTITUDE_FT} and ${MAX_ALTITUDE_FT} ft.`;
+  }
+  if (min !== null && max !== null && min >= max) {
+    return "The floor must be below the ceiling, or the rule can never match.";
+  }
+  return null;
+}
+
+/** What is wrong with one condition, or `null` when it is ready to send. */
+export function validateCondition(draft: ConditionDraft): string | null {
+  switch (draft.kind) {
+    case "classification":
+      if (
+        !draft.military &&
+        !draft.government &&
+        !draft.lawEnforcement &&
+        draft.mission === ""
+      ) {
+        return "Require at least one of military, government, law enforcement, or a mission.";
+      }
+      return null;
+    case "type_code": {
+      const text = draft.text.trim();
+      if (text.length === 0) {
+        return "Enter a type designator.";
+      }
+      if (text.length > MAX_TYPE_CODE_LENGTH) {
+        return `A type designator is at most ${MAX_TYPE_CODE_LENGTH} characters.`;
+      }
+      return null;
+    }
+    case "model": {
+      const text = draft.text.trim();
+      if (text.length === 0) {
+        return "Enter part of a model name.";
+      }
+      if (text.length > MAX_MODEL_LENGTH) {
+        return `A model substring is at most ${MAX_MODEL_LENGTH} characters.`;
+      }
+      return null;
+    }
+    case "watchlist":
+      return draft.watchlistId === "" ? "Choose a watchlist." : null;
+    case "watchlist_any":
+      return null;
+    case "rare_aircraft":
+    case "rare_type":
+      return validateRarity(draft.maxSightings);
+    case "distance":
+      return validateDistance(draft);
+    case "altitude":
+      return validateAltitude(draft);
+  }
+}
+
+/** What is wrong with the rule's name, or `null`. */
+export function validateRuleName(raw: string): string | null {
+  const name = raw.trim();
+  if (name.length === 0) {
+    return "Enter a name.";
+  }
+  if (name.length > MAX_NAME_LENGTH) {
+    return `A name is at most ${MAX_NAME_LENGTH} characters.`;
+  }
+  return null;
+}
+
+/** What is wrong with the rule's description, or `null`. */
+export function validateRuleDescription(raw: string): string | null {
+  return raw.trim().length > MAX_DESCRIPTION_LENGTH
+    ? `A description is at most ${MAX_DESCRIPTION_LENGTH} characters.`
+    : null;
+}
+
+/**
+ * Why the condition list as a whole cannot be sent, or `null`.
+ *
+ * The empty case is a rule, not a nitpick: a condition set that constrains
+ * nothing would match every aircraft in the sky at whatever severity it
+ * declared, which is the one configuration a user can never have meant. The
+ * backend refuses it for the same reason.
+ */
+export function validateConditionList(
+  drafts: readonly ConditionDraft[],
+): string | null {
+  return drafts.length === 0
+    ? "Add at least one condition. A rule with none would match every aircraft."
+    : null;
+}
+
+/** Whether every part of the rule is ready to send. */
+export function isRuleDraftValid(
+  name: string,
+  description: string,
+  drafts: readonly ConditionDraft[],
+): boolean {
+  return (
+    validateRuleName(name) === null &&
+    validateRuleDescription(description) === null &&
+    validateConditionList(drafts) === null &&
+    drafts.every((draft) => validateCondition(draft) === null)
+  );
+}
+
+/** A numeric field's value for the document: the parsed number, or
+ * `undefined` when the field was left blank. Assumes the draft has passed
+ * {@link validateCondition}. */
+function numberOrUndefined(raw: string): number | undefined {
+  const value = parseNumeric(raw);
+  return value === null || Number.isNaN(value) ? undefined : value;
+}
+
+/**
+ * The stored document these drafts describe.
+ *
+ * Only the conditions the user actually added appear: an unset condition is
+ * an absent key, never a `null` or a zero, so adding a condition kind in a
+ * later document version cannot change what an existing rule means.
+ */
+export function conditionsToDocument(
+  drafts: readonly ConditionDraft[],
+  appliesOnGround: boolean,
+): AlertRuleConditions {
+  const document: AlertRuleConditions = { version: 1 };
+  for (const draft of drafts) {
+    switch (draft.kind) {
+      case "classification":
+        document.classification = {
+          military: draft.military,
+          government: draft.government,
+          law_enforcement: draft.lawEnforcement,
+          ...(draft.mission === "" ? {} : { mission: draft.mission }),
+        };
+        break;
+      case "type_code":
+        document.type_code = draft.text.trim();
+        break;
+      case "model":
+        document.model = draft.text.trim();
+        break;
+      case "watchlist":
+        document.watchlist_id = Number(draft.watchlistId);
+        break;
+      case "watchlist_any":
+        document.watchlist_any = true;
+        break;
+      case "rare_aircraft":
+        document.rare_aircraft = { max_sightings: Number(draft.maxSightings) };
+        break;
+      case "rare_type":
+        document.rare_type = { max_sightings: Number(draft.maxSightings) };
+        break;
+      case "distance":
+        document.min_distance_nm = numberOrUndefined(draft.min);
+        document.max_distance_nm = numberOrUndefined(draft.max);
+        break;
+      case "altitude":
+        document.min_alt_ft = numberOrUndefined(draft.min);
+        document.max_alt_ft = numberOrUndefined(draft.max);
+        break;
+    }
+  }
+  if (appliesOnGround) {
+    document.applies_on_ground = true;
+  }
+  return document;
+}
+
+function numericText(value: number | null | undefined): string {
+  return value === null || value === undefined ? "" : String(value);
+}
+
+/**
+ * The drafts a stored document describes, for editing an existing rule.
+ *
+ * The inverse of {@link conditionsToDocument} over every document this build
+ * can write, which is what lets a rule be opened, changed in one place and
+ * saved without the untouched conditions being reworded on the way through.
+ * Drafts come back in {@link CONDITION_KINDS} order rather than in whatever
+ * order the JSON happened to serialize, so the same rule always presents the
+ * same way.
+ */
+export function documentToConditions(conditions: AlertRuleConditions): {
+  drafts: ConditionDraft[];
+  appliesOnGround: boolean;
+} {
+  const drafts: ConditionDraft[] = [];
+  const classification = conditions.classification;
+  if (classification) {
+    drafts.push({
+      kind: "classification",
+      military: classification.military,
+      government: classification.government,
+      lawEnforcement: classification.law_enforcement,
+      mission: classification.mission ?? "",
+    });
+  }
+  if (conditions.type_code != null) {
+    drafts.push({ kind: "type_code", text: conditions.type_code });
+  }
+  if (conditions.model != null) {
+    drafts.push({ kind: "model", text: conditions.model });
+  }
+  if (conditions.watchlist_id != null) {
+    drafts.push({
+      kind: "watchlist",
+      watchlistId: String(conditions.watchlist_id),
+    });
+  }
+  if (conditions.watchlist_any === true) {
+    drafts.push({ kind: "watchlist_any" });
+  }
+  if (conditions.rare_aircraft) {
+    drafts.push({
+      kind: "rare_aircraft",
+      maxSightings: String(conditions.rare_aircraft.max_sightings),
+    });
+  }
+  if (conditions.rare_type) {
+    drafts.push({
+      kind: "rare_type",
+      maxSightings: String(conditions.rare_type.max_sightings),
+    });
+  }
+  if (conditions.min_distance_nm != null || conditions.max_distance_nm != null) {
+    drafts.push({
+      kind: "distance",
+      min: numericText(conditions.min_distance_nm),
+      max: numericText(conditions.max_distance_nm),
+    });
+  }
+  if (conditions.min_alt_ft != null || conditions.max_alt_ft != null) {
+    drafts.push({
+      kind: "altitude",
+      min: numericText(conditions.min_alt_ft),
+      max: numericText(conditions.max_alt_ft),
+    });
+  }
+  return { drafts, appliesOnGround: conditions.applies_on_ground === true };
+}

--- a/frontend/src/features/alerts/lib/vocabulary.ts
+++ b/frontend/src/features/alerts/lib/vocabulary.ts
@@ -1,0 +1,84 @@
+/**
+ * Static catalogues the Alerts page renders: the severity ladder, the
+ * mission categories a classification condition may require, and the
+ * built-in detector keys the history can show.
+ *
+ * Data, not logic, and keyed rather than listed wherever a lookup happens,
+ * so `noUncheckedIndexedAccess` never forces a fallback for a value the type
+ * system already knows is present — the shape `features/watchlists/lib/
+ * vocabulary.ts` established.
+ */
+import type { AlertSeverity } from "@/lib/api/sightings";
+import type { AlertMissionCategory } from "@/lib/api/alertRules";
+
+export interface SeverityOption {
+  value: AlertSeverity;
+  label: string;
+  /** What choosing this level means, in SPEC §46's terms. Shown beside the
+   * selector so a user picks a level by its consequence rather than by
+   * guessing at a word's rank. */
+  hint: string;
+}
+
+/** The four levels of §2.8's ladder, lowest first — the order SPEC §46
+ * states them in, and the order a selector should offer them. */
+export const SEVERITY_OPTIONS: SeverityOption[] = [
+  {
+    value: "info",
+    label: "Info",
+    hint: "Worth recording. Happens often on a new receiver.",
+  },
+  {
+    value: "interesting",
+    label: "Interesting",
+    hint: "Worth a glance when you are already looking.",
+  },
+  {
+    value: "high",
+    label: "High",
+    hint: "Worth interrupting for — military, government, police.",
+  },
+  {
+    value: "critical",
+    label: "Critical",
+    hint: "Emergencies. Reserve this for things that cannot wait.",
+  },
+];
+
+export interface MissionOption {
+  value: AlertMissionCategory;
+  label: string;
+}
+
+/** The mission categories a rule may require. `unknown` is deliberately
+ * absent — the backend refuses it, because a rule matching every airframe no
+ * metadata source has heard of would be a rule about FlightSite's ignorance
+ * rather than about aircraft. */
+export const MISSION_OPTIONS: MissionOption[] = [
+  { value: "commercial_passenger", label: "Commercial passenger" },
+  { value: "cargo", label: "Cargo" },
+  { value: "general_aviation", label: "General aviation" },
+  { value: "business_aviation", label: "Business aviation" },
+  { value: "military", label: "Military" },
+  { value: "government", label: "Government" },
+  { value: "law_enforcement", label: "Law enforcement" },
+  { value: "medical", label: "Medical" },
+  { value: "firefighting", label: "Firefighting" },
+  { value: "training", label: "Training" },
+  { value: "helicopter", label: "Helicopter" },
+];
+
+/** What each built-in detector key means, for a history row that has no rule
+ * to name (SPEC §47). Mirrors
+ * `flightsite.alerts.vocabulary.EMERGENCY_MEANINGS`. */
+export const BUILTIN_KEY_LABELS: Record<string, string> = {
+  emergency_7500: "Squawk 7500 — unlawful interference",
+  emergency_7600: "Squawk 7600 — radio failure",
+  emergency_7700: "Squawk 7700 — general emergency",
+};
+
+/** A readable name for a built-in detector, falling back to the raw key so a
+ * newer backend's detector still renders as something rather than blank. */
+export function builtinKeyLabel(key: string): string {
+  return BUILTIN_KEY_LABELS[key] ?? key;
+}

--- a/frontend/src/lib/api/alertMatches.ts
+++ b/frontend/src/lib/api/alertMatches.ts
@@ -1,0 +1,137 @@
+/**
+ * Typed client for the alert match history — `GET /api/v1/alerts/matches`
+ * (docs/API.md §3.9, SPEC §43 to §48, roadmap slices 038/041).
+ *
+ * Reuses the `apiV1Fetch` pattern `lib/api/activity.ts` established for the
+ * external `/api/v1` surface's `{"error": {...}}` envelope (§2.5) —
+ * duplicated rather than imported so this module stays a self-contained read
+ * of one small file, the same call `lib/api/sightings.ts` makes.
+ *
+ * History is a *record*, not a re-derivation: `reason` is the text recorded
+ * when the match happened, so the history keeps saying what the user was
+ * actually shown even after the rule behind it is renamed or retuned. This
+ * client therefore never recomposes a row from the current rule set.
+ */
+import {
+  keepPreviousData,
+  useQuery,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+
+import type { AlertSeverity } from "@/lib/api/sightings";
+
+/** The rule an alert match names. `null` on the match itself for a built-in
+ * emergency detection, which fires without any rule at all (SPEC §47). */
+export interface AlertMatchRuleRef {
+  id: number;
+  /** `null` only if the rule row vanished between the match and this read. */
+  name: string | null;
+}
+
+export interface AlertMatch {
+  id: number;
+  /** UTC ISO-8601 with a `Z` suffix and millisecond precision (§2.2). */
+  at: string;
+  severity: AlertSeverity;
+  reason: string;
+  icao: string;
+  sighting_id: number;
+  /** `null` for a built-in emergency match. */
+  rule: AlertMatchRuleRef | null;
+  /** `null` for a rule match; a built-in detector's key (e.g.
+   * `"emergency_7700"`) otherwise. */
+  builtin_key: string | null;
+  /** Whether a browser notification has been delivered for this match. */
+  notified: boolean;
+}
+
+export interface AlertMatchListResponse {
+  items: AlertMatch[];
+  /** Always `null` — the history grows without bound over a multi-year
+   * install, so §2.4's allowance to omit an exact filtered count applies and
+   * a client pages until a page comes back short of `limit`. */
+  total: number | null;
+  limit: number;
+  offset: number;
+}
+
+interface ApiV1ErrorBody {
+  error?: { code?: string; message?: string; detail?: unknown };
+}
+
+/** Thrown for any non-2xx response. `code` is the §2.5 machine-readable
+ * slug, `null` when the response did not carry the documented envelope. */
+export class AlertMatchesApiError extends Error {
+  readonly status: number;
+  readonly code: string | null;
+
+  constructor(status: number, body: ApiV1ErrorBody | undefined) {
+    super(body?.error?.message ?? `Request failed with status ${status}`);
+    this.name = "AlertMatchesApiError";
+    this.status = status;
+    this.code = body?.error?.code ?? null;
+  }
+}
+
+async function apiV1Fetch<T>(path: string): Promise<T> {
+  const response = await fetch(path);
+  if (!response.ok) {
+    let body: ApiV1ErrorBody | undefined;
+    try {
+      body = (await response.json()) as ApiV1ErrorBody;
+    } catch {
+      body = undefined;
+    }
+    throw new AlertMatchesApiError(response.status, body);
+  }
+  return (await response.json()) as T;
+}
+
+export interface AlertMatchListParams {
+  limit: number;
+  offset: number;
+  /** Restrict to one severity of the §2.8 ladder. */
+  severity?: AlertSeverity;
+  /** Restrict to one airframe, as lower-case ICAO hex (§2.9). */
+  icao?: string;
+}
+
+function query(params: AlertMatchListParams): string {
+  const search = new URLSearchParams({
+    limit: String(params.limit),
+    offset: String(params.offset),
+  });
+  if (params.severity !== undefined) {
+    search.set("severity", params.severity);
+  }
+  if (params.icao !== undefined) {
+    search.set("icao", params.icao);
+  }
+  return search.toString();
+}
+
+export function getAlertMatches(
+  params: AlertMatchListParams,
+): Promise<AlertMatchListResponse> {
+  return apiV1Fetch<AlertMatchListResponse>(
+    `/api/v1/alerts/matches?${query(params)}`,
+  );
+}
+
+export const alertMatchesQueryKeys = {
+  list: (params: AlertMatchListParams) =>
+    ["alert-matches", "list", params] as const,
+};
+
+/** One page of the history. `placeholderData: keepPreviousData` keeps the
+ * rows on screen while the next page loads, so paging or changing the
+ * severity filter does not blank the table between answers. */
+export function useAlertMatchesQuery(
+  params: AlertMatchListParams,
+): UseQueryResult<AlertMatchListResponse> {
+  return useQuery({
+    queryKey: alertMatchesQueryKeys.list(params),
+    queryFn: () => getAlertMatches(params),
+    placeholderData: keepPreviousData,
+  });
+}

--- a/frontend/src/lib/api/alertRules.ts
+++ b/frontend/src/lib/api/alertRules.ts
@@ -163,7 +163,9 @@ export function getAlertTemplates(): Promise<AlertTemplatesListResponse> {
   return apiFetch<AlertTemplatesListResponse>(TEMPLATES_PATH);
 }
 
-export function createAlertRule(input: AlertRuleWriteInput): Promise<AlertRule> {
+export function createAlertRule(
+  input: AlertRuleWriteInput,
+): Promise<AlertRule> {
   return apiFetch<AlertRule>(RULES_PATH, {
     method: "POST",
     headers: JSON_HEADERS,

--- a/frontend/src/lib/api/alertRules.ts
+++ b/frontend/src/lib/api/alertRules.ts
@@ -1,0 +1,284 @@
+/**
+ * Typed client for `/api/internal/alert-rules*` and `/alert-templates*`
+ * (docs/API.md §5, roadmap slices 038/041). Shapes mirror the payloads
+ * `backend/src/flightsite/api/alert_rules.py` builds — see its
+ * `_rule_payload` / `_template_payload`.
+ *
+ * The condition document is the part worth reading carefully. The backend
+ * validates it with the very model the *stored* document is parsed with
+ * (`flightsite.alerts.model.RuleConditions`), so a document this client sends
+ * and one it reads back are the same shape, and a rule the API accepts is by
+ * construction one the engine can evaluate. That is what makes slice 041's
+ * round-trip property ("rules created in the UI evaluate identically to
+ * API-created rules") hold without this file re-deriving any of it.
+ *
+ * Optional members are written `?: T | null` rather than `?: T` because the
+ * backend dumps with `exclude_none=True`: an unset condition is an *absent*
+ * key on the way out, and either an absent key or an explicit `null` is
+ * accepted on the way in.
+ */
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+
+import { apiFetch } from "@/lib/api/client";
+import type { AlertSeverity } from "@/lib/api/sightings";
+
+/** The mission categories a classification condition may require, spelled
+ * exactly as `flightsite.classification.vocabulary.MissionCategory` does.
+ * `unknown` is deliberately absent: the backend refuses it, because a rule
+ * matching every airframe no metadata source has heard of would be a rule
+ * about FlightSite's ignorance rather than about aircraft. */
+export type AlertMissionCategory =
+  | "commercial_passenger"
+  | "cargo"
+  | "general_aviation"
+  | "business_aviation"
+  | "military"
+  | "government"
+  | "law_enforcement"
+  | "medical"
+  | "firefighting"
+  | "training"
+  | "helicopter";
+
+/** SPEC §39 classification requirements. The three flags are requirements,
+ * never negations — `military: true` means "must be military" and
+ * `military: false` means "do not care". There is no way to say "must not
+ * be", because that is a boolean `NOT` and SPEC §43 limits v1 to `AND` over
+ * positive conditions. */
+export interface AlertClassificationCondition {
+  military: boolean;
+  government: boolean;
+  law_enforcement: boolean;
+  mission?: AlertMissionCategory | null;
+}
+
+/** A receiver-relative rarity threshold (SPEC §44). `max_sightings` is
+ * inclusive, so `1` is exactly "never seen here before". */
+export interface AlertRarityCondition {
+  max_sightings: number;
+}
+
+/**
+ * One rule's `AND`-combined condition set (docs/DATA_MODEL.md §4.2).
+ *
+ * Flat, with every member optional, because SPEC §43 gives v1 no nested
+ * boolean trees: every condition present must hold. `version` is the
+ * document's forward door and this build reads and writes `1` only.
+ */
+export interface AlertRuleConditions {
+  version: 1;
+  classification?: AlertClassificationCondition | null;
+  /** Exact match on the resolved ICAO type designator, case-insensitively. */
+  type_code?: string | null;
+  /** Case-insensitive *substring* of the resolved model name — the stored
+   * value is registry prose ("Boeing C-17A Globemaster III"), so a user
+   * means "Globemaster", not that string character for character. */
+  model?: string | null;
+  /** Membership of one specific watchlist, by id. */
+  watchlist_id?: number | null;
+  /** Membership of *any* watchlist. Exists beside `watchlist_id` because a
+   * template instantiated at first run has no watchlist to name yet. */
+  watchlist_any?: boolean;
+  rare_aircraft?: AlertRarityCondition | null;
+  rare_type?: AlertRarityCondition | null;
+  max_distance_nm?: number | null;
+  min_distance_nm?: number | null;
+  max_alt_ft?: number | null;
+  min_alt_ft?: number | null;
+  /** Whether the rule also applies to aircraft the decoder reports on the
+   * ground. `false` — the default — is SPEC §40's "excluded from relevant
+   * alerts". Not itself a condition: a rule that says only this matches
+   * nothing, and the backend refuses it. */
+  applies_on_ground?: boolean;
+}
+
+export interface AlertRule {
+  id: number;
+  name: string;
+  description: string | null;
+  severity: AlertSeverity;
+  enabled: boolean;
+  /** `null` for a user-written rule; the shipped template's key for one that
+   * came from the gallery or from first-run instantiation. Provenance is not
+   * replaceable — tuning a shipped rule does not make it stop having been
+   * shipped. */
+  template_key: string | null;
+  conditions: AlertRuleConditions;
+  /** The rule stated in prose, one phrase per condition, composed by the
+   * backend's `RuleConditions.describe()`. Rendered as-is so every client
+   * says the same thing about a rule rather than re-implementing it. */
+  describes: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+/** One shipped template (SPEC §45). `builtin` is the field that matters: a
+ * built-in template describes behaviour that is already on and cannot be
+ * turned off (SPEC §47's emergency squawks), so its `conditions` are `null`
+ * because there is no rule to create. */
+export interface AlertTemplate {
+  key: string;
+  name: string;
+  description: string;
+  severity: AlertSeverity;
+  builtin: boolean;
+  conditions: AlertRuleConditions | null;
+}
+
+export interface AlertRulesListResponse {
+  rules: AlertRule[];
+}
+
+export interface AlertTemplatesListResponse {
+  templates: AlertTemplate[];
+}
+
+/** `POST` and `PUT` body. One shape for both, because `PUT` is a full
+ * replace rather than a patch — a partial update of an `AND` condition set
+ * is ambiguous about whether an omitted condition was meant to be removed. */
+export interface AlertRuleWriteInput {
+  name: string;
+  description: string | null;
+  severity: AlertSeverity;
+  conditions: AlertRuleConditions;
+  enabled: boolean;
+}
+
+const RULES_PATH = "/api/internal/alert-rules";
+const TEMPLATES_PATH = "/api/internal/alert-templates";
+
+const JSON_HEADERS = { "Content-Type": "application/json" };
+
+export function getAlertRules(): Promise<AlertRulesListResponse> {
+  return apiFetch<AlertRulesListResponse>(RULES_PATH);
+}
+
+export function getAlertTemplates(): Promise<AlertTemplatesListResponse> {
+  return apiFetch<AlertTemplatesListResponse>(TEMPLATES_PATH);
+}
+
+export function createAlertRule(input: AlertRuleWriteInput): Promise<AlertRule> {
+  return apiFetch<AlertRule>(RULES_PATH, {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify(input),
+  });
+}
+
+export function updateAlertRule(
+  ruleId: number,
+  input: AlertRuleWriteInput,
+): Promise<AlertRule> {
+  return apiFetch<AlertRule>(`${RULES_PATH}/${ruleId}`, {
+    method: "PUT",
+    headers: JSON_HEADERS,
+    body: JSON.stringify(input),
+  });
+}
+
+export function deleteAlertRule(ruleId: number): Promise<void> {
+  return apiFetch<void>(`${RULES_PATH}/${ruleId}`, { method: "DELETE" });
+}
+
+/** Turns one shipped template into a rule carrying its `template_key`. The
+ * body is empty on purpose: the conditions and severity come from the
+ * backend's catalogue, never from here, so provenance stays a statement the
+ * server makes rather than a claim a client attaches. */
+export function instantiateAlertTemplate(key: string): Promise<AlertRule> {
+  return apiFetch<AlertRule>(`${TEMPLATES_PATH}/${key}/rules`, {
+    method: "POST",
+  });
+}
+
+/** Query key for the rule list. */
+export const alertRulesQueryKey = ["alert-rules"] as const;
+
+/** Query key for the shipped-template catalogue. */
+export const alertTemplatesQueryKey = ["alert-templates"] as const;
+
+export function useAlertRulesQuery(): UseQueryResult<AlertRulesListResponse> {
+  return useQuery({ queryKey: alertRulesQueryKey, queryFn: getAlertRules });
+}
+
+/** The shipped catalogue is static data compiled into the backend — it
+ * cannot change while the app is running — so it is never refetched for
+ * staleness. What *does* change is which templates have been instantiated,
+ * and that is read from the rule list's `template_key`, not from here. */
+export function useAlertTemplatesQuery(): UseQueryResult<AlertTemplatesListResponse> {
+  return useQuery({
+    queryKey: alertTemplatesQueryKey,
+    queryFn: getAlertTemplates,
+    staleTime: Infinity,
+  });
+}
+
+/** Every rule mutation invalidates the rule list, so no consumer has to
+ * remember to refetch: the list is what the rules tab renders *and* what the
+ * template gallery reads to decide which templates are already instantiated. */
+function invalidateAlertRules(
+  queryClient: ReturnType<typeof useQueryClient>,
+): void {
+  void queryClient.invalidateQueries({ queryKey: alertRulesQueryKey });
+}
+
+export function useCreateAlertRuleMutation(): UseMutationResult<
+  AlertRule,
+  Error,
+  AlertRuleWriteInput
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createAlertRule,
+    onSuccess: () => {
+      invalidateAlertRules(queryClient);
+    },
+  });
+}
+
+export function useUpdateAlertRuleMutation(): UseMutationResult<
+  AlertRule,
+  Error,
+  { ruleId: number; input: AlertRuleWriteInput }
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ ruleId, input }) => updateAlertRule(ruleId, input),
+    onSuccess: () => {
+      invalidateAlertRules(queryClient);
+    },
+  });
+}
+
+export function useDeleteAlertRuleMutation(): UseMutationResult<
+  void,
+  Error,
+  number
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteAlertRule,
+    onSuccess: () => {
+      invalidateAlertRules(queryClient);
+    },
+  });
+}
+
+export function useInstantiateAlertTemplateMutation(): UseMutationResult<
+  AlertRule,
+  Error,
+  string
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: instantiateAlertTemplate,
+    onSuccess: () => {
+      invalidateAlertRules(queryClient);
+    },
+  });
+}

--- a/frontend/src/pages/AlertsPage.test.tsx
+++ b/frontend/src/pages/AlertsPage.test.tsx
@@ -1,21 +1,40 @@
-import { screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AlertsPage } from "@/pages/AlertsPage";
-import { renderWithProviders } from "@/test/test-utils";
-import { installWatchlistsApiMock, watchlist } from "@/test/watchlistsApiMock";
+import { alertMatch, alertRule, installAlertsApiMock } from "@/test/alertsApiMock";
+import { watchlist } from "@/test/watchlistsApiMock";
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
+/** The History tab links an airframe, so the page needs a router as well as
+ * a query client. */
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <AlertsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
 describe("AlertsPage", () => {
-  it("renders the page heading and the Watchlists area", async () => {
-    installWatchlistsApiMock({
+  it("renders the page heading and opens on the Watchlists area", async () => {
+    installAlertsApiMock({
       watchlists: [watchlist({ name: "Police Helicopters" })],
     });
 
-    renderWithProviders(<AlertsPage />);
+    renderPage();
 
     expect(
       screen.getByRole("heading", { level: 1, name: "Alerts" }),
@@ -23,16 +42,59 @@ describe("AlertsPage", () => {
     expect(await screen.findByText("Police Helicopters")).toBeInTheDocument();
   });
 
-  it("renders a single-tab page without a visible tab bar", async () => {
-    // With only the Watchlists area implemented (roadmap slice 037), a tab
-    // bar with nothing to switch between would just be visual noise —
-    // slice 041 adding a sibling tab is what makes it appear.
-    installWatchlistsApiMock();
+  it("offers every area of the page as a tab", () => {
+    installAlertsApiMock();
 
-    renderWithProviders(<AlertsPage />);
-    await screen.findByText(/no watchlists yet/i);
+    renderPage();
 
-    expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
-    expect(screen.getByRole("tabpanel")).toBeInTheDocument();
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("tab").map((tab) => tab.textContent),
+    ).toEqual(["Watchlists", "Rules", "Templates", "History"]);
+  });
+
+  it("switches to the rule builder's area", async () => {
+    const user = userEvent.setup();
+    installAlertsApiMock({ rules: [alertRule({ name: "Military aircraft" })] });
+
+    renderPage();
+
+    await user.click(screen.getByRole("tab", { name: "Rules" }));
+
+    expect(
+      await screen.findByRole("article", { name: "Military aircraft" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Rules" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("switches to the template gallery", async () => {
+    const user = userEvent.setup();
+    installAlertsApiMock();
+
+    renderPage();
+
+    await user.click(screen.getByRole("tab", { name: "Templates" }));
+
+    expect(
+      await screen.findByRole("article", { name: "Emergency squawk" }),
+    ).toBeInTheDocument();
+  });
+
+  it("switches to the alert history", async () => {
+    const user = userEvent.setup();
+    installAlertsApiMock({
+      matches: [alertMatch({ reason: "Rule: Military aircraft" })],
+    });
+
+    renderPage();
+
+    await user.click(screen.getByRole("tab", { name: "History" }));
+
+    expect(
+      await screen.findByText("Rule: Military aircraft"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/AlertsPage.test.tsx
+++ b/frontend/src/pages/AlertsPage.test.tsx
@@ -5,7 +5,11 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AlertsPage } from "@/pages/AlertsPage";
-import { alertMatch, alertRule, installAlertsApiMock } from "@/test/alertsApiMock";
+import {
+  alertMatch,
+  alertRule,
+  installAlertsApiMock,
+} from "@/test/alertsApiMock";
 import { watchlist } from "@/test/watchlistsApiMock";
 
 afterEach(() => {
@@ -48,9 +52,12 @@ describe("AlertsPage", () => {
     renderPage();
 
     expect(screen.getByRole("tablist")).toBeInTheDocument();
-    expect(
-      screen.getAllByRole("tab").map((tab) => tab.textContent),
-    ).toEqual(["Watchlists", "Rules", "Templates", "History"]);
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+      "Watchlists",
+      "Rules",
+      "Templates",
+      "History",
+    ]);
   });
 
   it("switches to the rule builder's area", async () => {

--- a/frontend/src/pages/AlertsPage.tsx
+++ b/frontend/src/pages/AlertsPage.tsx
@@ -1,6 +1,9 @@
 import { useId, useState } from "react";
 
 import { requireNavItem } from "@/components/shell/nav-items";
+import { AlertHistorySection } from "@/features/alerts/components/AlertHistorySection";
+import { AlertRulesSection } from "@/features/alerts/components/AlertRulesSection";
+import { TemplateGallery } from "@/features/alerts/components/TemplateGallery";
 import { WatchlistsSection } from "@/features/watchlists/components/WatchlistsSection";
 
 const item = requireNavItem("/alerts");
@@ -21,20 +24,25 @@ const WATCHLISTS_TAB: AlertsTab = {
 };
 
 /**
- * The Alerts page's areas, in tab order. Roadmap slice 037 (watchlists)
- * lands the first one; slice 041 (alert rules) adds a sibling entry here —
- * nothing about this page's own composition needs to change for that, only
- * this list.
+ * The Alerts page's areas, in tab order. Roadmap slice 037 landed
+ * watchlists; slice 041 adds the other three as siblings, which is exactly
+ * the change this page was built to absorb — the list grew, the composition
+ * did not.
+ *
+ * The order is the order the work is done in: what you are watching, then
+ * the rules over it, then the ready-made rules you can start from, then
+ * what has actually fired.
  */
-const TABS: AlertsTab[] = [WATCHLISTS_TAB];
+const TABS: AlertsTab[] = [
+  WATCHLISTS_TAB,
+  { id: "rules", label: "Rules", render: () => <AlertRulesSection /> },
+  { id: "templates", label: "Templates", render: () => <TemplateGallery /> },
+  { id: "history", label: "History", render: () => <AlertHistorySection /> },
+];
 
 /**
- * The Alerts page (SPEC §42/§43). A single "Watchlists" area for now
- * (roadmap slice 037); rendered as a tab bar from the start so slice 041's
- * alert-rules area joins it as a sibling tab rather than requiring a later
- * rewrite of this page's structure. With one tab the bar itself stays
- * hidden — there is nothing to switch between yet — but the tabpanel
- * semantics are in place either way.
+ * The Alerts page (SPEC §42 to §48): watchlists, the rule builder, the
+ * shipped-template gallery, and the history of every alert that has fired.
  */
 export function AlertsPage() {
   const [activeTabId, setActiveTabId] = useState(WATCHLISTS_TAB.id);

--- a/frontend/src/test/alertsApiMock.ts
+++ b/frontend/src/test/alertsApiMock.ts
@@ -1,0 +1,389 @@
+import { vi } from "vitest";
+
+import type {
+  AlertRule,
+  AlertRuleConditions,
+  AlertTemplate,
+} from "@/lib/api/alertRules";
+import type { AlertMatch } from "@/lib/api/alertMatches";
+import type { Watchlist } from "@/lib/api/watchlists";
+import { defaultFlightSiteConfig } from "@/test/configApiMock";
+
+/** An `AlertRule`, defaulting to a user-written military rule — override
+ * just the fields a test cares about. */
+export function alertRule(overrides: Partial<AlertRule> = {}): AlertRule {
+  const conditions: AlertRuleConditions = overrides.conditions ?? {
+    version: 1,
+    classification: {
+      military: true,
+      government: false,
+      law_enforcement: false,
+    },
+  };
+  return {
+    id: 1,
+    name: "Military aircraft",
+    description: null,
+    severity: "high",
+    enabled: true,
+    template_key: null,
+    describes: describeConditions(conditions),
+    created_at: "2026-08-31T00:00:00.000Z",
+    updated_at: "2026-08-31T00:00:00.000Z",
+    ...overrides,
+    conditions,
+  };
+}
+
+export function alertTemplate(
+  overrides: Partial<AlertTemplate> = {},
+): AlertTemplate {
+  return {
+    key: "military",
+    name: "Military aircraft",
+    description: "Any aircraft classified as military (SPEC §39).",
+    severity: "high",
+    builtin: false,
+    conditions: {
+      version: 1,
+      classification: {
+        military: true,
+        government: false,
+        law_enforcement: false,
+      },
+    },
+    ...overrides,
+  };
+}
+
+export function alertMatch(overrides: Partial<AlertMatch> = {}): AlertMatch {
+  return {
+    id: 1,
+    at: "2026-08-31T12:00:00.000Z",
+    severity: "high",
+    reason: "Rule: Military aircraft",
+    icao: "ae1463",
+    sighting_id: 42,
+    rule: { id: 1, name: "Military aircraft" },
+    builtin_key: null,
+    notified: false,
+    ...overrides,
+  };
+}
+
+/**
+ * The catalogue the real backend ships (SPEC §45), in `SHIPPED_TEMPLATES`
+ * order — including the built-in emergency entry, which has no conditions
+ * because SPEC §47 gives it no rule to create.
+ */
+export const SHIPPED_TEMPLATE_FIXTURES: AlertTemplate[] = [
+  alertTemplate(),
+  alertTemplate({
+    key: "government",
+    name: "Government aircraft",
+    description: "Any aircraft classified as a government operator.",
+    conditions: {
+      version: 1,
+      classification: {
+        military: false,
+        government: true,
+        law_enforcement: false,
+      },
+    },
+  }),
+  alertTemplate({
+    key: "emergency_squawk",
+    name: "Emergency squawk",
+    description:
+      "Squawk 7500, 7600 or 7700. Built in and always on: SPEC §47 requires emergency squawks to alert without a rule.",
+    severity: "critical",
+    builtin: true,
+    conditions: null,
+  }),
+  alertTemplate({
+    key: "first_ever",
+    name: "First-ever aircraft",
+    description: "An airframe this receiver has never recorded before.",
+    severity: "info",
+    conditions: { version: 1, rare_aircraft: { max_sightings: 1 } },
+  }),
+  alertTemplate({
+    key: "watchlist",
+    name: "Watchlist match",
+    description: "Any aircraft on any watchlist (SPEC §42).",
+    severity: "interesting",
+    conditions: { version: 1, watchlist_any: true },
+  }),
+];
+
+/**
+ * The prose the backend's `RuleConditions.describe()` produces, mirrored so
+ * a rule created through this mock renders the same phrases a real one
+ * would. Mirroring backend output is precisely a mock's job; nothing outside
+ * `src/test` may depend on it.
+ */
+function describeConditions(conditions: AlertRuleConditions): string[] {
+  const phrases: string[] = [];
+  const classification = conditions.classification;
+  if (classification) {
+    const parts: string[] = [];
+    if (classification.military) parts.push("military");
+    if (classification.government) parts.push("government");
+    if (classification.law_enforcement) parts.push("law enforcement");
+    if (classification.mission) parts.push(`mission ${classification.mission}`);
+    phrases.push(parts.join(" and "));
+  }
+  if (conditions.type_code != null) {
+    phrases.push(`type ${conditions.type_code}`);
+  }
+  if (conditions.model != null) {
+    phrases.push(`model containing '${conditions.model}'`);
+  }
+  if (conditions.watchlist_id != null) {
+    phrases.push(`on watchlist ${conditions.watchlist_id}`);
+  }
+  if (conditions.watchlist_any === true) {
+    phrases.push("on any watchlist");
+  }
+  if (conditions.rare_aircraft) {
+    phrases.push(
+      `seen at most ${conditions.rare_aircraft.max_sightings} time(s) here`,
+    );
+  }
+  if (conditions.rare_type) {
+    phrases.push(
+      `type seen on at most ${conditions.rare_type.max_sightings} airframe(s) here`,
+    );
+  }
+  if (conditions.min_distance_nm != null) {
+    phrases.push(`at least ${conditions.min_distance_nm} nm away`);
+  }
+  if (conditions.max_distance_nm != null) {
+    phrases.push(`within ${conditions.max_distance_nm} nm`);
+  }
+  if (conditions.min_alt_ft != null) {
+    phrases.push(`at or above ${conditions.min_alt_ft} ft`);
+  }
+  if (conditions.max_alt_ft != null) {
+    phrases.push(`at or below ${conditions.max_alt_ft} ft`);
+  }
+  return phrases;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  if (status === 204) {
+    return new Response(null, { status });
+  }
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** The `/api/v1` error envelope (§2.5), which the match history reads. */
+function v1Error(status: number, message: string): Response {
+  return jsonResponse({ error: { code: "error", message } }, status);
+}
+
+function parseBody(
+  init: RequestInit | undefined,
+): Record<string, unknown> | undefined {
+  if (!init?.body) {
+    return undefined;
+  }
+  return JSON.parse(init.body as string) as Record<string, unknown>;
+}
+
+export interface InstallAlertsApiMockOptions {
+  rules?: AlertRule[];
+  templates?: AlertTemplate[];
+  matches?: AlertMatch[];
+  /** Served on `GET /api/internal/watchlists`, which the rule builder reads
+   * to offer a "on a watchlist" condition its choices. */
+  watchlists?: Watchlist[];
+  timezone?: string;
+}
+
+/**
+ * Installs a stateful `global.fetch` stub over an in-memory store serving
+ * every endpoint the Alerts page touches: alert-rule CRUD and template
+ * instantiation (`/api/internal`, docs/API.md §5), the match history
+ * (`GET /api/v1/alerts/matches`, §3.9), plus the watchlist list and config
+ * document the rule builder and the history read for their own reasons.
+ *
+ * Stateful rather than scripted, the way `watchlistsApiMock` is, so a test
+ * exercises the real `lib/api/alertRules` client and its mutations end to
+ * end — build a rule in the UI, see it appear in the list with the
+ * conditions the builder composed — instead of asserting against a single
+ * canned response. The status codes the backend actually returns are served
+ * too (`404` for an unknown key, `409` for a template that is built in or
+ * already instantiated), so `ApiError` round-trips are exercised as well.
+ */
+export function installAlertsApiMock(
+  options: InstallAlertsApiMockOptions = {},
+) {
+  let rules = [...(options.rules ?? [])];
+  const templates = options.templates ?? SHIPPED_TEMPLATE_FIXTURES;
+  const matches = [...(options.matches ?? [])];
+  const watchlists = [...(options.watchlists ?? [])];
+  const timezone = options.timezone ?? "UTC";
+  let nextRuleId = Math.max(0, ...rules.map((rule) => rule.id)) + 1;
+
+  function ruleFromBody(
+    body: Record<string, unknown> | undefined,
+    base: Partial<AlertRule>,
+  ): AlertRule {
+    const conditions = (body?.conditions ?? { version: 1 }) as AlertRuleConditions;
+    return {
+      id: base.id ?? nextRuleId++,
+      name: String(body?.name ?? ""),
+      description: (body?.description as string | null) ?? null,
+      severity: (body?.severity as AlertRule["severity"]) ?? "interesting",
+      enabled: body?.enabled !== false,
+      template_key: base.template_key ?? null,
+      conditions,
+      describes: describeConditions(conditions),
+      created_at: base.created_at ?? "2026-08-31T00:00:00.000Z",
+      updated_at: "2026-08-31T00:00:00.000Z",
+    };
+  }
+
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const raw = typeof input === "string" ? input : input.toString();
+      const [path = "", search = ""] = raw.split("?");
+      const method = (init?.method ?? "GET").toUpperCase();
+      const body = parseBody(init);
+
+      if (path === "/api/internal/config" && method === "GET") {
+        return jsonResponse({
+          first_run: false,
+          config: defaultFlightSiteConfig({ timezone }),
+          secrets_set: {},
+        });
+      }
+
+      if (path === "/api/internal/watchlists" && method === "GET") {
+        return jsonResponse({ watchlists });
+      }
+
+      if (path === "/api/internal/alert-templates" && method === "GET") {
+        return jsonResponse({ templates });
+      }
+
+      const instantiateMatch =
+        /^\/api\/internal\/alert-templates\/([^/]+)\/rules$/.exec(path);
+      if (instantiateMatch && method === "POST") {
+        const key = instantiateMatch[1] as string;
+        const template = templates.find((entry) => entry.key === key);
+        if (!template) {
+          return jsonResponse(
+            { detail: `no alert template with key '${key}'` },
+            404,
+          );
+        }
+        if (template.builtin || template.conditions === null) {
+          return jsonResponse(
+            {
+              detail: `template '${key}' is built in and always on: it has no rule to create`,
+            },
+            409,
+          );
+        }
+        if (rules.some((rule) => rule.template_key === key)) {
+          return jsonResponse(
+            { detail: `template '${key}' already has a rule` },
+            409,
+          );
+        }
+        const created = alertRule({
+          id: nextRuleId++,
+          name: template.name,
+          description: template.description,
+          severity: template.severity,
+          template_key: key,
+          conditions: template.conditions,
+        });
+        rules = [...rules, created];
+        return jsonResponse(created, 201);
+      }
+
+      const ruleMatch = /^\/api\/internal\/alert-rules(?:\/(\d+))?$/.exec(path);
+      if (ruleMatch) {
+        const ruleId =
+          ruleMatch[1] === undefined ? undefined : Number(ruleMatch[1]);
+
+        if (method === "GET" && ruleId === undefined) {
+          return jsonResponse({ rules });
+        }
+        if (method === "POST" && ruleId === undefined) {
+          if (String(body?.name ?? "").trim().length === 0) {
+            return jsonResponse({ detail: "rule name must not be blank" }, 422);
+          }
+          const created = ruleFromBody(body, {});
+          rules = [...rules, created];
+          return jsonResponse(created, 201);
+        }
+        if (method === "PUT" && ruleId !== undefined) {
+          const target = rules.find((rule) => rule.id === ruleId);
+          if (!target) {
+            return jsonResponse(
+              { detail: `no alert rule with id ${ruleId}` },
+              404,
+            );
+          }
+          if (String(body?.name ?? "").trim().length === 0) {
+            return jsonResponse({ detail: "rule name must not be blank" }, 422);
+          }
+          // Provenance is not replaceable: tuning a shipped rule does not
+          // make it stop having been shipped.
+          const updated = ruleFromBody(body, {
+            id: target.id,
+            template_key: target.template_key,
+            created_at: target.created_at,
+          });
+          rules = rules.map((rule) => (rule.id === ruleId ? updated : rule));
+          return jsonResponse(updated);
+        }
+        if (method === "DELETE" && ruleId !== undefined) {
+          if (!rules.some((rule) => rule.id === ruleId)) {
+            return jsonResponse(
+              { detail: `no alert rule with id ${ruleId}` },
+              404,
+            );
+          }
+          rules = rules.filter((rule) => rule.id !== ruleId);
+          return jsonResponse(undefined, 204);
+        }
+      }
+
+      if (path === "/api/v1/alerts/matches" && method === "GET") {
+        const params = new URLSearchParams(search);
+        const severity = params.get("severity");
+        const icao = params.get("icao");
+        if (icao !== null && !/^[0-9a-f]{6}$/.test(icao)) {
+          return v1Error(422, "icao must be six lower-case hex digits");
+        }
+        const limit = Number(params.get("limit") ?? "50");
+        const offset = Number(params.get("offset") ?? "0");
+        const filtered = matches.filter(
+          (match) =>
+            (severity === null || match.severity === severity) &&
+            (icao === null || match.icao === icao),
+        );
+        return jsonResponse({
+          items: filtered.slice(offset, offset + limit),
+          total: null,
+          limit,
+          offset,
+        });
+      }
+
+      throw new Error(`Unhandled fetch in test: ${method} ${raw}`);
+    },
+  );
+
+  vi.stubGlobal("fetch", fetchMock);
+
+  return { fetchMock };
+}

--- a/frontend/src/test/alertsApiMock.ts
+++ b/frontend/src/test/alertsApiMock.ts
@@ -233,7 +233,9 @@ export function installAlertsApiMock(
     body: Record<string, unknown> | undefined,
     base: Partial<AlertRule>,
   ): AlertRule {
-    const conditions = (body?.conditions ?? { version: 1 }) as AlertRuleConditions;
+    const conditions = (body?.conditions ?? {
+      version: 1,
+    }) as AlertRuleConditions;
     return {
       id: base.id ?? nextRuleId++,
       name: String(body?.name ?? ""),

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1071,7 +1071,7 @@ slices:
     title: "Alerts page & rule builder"
     phase: 6
     branch: "041-alerts-page"
-    status: planned
+    status: merged
     depends_on: ["038", "037"]
     objective: "Visual rule builder, template management, and alert history on the Alerts page."
     scope:


### PR DESCRIPTION
## Slice 041 — Alerts page & rule builder

Three new tabs on the Alerts page (`frontend/src/features/alerts/`):

- **Rule list**: enable/disable, severity, template provenance, edit-in-place, delete-with-confirm; condition prose rendered from the backend's `describes` so card/notification/history always agree
- **Visual rule builder**: all nine v1 condition kinds + `applies_on_ground`; draft-based editing (flat-AND enforced structurally — a kind in use isn't offered twice); distance/altitude windows edited as one idea and validated as the pair
- **Template gallery**: instantiates shipped templates; built-in emergency renders as 'Always on'
- **Match history**: stored reasons, severity filter, paging

One backend addition, `POST /api/internal/alert-templates/{key}/rules` (empty body — conditions/severity come from the catalogue, never the caller, preserving `template_key` provenance integrity; 404 unknown, 409 built-in/duplicate). Necessary because startup instantiation's all-or-nothing guard exists to keep deleted shipped rules deleted, so the gallery had no provenance-preserving path.

Severity is never color-only; enabled state is words, not just style.

Verification: frontend lint/typecheck clean, 1365 tests, 97.22% stmt coverage; backend ruff/format/mypy clean, 3703 passed, 99.36% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)