### PR TITLE
feat: browser notifications for alerts (slice 040)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -61,6 +61,8 @@ browser, not just the first one to run (see `e2e/playwright.config.ts` and
 `e2e/scripts/`).
 
 ```bash
+docker compose build                   # FIRST — see below; not done for you
+
 cd e2e
 npm install
 npx playwright install --with-deps    # first run only
@@ -69,6 +71,16 @@ npm run e2e                            # Chromium: stack up, full suite, stack d
 npm run e2e:firefox                    # same, Firefox
 npm run e2e:webkit                     # same, WebKit
 ```
+
+**Build the images yourself, every time you change the app.** `compose.yaml` names
+both services by a published `ghcr.io/...:latest` tag, so `docker compose up` reuses
+whatever image already carries that tag in the local daemon and builds only when
+there is none. `scripts/stack.mjs` deliberately does not build (CI builds both images
+in an earlier step — `.github/workflows/e2e.yml`), so a local run started without the
+command above silently exercises whatever was last built on this machine — quite
+possibly another branch or another worktree. The failure mode is a confusing one:
+every pre-existing spec passes and only the specs covering your new UI fail, on
+elements that "should" be there.
 
 `npm run e2e` (etc.) always tears the stack down afterward, pass or fail. To run
 against a stack you're keeping up between runs (faster iteration on one spec):
@@ -79,10 +91,10 @@ npm test                               # Chromium only, against the running stac
 npm run stack:down
 ```
 
-The suite's four spec files (`e2e/tests/01-*` … `04-*`) run in that fixed order,
-serially (`workers: 1`), against one shared backend within a browser: `01` completes
+The suite's spec files (`e2e/tests/01-*` … `05-*`) run in that fixed order, serially
+(`workers: 1`), against one shared backend within a browser: `01` completes
 first-run setup, `02` exercises the decoder connection test against the now-configured
-install, `03` and `04` assume setup is already done. Failures produce Playwright
+install, and `03`–`05` assume setup is already done. Failures produce Playwright
 traces/screenshots/video under `e2e/test-results/` and `e2e/playwright-report/`
 (`npm run report` to view).
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -155,8 +155,11 @@ information. No period-over-period comparison in v1.
   rule (§47).
 - **Browser notifications** (the only v1 channel): once per sighting per rule, with a
   higher-priority re-notification allowed; include callsign/tail, type,
-  classification, altitude, distance, match reason; clicking opens/selects the
-  aircraft; works while FlightSite is open, including background tabs (§48).
+  classification, altitude, distance, match reason; clicking focuses the tab and
+  selects the aircraft; works while FlightSite is open, including background and
+  minimized tabs (§48). "Open" means a tab on the Live Map, which is where the
+  connection that carries live alerts lives; permission is asked for once, from the
+  setup wizard or Settings, and never on load (`docs/SECURITY.md` §5).
 
 ### 4.9 Activity & Records (§16, §53–§55)
 

--- a/docs/RISKS.md
+++ b/docs/RISKS.md
@@ -62,10 +62,14 @@ corruption diagnostics rather than silent failure (slice 044).
 
 ### R-06 — Browser notification limitations
 Notifications only work while a FlightSite tab is open; permission UX varies by
-browser and OS; some platforms suppress background-tab notifications.
+browser and OS; some platforms suppress background-tab notifications; browsers
+withhold the API entirely from the plain-HTTP LAN origin FlightSite normally runs on.
 **Mitigation:** scope is explicitly browser-only in v1 (SPEC §48); permission status
 surfaced in diagnostics; degradation is clean and visible; richer channels are
-tracked backlog items, not silent scope creep.
+tracked backlog items, not silent scope creep. Delivered in slice 040: each
+non-delivering state — not asked, blocked, unsupported browser, insecure origin —
+carries its own explanation and remedy in Settings, and alerts that could not be
+shown are counted there, so a degraded install is visibly degraded.
 
 ### R-07 — Map tile provider changes
 Free basemap providers change terms, styles, or availability.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -72,6 +72,20 @@ requested only after the user opts in (setup wizard or settings), never unprompt
 Notification content includes aircraft data only — never secrets or configuration.
 Denied/blocked permission degrades cleanly and is surfaced in diagnostics.
 
+Two consequences of that first rule, as implemented (slice 040):
+
+- The request is issued from the user's own click — the wizard's **Finish** when the
+  notification preference is on, or the **Allow notifications** button in Settings —
+  and never from an arriving alert, a page load, or a background task. Firefox and
+  Safari require that user activation anyway; FlightSite requires it of itself.
+- Browsers withhold the Notification API entirely outside a secure context (HTTPS, or
+  a `localhost`/`127.0.0.1` origin). Reaching FlightSite over plain HTTP on a LAN
+  address — the normal deployment of §1 — therefore means no notifications at all.
+  That is reported as its own state ("Unavailable on this address") rather than as a
+  fault, and every other alert surface (map emphasis, interesting panel, activity
+  feed) is unaffected. Alerts that could not be shown are counted and displayed
+  alongside the permission, so a silently-degraded install is visibly degraded.
+
 ## 6. Data Integrity: SQLite, Power Loss
 
 - WAL mode with recovery on startup; automatic integrity checks (`quick_check`) at

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -119,7 +119,7 @@ Flaky tests are treated as defects. Rules:
 | Aircraft selection | 020 |
 | Aircraft detail | 020 |
 | Interesting-aircraft alert | 046 |
-| Browser notification permission flow | 046 |
+| Browser notification permission flow | 040 (Chromium only — see below) |
 | Aircraft page | 046 |
 | Sightings page | 046 |
 | Analytics windows (all presets) | 046 |
@@ -128,6 +128,17 @@ Flaky tests are treated as defects. Rules:
 
 E2E is a required CI check from slice 020 onward. Failures produce traces and
 screenshots as CI artifacts.
+
+**Browser notifications.** The permission flow runs in Chromium only: Playwright can
+grant and clear the `notifications` permission there, cannot in Firefox or WebKit, and
+cannot drive a native permission prompt in any of the three — so the other two
+projects skip the spec, the same capability escape hatch aircraft selection uses for
+WebGL. *Delivery* (an alert becoming exactly one notification, plus the allowed
+severity-upgrade extra) is covered by unit tests against the real protocol client
+rather than E2E: a demo alert fires at a fixed phase of the scenario's 30-minute
+rotation, so waiting for one from an arbitrary start time would be a coin toss.
+Making a demo alert observable end to end belongs with the interesting-aircraft alert
+flow above.
 
 ---
 

--- a/e2e/tests/05-browser-notifications.spec.ts
+++ b/e2e/tests/05-browser-notifications.spec.ts
@@ -4,23 +4,31 @@
  * Settings page is reachable and the notification preferences it shows are
  * the ones the wizard wrote.
  *
- * What only a real browser can prove, and therefore what this covers:
+ * **What a headless browser will and will not do.** An automated engine does
+ * not present the interactive permission model a person sees: headless
+ * Chromium has no notification centre to deliver to, so it reports a standing
+ * `denied` and a CDP grant does not move it, and Playwright cannot drive a
+ * native permission prompt in any of the three engines. An earlier version of
+ * this spec assumed the not-yet-asked state existed and every assertion in it
+ * failed on CI for that one reason. So nothing here assumes a state: each test
+ * asks the page what the browser actually reports and then asserts against
+ * *that*, skipping with a reason where a state is unreachable — the same
+ * capability escape hatch spec 04 uses for WebGL.
  *
- * - **Loading FlightSite does not ask.** `docs/SECURITY.md` §5 allows the
- *   permission to be requested only after the user opts in. jsdom can assert
- *   that no *mock* was called; only a real engine can confirm the real
- *   `Notification.permission` is untouched after the app has fully loaded,
- *   fetched its config (which says notifications are enabled) and connected
- *   its socket.
- * - **The status the user sees matches what the browser actually thinks**, in
- *   both the granted and the not-yet-asked states.
- * - **The ask is re-promptable from Settings**, and answering it moves the
- *   status off "Not requested" whichever way the browser answers.
+ * That leaves two assertions that hold in every engine and are the two worth
+ * having:
  *
- * Chromium only. Playwright can grant and clear the notifications permission
- * in Chromium; Firefox and WebKit do not support it, and there is no way to
- * drive a native permission prompt in any of the three — so the other two
- * projects skip, the same capability escape hatch spec 04 uses for WebGL.
+ * - **Loading FlightSite never asks.** `docs/SECURITY.md` §5 allows the
+ *   permission to be requested only after the user opts in. This is checked by
+ *   counting real calls to `Notification.requestPermission` rather than by
+ *   inspecting the resulting permission — which is both stronger and immune to
+ *   whatever standing answer the engine happens to give.
+ * - **The status the user sees is the status the browser reports.** Whichever
+ *   of the five states this engine is in, Settings names that one, offers the
+ *   ask only where asking could still work, and — in the `denied` state CI
+ *   actually runs in — shows the remedy. That is the slice's "denied
+ *   permission degrades cleanly with status surfaced" criterion, exercised in
+ *   a real browser.
  *
  * Delivery itself (an alert becoming exactly one notification) is not here.
  * A demo alert fires at a fixed phase of the scenario's 30-minute rotation
@@ -33,46 +41,178 @@
  * flow that `docs/TEST_STRATEGY.md` §4 assigns to slice 046.
  */
 
+import type { Page } from "@playwright/test";
+
 import { waitForLiveAircraft } from "./support/liveMap";
 import { expect, test } from "./support/fixtures";
 
 const STATUS = "notification-permission-status";
 
+/** Where the init script records what it saw, on `window`. */
+const PROBE = "__flightsiteNotificationProbe";
+
+interface AskProbe {
+  /** Whether `requestPermission` was successfully wrapped. Asserted so a
+   * failure to instrument shows up as a failure rather than as a test that
+   * passes by never having watched anything. */
+  patched: boolean;
+  /** How many times the app asked the browser for permission. */
+  calls: number;
+}
+
+/** What this engine can actually do, read from inside the page. */
+interface Capability {
+  /** Whether the Notification API exists here at all. */
+  api: boolean;
+  /** Whether the origin is one the engine considers trustworthy. */
+  secure: boolean;
+  /** The standing answer, or `null` where there is no API to ask. */
+  permission: "default" | "granted" | "denied" | null;
+}
+
+async function capability(page: Page): Promise<Capability> {
+  return page.evaluate(() => {
+    const api = typeof Notification !== "undefined";
+    return {
+      api,
+      secure: window.isSecureContext,
+      permission: api ? (Notification.permission as Capability["permission"]) : null,
+    };
+  }) as Promise<Capability>;
+}
+
+/**
+ * Counts real `Notification.requestPermission` calls for the life of the
+ * page's JS context.
+ *
+ * Installed before any navigation so it is in place while the app boots. The
+ * counter lives in the page context, so it survives client-side route changes
+ * (which is how the Settings page is reached below) but resets on a full
+ * reload — every assertion here is therefore made within one `goto`.
+ */
+async function watchForAsks(page: Page): Promise<void> {
+  await page.addInitScript((key: string) => {
+    const store = { patched: false, calls: 0 };
+    (window as unknown as Record<string, unknown>)[key] = store;
+    if (typeof Notification === "undefined") {
+      return;
+    }
+    try {
+      const original = Notification.requestPermission.bind(Notification);
+      Notification.requestPermission = ((...args: unknown[]) => {
+        store.calls += 1;
+        return (original as (...rest: unknown[]) => unknown)(...args);
+      }) as typeof Notification.requestPermission;
+      store.patched = true;
+    } catch {
+      // Left unpatched; the test asserts `patched` and will say so.
+    }
+  }, PROBE);
+}
+
+async function askProbe(page: Page): Promise<AskProbe> {
+  return page.evaluate(
+    (key: string) =>
+      ((window as unknown as Record<string, unknown>)[key] as AskProbe) ?? {
+        patched: false,
+        calls: 0,
+      },
+    PROBE,
+  ) as Promise<AskProbe>;
+}
+
+/**
+ * The state `NotificationPermissionStatus` must be reporting, derived from
+ * what the browser says — mirroring `features/notifications/lib/permission.ts`
+ * from the outside. The component publishes its own answer as
+ * `data-permission`, so comparing the two is a direct check that FlightSite
+ * and the browser agree.
+ */
+type PermissionState =
+  | "granted"
+  | "denied"
+  | "default"
+  | "unsupported"
+  | "insecure-context";
+
+function expectedState(state: Capability): PermissionState {
+  if (!state.api) {
+    return state.secure ? "unsupported" : "insecure-context";
+  }
+  return state.permission === "granted" || state.permission === "denied"
+    ? state.permission
+    : "default";
+}
+
+/** The label the user should see for that state. Asserted alongside the
+ * attribute so the prose cannot go missing or contradict it. */
+const LABELS: Record<PermissionState, RegExp> = {
+  granted: /browser permission: allowed/i,
+  denied: /browser permission: blocked/i,
+  default: /browser permission: not requested/i,
+  unsupported: /browser permission: unavailable in this browser/i,
+  "insecure-context": /browser permission: unavailable on this address/i,
+};
+
 test.describe("browser notification permission", () => {
-  test.skip(
-    ({ browserName }) => browserName !== "chromium",
-    "only Chromium lets Playwright grant or clear the notifications permission",
-  );
-
-  test("is never requested by loading FlightSite", async ({
+  test("is never requested by loading FlightSite or opening Settings", async ({
     page,
-    context,
   }) => {
-    await context.clearPermissions();
+    await watchForAsks(page);
 
-    // The Live Map is the page that holds the socket alerts arrive on — the
-    // one place an implementation might be tempted to ask from. Waiting for
-    // live aircraft means the config load, the socket and the first frames
-    // have all happened before the assertion.
+    // The Live Map holds the socket alerts arrive on — the one place an
+    // implementation might be tempted to ask from. Waiting for live aircraft
+    // means the config load (which says notifications are enabled), the
+    // socket and the first frames have all happened before the assertion.
     await page.goto("/");
     await waitForLiveAircraft(page);
 
-    expect(await page.evaluate(() => Notification.permission)).toBe("default");
+    const afterLoad = await askProbe(page);
+    const state = await capability(page);
+    if (state.api) {
+      expect(
+        afterLoad.patched,
+        "requestPermission could not be instrumented, so this test watched nothing",
+      ).toBe(true);
+    }
+    expect(afterLoad.calls, "loading the Live Map asked for permission").toBe(0);
+
+    // Client-side navigation, so the counter above stays in scope: opening
+    // the page that *owns* the ask must still not perform it.
+    await page.getByRole("link", { name: "Settings" }).click();
+    await expect(page.getByTestId(STATUS)).toBeVisible();
+
+    expect(
+      (await askProbe(page)).calls,
+      "opening Settings asked for permission without being asked to",
+    ).toBe(0);
   });
 
-  test("shows the not-yet-asked state in Settings, with the ask on offer", async ({
+  test("Settings reports the state the browser actually reports", async ({
     page,
-    context,
   }) => {
-    await context.clearPermissions();
     await page.goto("/settings");
-
     const status = page.getByTestId(STATUS);
     await expect(status).toBeVisible();
-    await expect(status).toContainText(/browser permission: not requested/i);
-    await expect(
-      status.getByRole("button", { name: /allow notifications/i }),
-    ).toBeVisible();
+
+    const state = await capability(page);
+    const expected = expectedState(state);
+    await expect(status).toHaveAttribute("data-permission", expected);
+    await expect(status).toContainText(LABELS[expected]);
+
+    // The ask is offered exactly where asking could still change the answer.
+    const ask = status.getByRole("button", { name: /allow notifications/i });
+    if (state.api && state.permission === "default") {
+      await expect(ask).toBeVisible();
+    } else {
+      await expect(ask).toHaveCount(0);
+    }
+
+    // The state CI actually runs in: a standing denial, which must carry its
+    // remedy rather than a dead end.
+    if (state.api && state.permission === "denied") {
+      await expect(status).toContainText(/site settings/i);
+    }
   });
 
   test("asking the browser moves the status off 'not requested'", async ({
@@ -82,12 +222,17 @@ test.describe("browser notification permission", () => {
     await context.clearPermissions();
     await page.goto("/settings");
 
+    const state = await capability(page);
+    test.skip(
+      !state.api || state.permission !== "default",
+      `this engine reports "${state.permission ?? "no Notification API"}" rather than an askable state, and no automation can drive a native permission prompt`,
+    );
+
     const status = page.getByTestId(STATUS);
     await status.getByRole("button", { name: /allow notifications/i }).click();
 
-    // Headless Chromium answers the request itself rather than showing a
-    // prompt, and which way it answers is the browser's business — what
-    // matters is that FlightSite asked and then reported the real answer.
+    // Which way the browser answers is its business; that FlightSite asked
+    // and then reported the real answer is not.
     await expect(status).not.toContainText(/not requested/i);
     await expect(status).toContainText(/browser permission: (allowed|blocked)/i);
   });
@@ -95,9 +240,20 @@ test.describe("browser notification permission", () => {
   test("reports a granted permission, and stops offering to ask", async ({
     page,
     context,
+    browserName,
   }) => {
+    test.skip(
+      browserName !== "chromium",
+      "only Chromium lets Playwright grant the notifications permission",
+    );
     await context.grantPermissions(["notifications"]);
     await page.goto("/settings");
+
+    const state = await capability(page);
+    test.skip(
+      state.permission !== "granted",
+      `granting had no effect — this engine still reports "${state.permission ?? "no Notification API"}"; headless Chromium has no notification centre to deliver to`,
+    );
 
     const status = page.getByTestId(STATUS);
     await expect(status).toContainText(/browser permission: allowed/i);

--- a/e2e/tests/05-browser-notifications.spec.ts
+++ b/e2e/tests/05-browser-notifications.spec.ts
@@ -34,8 +34,18 @@
  *   FlightSite's half — ask offered, ask made exactly once, answer reflected,
  *   ask withdrawn — and stubbing makes it the same assertion everywhere
  *   instead of three engine-specific ones.
- * - **A real grant, where an engine honours one** (test 4), which keeps one
- *   unstubbed path over the genuine permission machinery.
+ * - **A real grant, where an engine honours one** (test 4). Be clear about what
+ *   this is worth: it skips in all three headless engines — Firefox and WebKit
+ *   because Playwright cannot grant the permission there at all, Chromium
+ *   because the grant does not move a permission the engine has no notification
+ *   centre to satisfy. It earns its place as the one unstubbed path over the
+ *   genuine permission machinery for a headed local run, and as a tripwire: if
+ *   a future engine starts honouring the grant, this stops skipping and starts
+ *   asserting instead of quietly staying green.
+ *
+ * So in headless CI, tests 1-3 run and test 4 skips. Tests 1 and 2 are the
+ * unstubbed ones, and between them they cover what the browser decides; test 3
+ * covers what FlightSite decides.
  *
  * Delivery itself (an alert becoming exactly one notification) is not here.
  * A demo alert fires at a fixed phase of the scenario's 30-minute rotation

--- a/e2e/tests/05-browser-notifications.spec.ts
+++ b/e2e/tests/05-browser-notifications.spec.ts
@@ -4,31 +4,38 @@
  * Settings page is reachable and the notification preferences it shows are
  * the ones the wizard wrote.
  *
- * **What a headless browser will and will not do.** An automated engine does
- * not present the interactive permission model a person sees: headless
- * Chromium has no notification centre to deliver to, so it reports a standing
- * `denied` and a CDP grant does not move it, and Playwright cannot drive a
- * native permission prompt in any of the three engines. An earlier version of
- * this spec assumed the not-yet-asked state existed and every assertion in it
- * failed on CI for that one reason. So nothing here assumes a state: each test
- * asks the page what the browser actually reports and then asserts against
- * *that*, skipping with a reason where a state is unreachable — the same
- * capability escape hatch spec 04 uses for WebGL.
+ * **What a headless browser will and will not do**, learned the hard way from
+ * two CI rounds. No automated engine presents the interactive permission model
+ * a person sees, and no two of them decline in the same way: headless Chromium
+ * has no notification centre to deliver to, so it reports a standing `denied`
+ * that a CDP grant does not move, while headless Firefox reports `default` and
+ * then never settles `requestPermission()` at all, because settling it is the
+ * prompt's job and there is no prompt. An engine's native permission behaviour
+ * is therefore not something a cross-browser spec can assert against — and
+ * both rounds of failures came from trying.
  *
- * That leaves two assertions that hold in every engine and are the two worth
- * having:
+ * So the split here is between what the *browser* decides and what *FlightSite*
+ * decides, and each is tested where it is deterministic:
  *
- * - **Loading FlightSite never asks.** `docs/SECURITY.md` §5 allows the
- *   permission to be requested only after the user opts in. This is checked by
+ * - **Loading FlightSite never asks** (test 1). `docs/SECURITY.md` §5 allows
+ *   the permission to be requested only after the user opts in. Checked by
  *   counting real calls to `Notification.requestPermission` rather than by
- *   inspecting the resulting permission — which is both stronger and immune to
- *   whatever standing answer the engine happens to give.
- * - **The status the user sees is the status the browser reports.** Whichever
- *   of the five states this engine is in, Settings names that one, offers the
- *   ask only where asking could still work, and — in the `denied` state CI
- *   actually runs in — shows the remedy. That is the slice's "denied
- *   permission degrades cleanly with status surfaced" criterion, exercised in
- *   a real browser.
+ *   inspecting the resulting permission — stronger, and immune to whatever
+ *   standing answer the engine gives.
+ * - **The status the user sees is the status the browser reports** (test 2).
+ *   Whichever of the five states this engine is in, Settings names that one,
+ *   offers the ask only where asking could still work, and — in the `denied`
+ *   state Chromium runs in — shows the remedy. That is the slice's "denied
+ *   permission degrades cleanly with status surfaced" criterion, in a real
+ *   browser.
+ * - **Answering the prompt updates the UI** (test 3). The engine's prompt is
+ *   stubbed at the `Notification` boundary, because that boundary is the only
+ *   part of this flow no headless engine implements. What is under test is
+ *   FlightSite's half — ask offered, ask made exactly once, answer reflected,
+ *   ask withdrawn — and stubbing makes it the same assertion everywhere
+ *   instead of three engine-specific ones.
+ * - **A real grant, where an engine honours one** (test 4), which keeps one
+ *   unstubbed path over the genuine permission machinery.
  *
  * Delivery itself (an alert becoming exactly one notification) is not here.
  * A demo alert fires at a fixed phase of the scenario's 30-minute rotation
@@ -108,6 +115,75 @@ async function watchForAsks(page: Page): Promise<void> {
       // Left unpatched; the test asserts `patched` and will say so.
     }
   }, PROBE);
+}
+
+/** Where the prompt stub records what it did, on `window`. */
+const STUB = "__flightsiteNotificationStub";
+
+interface StubProbe {
+  /** Whether the boundary was successfully replaced. */
+  installed: boolean;
+  /** How many times FlightSite asked. */
+  calls: number;
+}
+
+/**
+ * Replaces the engine's permission prompt with one that answers immediately.
+ *
+ * The only part of the flow no headless engine implements: Chromium refuses
+ * before asking, Firefox never settles the promise because settling it is the
+ * prompt's job. Both the request *and* the `permission` getter are replaced, so
+ * the page is internally consistent afterwards — a component that re-reads the
+ * standing permission (on a visibility change, say) must not see `default`
+ * moments after being told `granted`.
+ *
+ * Starts at `default` regardless of what the engine would have said, so the
+ * not-yet-asked state — the one Chromium never offers — is reachable and the
+ * whole ask-and-answer flow can be driven in every engine.
+ */
+async function stubPermissionPrompt(page: Page): Promise<void> {
+  await page.addInitScript((key: string) => {
+    const store: { installed: boolean; calls: number } = {
+      installed: false,
+      calls: 0,
+    };
+    (window as unknown as Record<string, unknown>)[key] = store;
+    if (typeof Notification === "undefined") {
+      return;
+    }
+    let answer: NotificationPermission = "default";
+    try {
+      Object.defineProperty(Notification, "permission", {
+        configurable: true,
+        get: () => answer,
+      });
+      Notification.requestPermission = ((
+        callback?: (permission: NotificationPermission) => void,
+      ) => {
+        store.calls += 1;
+        answer = "granted";
+        // Answer both ways the API can be consumed: the modern promise and
+        // the legacy callback older Safari only supports. Resolving a
+        // promise twice is a no-op, so serving both is safe.
+        callback?.("granted");
+        return Promise.resolve<NotificationPermission>("granted");
+      }) as typeof Notification.requestPermission;
+      store.installed = true;
+    } catch {
+      // Left uninstalled; the test asserts `installed` and will say so.
+    }
+  }, STUB);
+}
+
+async function stubProbe(page: Page): Promise<StubProbe> {
+  return page.evaluate(
+    (key: string) =>
+      ((window as unknown as Record<string, unknown>)[key] as StubProbe) ?? {
+        installed: false,
+        calls: 0,
+      },
+    STUB,
+  ) as Promise<StubProbe>;
 }
 
 async function askProbe(page: Page): Promise<AskProbe> {
@@ -215,26 +291,45 @@ test.describe("browser notification permission", () => {
     }
   });
 
-  test("asking the browser moves the status off 'not requested'", async ({
+  test("asking, and being told yes, turns the status to allowed", async ({
     page,
-    context,
   }) => {
-    await context.clearPermissions();
+    // The prompt is stubbed (see `stubPermissionPrompt`): what is under test
+    // is FlightSite's half of the exchange, which is identical in every
+    // engine, rather than three engines' incompatible ways of declining to
+    // show a prompt.
+    await stubPermissionPrompt(page);
     await page.goto("/settings");
+
+    const status = page.getByTestId(STATUS);
+    await expect(status).toBeVisible();
 
     const state = await capability(page);
     test.skip(
-      !state.api || state.permission !== "default",
-      `this engine reports "${state.permission ?? "no Notification API"}" rather than an askable state, and no automation can drive a native permission prompt`,
+      !state.api,
+      "this engine exposes no Notification API to stub, so there is no ask to drive",
     );
+    expect(
+      (await stubProbe(page)).installed,
+      "the permission prompt could not be stubbed, so this test drove nothing",
+    ).toBe(true);
 
-    const status = page.getByTestId(STATUS);
-    await status.getByRole("button", { name: /allow notifications/i }).click();
+    // The not-yet-asked state, now reachable everywhere.
+    await expect(status).toHaveAttribute("data-permission", "default");
+    const ask = status.getByRole("button", { name: /allow notifications/i });
+    await expect(ask).toBeVisible();
 
-    // Which way the browser answers is its business; that FlightSite asked
-    // and then reported the real answer is not.
-    await expect(status).not.toContainText(/not requested/i);
-    await expect(status).toContainText(/browser permission: (allowed|blocked)/i);
+    await ask.click();
+
+    await expect(status).toHaveAttribute("data-permission", "granted");
+    await expect(status).toContainText(/browser permission: allowed/i);
+    // The ask is withdrawn once answered — there is nothing left to ask.
+    await expect(ask).toHaveCount(0);
+
+    expect(
+      (await stubProbe(page)).calls,
+      "one click on the ask should ask the browser exactly once",
+    ).toBe(1);
   });
 
   test("reports a granted permission, and stops offering to ask", async ({

--- a/e2e/tests/05-browser-notifications.spec.ts
+++ b/e2e/tests/05-browser-notifications.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * Flow — browser notification permission (roadmap slice 040, `docs/
+ * TEST_STRATEGY.md` §4). Runs after 01 has completed first-run setup, so the
+ * Settings page is reachable and the notification preferences it shows are
+ * the ones the wizard wrote.
+ *
+ * What only a real browser can prove, and therefore what this covers:
+ *
+ * - **Loading FlightSite does not ask.** `docs/SECURITY.md` §5 allows the
+ *   permission to be requested only after the user opts in. jsdom can assert
+ *   that no *mock* was called; only a real engine can confirm the real
+ *   `Notification.permission` is untouched after the app has fully loaded,
+ *   fetched its config (which says notifications are enabled) and connected
+ *   its socket.
+ * - **The status the user sees matches what the browser actually thinks**, in
+ *   both the granted and the not-yet-asked states.
+ * - **The ask is re-promptable from Settings**, and answering it moves the
+ *   status off "Not requested" whichever way the browser answers.
+ *
+ * Chromium only. Playwright can grant and clear the notifications permission
+ * in Chromium; Firefox and WebKit do not support it, and there is no way to
+ * drive a native permission prompt in any of the three — so the other two
+ * projects skip, the same capability escape hatch spec 04 uses for WebGL.
+ *
+ * Delivery itself (an alert becoming exactly one notification) is not here.
+ * A demo alert fires at a fixed phase of the scenario's 30-minute rotation
+ * (`flightsite.demo.roster.PERIOD_S`), so waiting for one from an arbitrary
+ * start time is a coin toss, not a test. Dispatch, dedupe and the
+ * severity-upgrade case are covered against the real protocol client in
+ * `frontend/src/features/map/aircraft/useLiveConnection.test.tsx` and
+ * `frontend/src/features/notifications/lib/dispatch.test.ts`; making a demo
+ * alert observable end-to-end belongs with the "Interesting-aircraft alert"
+ * flow that `docs/TEST_STRATEGY.md` §4 assigns to slice 046.
+ */
+
+import { waitForLiveAircraft } from "./support/liveMap";
+import { expect, test } from "./support/fixtures";
+
+const STATUS = "notification-permission-status";
+
+test.describe("browser notification permission", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "only Chromium lets Playwright grant or clear the notifications permission",
+  );
+
+  test("is never requested by loading FlightSite", async ({
+    page,
+    context,
+  }) => {
+    await context.clearPermissions();
+
+    // The Live Map is the page that holds the socket alerts arrive on — the
+    // one place an implementation might be tempted to ask from. Waiting for
+    // live aircraft means the config load, the socket and the first frames
+    // have all happened before the assertion.
+    await page.goto("/");
+    await waitForLiveAircraft(page);
+
+    expect(await page.evaluate(() => Notification.permission)).toBe("default");
+  });
+
+  test("shows the not-yet-asked state in Settings, with the ask on offer", async ({
+    page,
+    context,
+  }) => {
+    await context.clearPermissions();
+    await page.goto("/settings");
+
+    const status = page.getByTestId(STATUS);
+    await expect(status).toBeVisible();
+    await expect(status).toContainText(/browser permission: not requested/i);
+    await expect(
+      status.getByRole("button", { name: /allow notifications/i }),
+    ).toBeVisible();
+  });
+
+  test("asking the browser moves the status off 'not requested'", async ({
+    page,
+    context,
+  }) => {
+    await context.clearPermissions();
+    await page.goto("/settings");
+
+    const status = page.getByTestId(STATUS);
+    await status.getByRole("button", { name: /allow notifications/i }).click();
+
+    // Headless Chromium answers the request itself rather than showing a
+    // prompt, and which way it answers is the browser's business — what
+    // matters is that FlightSite asked and then reported the real answer.
+    await expect(status).not.toContainText(/not requested/i);
+    await expect(status).toContainText(/browser permission: (allowed|blocked)/i);
+  });
+
+  test("reports a granted permission, and stops offering to ask", async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(["notifications"]);
+    await page.goto("/settings");
+
+    const status = page.getByTestId(STATUS);
+    await expect(status).toContainText(/browser permission: allowed/i);
+    await expect(
+      status.getByRole("button", { name: /allow notifications/i }),
+    ).toHaveCount(0);
+  });
+});

--- a/frontend/src/components/shell/RootLayout.test.tsx
+++ b/frontend/src/components/shell/RootLayout.test.tsx
@@ -4,16 +4,19 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DEV_PLACEHOLDER_MAP_CONFIG } from "@/features/map/mapConfig";
 import { useMapConfigStore } from "@/features/map/store/useMapConfigStore";
+import { useNotificationStore } from "@/features/notifications/store/useNotificationStore";
 import { NAV_ITEMS } from "@/components/shell/nav-items";
 import {
   defaultFlightSiteConfig,
   installConfigApiMock,
 } from "@/test/configApiMock";
+import { installNotificationMock } from "@/test/notificationMock";
 import { renderApp } from "@/test/test-utils";
 
 afterEach(() => {
   vi.unstubAllGlobals();
   useMapConfigStore.setState({ config: DEV_PLACEHOLDER_MAP_CONFIG });
+  useNotificationStore.getState().reset();
 });
 
 describe("RootLayout", () => {
@@ -79,6 +82,45 @@ describe("RootLayout", () => {
         label: "Home Roof",
       });
     });
+  });
+
+  it("mirrors the notification preferences into the store the dispatcher reads", async () => {
+    installConfigApiMock({
+      firstRun: false,
+      config: defaultFlightSiteConfig({
+        notifications: {
+          enabled: true,
+          info: false,
+          interesting: false,
+          high: true,
+          critical: true,
+        },
+      }),
+    });
+    renderApp("/");
+
+    await waitFor(() => {
+      expect(useNotificationStore.getState().preferences).toEqual({
+        enabled: true,
+        info: false,
+        interesting: false,
+        high: true,
+        critical: true,
+      });
+    });
+  });
+
+  it("mirrors preferences without ever asking the browser for permission", async () => {
+    // `docs/SECURITY.md` §5: never unprompted. Loading the app is not a
+    // prompt, however enthusiastically the config says notifications are on.
+    const api = installNotificationMock({ permission: "default" });
+    installConfigApiMock({ firstRun: false });
+    renderApp("/");
+
+    await waitFor(() => {
+      expect(useNotificationStore.getState().preferences.enabled).toBe(true);
+    });
+    expect(api.requestPermission).not.toHaveBeenCalled();
   });
 
   it("leaves the map on its fallback config when the config fetch fails", async () => {

--- a/frontend/src/components/shell/RootLayout.tsx
+++ b/frontend/src/components/shell/RootLayout.tsx
@@ -1,15 +1,16 @@
 import { useEffect } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 
+import { applyServerConfigToNotificationStore } from "@/features/notifications/lib/configSync";
 import { applyServerConfigToMapStore } from "@/features/setup/lib/mapConfigSync";
 import { useConfigQuery } from "@/lib/api/config";
 
 const SETUP_PATH = "/setup";
 
 /**
- * Pathless root route (see `src/routes.tsx`): owns the two cross-cutting
+ * Pathless root route (see `src/routes.tsx`): owns the cross-cutting
  * behaviors that must run regardless of which page is active, and renders
- * nothing but `<Outlet />` so neither one ever blocks the page underneath
+ * nothing but `<Outlet />` so none of them ever blocks the page underneath
  * from rendering while the config query is in flight.
  *
  * - First-run redirect: once `GET /api/internal/config` reports
@@ -21,6 +22,11 @@ const SETUP_PATH = "/setup";
  *   it's applied to `useMapConfigStore` so the Live Map centers on the
  *   real site instead of the slice-013 dev placeholder — see
  *   `applyServerConfigToMapStore`.
+ * - Notification sync: the same config load feeds the user's per-severity
+ *   notification preferences (SPEC §46/§48) to `useNotificationStore`, where
+ *   the slice-040 dispatcher reads them without a React subscription. A
+ *   mirror only — this never asks the browser for permission, which
+ *   `docs/SECURITY.md` §5 allows solely in response to a user's own click.
  */
 export function RootLayout() {
   const { data } = useConfigQuery();
@@ -36,6 +42,7 @@ export function RootLayout() {
   useEffect(() => {
     if (data) {
       applyServerConfigToMapStore(data.config);
+      applyServerConfigToNotificationStore(data.config);
     }
   }, [data]);
 

--- a/frontend/src/features/map/aircraft/useLiveConnection.test.tsx
+++ b/frontend/src/features/map/aircraft/useLiveConnection.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * The socket-to-notification path, end to end through the real protocol
+ * client: an `activity` frame arrives and becomes exactly one browser
+ * notification (roadmap slice 040), while the activity store gets the same
+ * event for the panel.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useActivityFeedStore } from "@/features/activity/store/useActivityFeedStore";
+import { useLiveConnection } from "@/features/map/aircraft/useLiveConnection";
+import { useLiveAircraftStore } from "@/features/map/aircraft/store/useLiveAircraftStore";
+import { resetNotificationDedupe } from "@/features/notifications/lib/dedupe";
+import { useNotificationStore } from "@/features/notifications/store/useNotificationStore";
+import { alertTriggeredEvent } from "@/test/activityApiMock";
+import {
+  FakeNotification,
+  installNotificationMock,
+} from "@/test/notificationMock";
+import { getLastWebSocket } from "@/test/webSocketMock";
+
+const ALL_ON = {
+  enabled: true,
+  info: true,
+  interesting: true,
+  high: true,
+  critical: true,
+};
+
+function connectAndDeliver(...events: unknown[]): void {
+  const ws = getLastWebSocket();
+  act(() => {
+    ws.emitFrame({
+      type: "snapshot",
+      seq: 1,
+      data: { aircraft: [], receiver: null },
+    });
+    events.forEach((data, index) => {
+      ws.emitFrame({ type: "activity", seq: index + 2, data });
+    });
+  });
+}
+
+beforeEach(() => {
+  resetNotificationDedupe();
+  useActivityFeedStore.getState().reset();
+  useLiveAircraftStore.getState().reset();
+  useNotificationStore.getState().reset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetNotificationDedupe();
+  useActivityFeedStore.getState().reset();
+  useLiveAircraftStore.getState().reset();
+  useNotificationStore.getState().reset();
+});
+
+describe("useLiveConnection", () => {
+  it("turns an alert frame into one notification and one feed entry", () => {
+    installNotificationMock({ permission: "granted" });
+    useNotificationStore.getState().setPreferences(ALL_ON);
+    renderHook(() => {
+      useLiveConnection();
+    });
+
+    connectAndDeliver(alertTriggeredEvent());
+
+    expect(FakeNotification.instances).toHaveLength(1);
+    expect(FakeNotification.instances[0]?.title).toBe(
+      "RCH485 · Rule: Military aircraft",
+    );
+    expect(useActivityFeedStore.getState().events).toHaveLength(1);
+  });
+
+  it("shows one notification per match, and one more for the allowed upgrade", () => {
+    installNotificationMock({ permission: "granted" });
+    useNotificationStore.getState().setPreferences(ALL_ON);
+    renderHook(() => {
+      useLiveConnection();
+    });
+
+    connectAndDeliver(
+      alertTriggeredEvent({ id: 1 }),
+      // The same match redelivered — a duplicate frame must not double up.
+      alertTriggeredEvent({ id: 1 }),
+      // A second, higher-severity match against the same sighting: its own
+      // row on the backend, its own event id, and SPEC §48's allowed extra.
+      alertTriggeredEvent({
+        id: 2,
+        severity: "critical",
+        payload: { reason: "Rule: Emergency" },
+      }),
+    );
+
+    expect(FakeNotification.instances).toHaveLength(2);
+    expect(useNotificationStore.getState().delivered).toBe(2);
+  });
+
+  it("does not notify for non-alert activity", () => {
+    installNotificationMock({ permission: "granted" });
+    useNotificationStore.getState().setPreferences(ALL_ON);
+    renderHook(() => {
+      useLiveConnection();
+    });
+
+    connectAndDeliver({
+      id: 9,
+      type: "range_record",
+      severity: "interesting",
+      at: "2026-08-31T15:00:00.000Z",
+      icao: null,
+      sighting_id: null,
+      payload: { range_nm: 412.75 },
+    });
+
+    expect(FakeNotification.instances).toHaveLength(0);
+    expect(useActivityFeedStore.getState().events).toHaveLength(1);
+  });
+
+  it("delivers nothing, and breaks nothing, when the user has not opted in", () => {
+    // The store's default: no config loaded, so nothing is enabled.
+    installNotificationMock({ permission: "granted" });
+    renderHook(() => {
+      useLiveConnection();
+    });
+
+    connectAndDeliver(alertTriggeredEvent());
+
+    expect(FakeNotification.instances).toHaveLength(0);
+    expect(useActivityFeedStore.getState().events).toHaveLength(1);
+  });
+});

--- a/frontend/src/features/map/aircraft/useLiveConnection.ts
+++ b/frontend/src/features/map/aircraft/useLiveConnection.ts
@@ -14,12 +14,19 @@
  * `ActivityPanel` can show them arriving while the map is open — while
  * `/activity` reads the same events from the database when it is not. Both
  * stores are reset on unmount for the same reason.
+ *
+ * An `activity` frame also goes to `dispatchAlertNotification` (slice 040),
+ * which turns the two alert event types into a browser notification when the
+ * user has asked for one. It is called here rather than downstream of the
+ * store because delivery must survive the store's reset on teardown: "already
+ * notified" is a fact about the tab, not about the current connection.
  */
 
 import { useEffect } from "react";
 
 import { useActivityFeedStore } from "@/features/activity/store/useActivityFeedStore";
 import { useLiveAircraftStore } from "@/features/map/aircraft/store/useLiveAircraftStore";
+import { dispatchAlertNotification } from "@/features/notifications/lib/dispatch";
 import { LiveSocket } from "@/lib/ws/liveSocket";
 
 export function useLiveConnection(): void {
@@ -35,6 +42,7 @@ export function useLiveConnection(): void {
       },
       onActivity: (event) => {
         activity().addEvent(event);
+        dispatchAlertNotification(event);
       },
       onStatus: (status) => {
         store().setConnection(status);

--- a/frontend/src/features/notifications/components/NotificationPermissionStatus.test.tsx
+++ b/frontend/src/features/notifications/components/NotificationPermissionStatus.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NotificationPermissionStatus } from "@/features/notifications/components/NotificationPermissionStatus";
+import { useNotificationStore } from "@/features/notifications/store/useNotificationStore";
+import { installNotificationMock } from "@/test/notificationMock";
+
+beforeEach(() => {
+  useNotificationStore.getState().reset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  useNotificationStore.getState().reset();
+});
+
+describe("NotificationPermissionStatus", () => {
+  it("offers the ask, and asks only when the button is clicked", async () => {
+    const api = installNotificationMock({
+      permission: "default",
+      requestResult: "granted",
+    });
+    const user = userEvent.setup();
+    render(<NotificationPermissionStatus enabled />);
+
+    expect(
+      screen.getByText(/browser permission: not requested/i),
+    ).toBeVisible();
+    // The heart of `docs/SECURITY.md` §5: rendering must not prompt.
+    expect(api.requestPermission).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole("button", { name: /allow notifications/i }),
+    );
+
+    expect(api.requestPermission).toHaveBeenCalledTimes(1);
+    expect(
+      await screen.findByText(/browser permission: allowed/i),
+    ).toBeVisible();
+  });
+
+  it("reports a denial the user just gave, and stops offering the button", async () => {
+    installNotificationMock({ permission: "default", requestResult: "denied" });
+    const user = userEvent.setup();
+    render(<NotificationPermissionStatus enabled />);
+
+    await user.click(
+      screen.getByRole("button", { name: /allow notifications/i }),
+    );
+
+    expect(
+      await screen.findByText(/browser permission: blocked/i),
+    ).toBeVisible();
+    // Browsers resolve a re-request immediately without prompting, so a
+    // button here would look broken; the site-settings remedy is offered
+    // instead.
+    expect(
+      screen.queryByRole("button", { name: /allow notifications/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/site settings/i)).toBeVisible();
+  });
+
+  it("explains a blocked permission on mount", () => {
+    installNotificationMock({ permission: "denied" });
+    render(<NotificationPermissionStatus enabled />);
+
+    expect(screen.getByText(/browser permission: blocked/i)).toBeVisible();
+  });
+
+  it("names the insecure-origin case rather than calling it unsupported", () => {
+    // The most likely real-world cause: FlightSite reached over plain HTTP
+    // on a LAN address (`docs/SECURITY.md` §1).
+    vi.stubGlobal("Notification", undefined);
+    vi.stubGlobal("isSecureContext", false);
+    render(<NotificationPermissionStatus enabled />);
+
+    expect(
+      screen.getByText(/browser permission: unavailable on this address/i),
+    ).toBeVisible();
+    expect(screen.getByText(/HTTPS or on localhost/i)).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: /allow notifications/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("names an unsupported browser", () => {
+    vi.stubGlobal("Notification", undefined);
+    vi.stubGlobal("isSecureContext", true);
+    render(<NotificationPermissionStatus enabled />);
+
+    expect(
+      screen.getByText(/browser permission: unavailable in this browser/i),
+    ).toBeVisible();
+  });
+
+  it("points out a granted permission that the master switch is wasting", () => {
+    installNotificationMock({ permission: "granted" });
+    render(<NotificationPermissionStatus enabled={false} />);
+
+    expect(screen.getByText(/switched off above/i)).toBeVisible();
+  });
+
+  it("surfaces what could not be shown", () => {
+    installNotificationMock({ permission: "denied" });
+    useNotificationStore.getState().recordSuppressed();
+    render(<NotificationPermissionStatus enabled />);
+
+    expect(
+      screen.getByText(/1 alert this session could not be shown/i),
+    ).toBeVisible();
+  });
+
+  it("pluralises the suppressed count and names the last error", () => {
+    installNotificationMock({ permission: "granted" });
+    useNotificationStore.getState().recordSuppressed();
+    useNotificationStore.getState().recordError("constructor failed");
+    render(<NotificationPermissionStatus enabled />);
+
+    expect(
+      screen.getByText(/2 alerts this session could not be shown/i),
+    ).toBeVisible();
+    expect(screen.getByText(/constructor failed/i)).toBeVisible();
+  });
+
+  it("re-reads the permission when the tab becomes visible again", async () => {
+    // The user may have unblocked FlightSite in the browser's own site
+    // settings while away from the tab.
+    const api = installNotificationMock({ permission: "denied" });
+    render(<NotificationPermissionStatus enabled />);
+    expect(screen.getByText(/browser permission: blocked/i)).toBeVisible();
+
+    api.permission = "granted";
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(
+      await screen.findByText(/browser permission: allowed/i),
+    ).toBeVisible();
+  });
+});

--- a/frontend/src/features/notifications/components/NotificationPermissionStatus.test.tsx
+++ b/frontend/src/features/notifications/components/NotificationPermissionStatus.test.tsx
@@ -68,6 +68,27 @@ describe("NotificationPermissionStatus", () => {
     expect(screen.getByText(/browser permission: blocked/i)).toBeVisible();
   });
 
+  it("publishes the state behind the prose for the E2E spec to compare", () => {
+    // `e2e/tests/05-browser-notifications.spec.ts` asserts this attribute
+    // against what the browser itself reports, so the two must keep the same
+    // vocabulary — and a copy edit must not be able to fail that spec.
+    installNotificationMock({ permission: "denied" });
+    const { rerender } = render(<NotificationPermissionStatus enabled />);
+
+    expect(
+      screen.getByTestId("notification-permission-status"),
+    ).toHaveAttribute("data-permission", "denied");
+
+    vi.stubGlobal("Notification", undefined);
+    vi.stubGlobal("isSecureContext", false);
+    useNotificationStore.getState().refreshPermission();
+    rerender(<NotificationPermissionStatus enabled />);
+
+    expect(
+      screen.getByTestId("notification-permission-status"),
+    ).toHaveAttribute("data-permission", "insecure-context");
+  });
+
   it("names the insecure-origin case rather than calling it unsupported", () => {
     // The most likely real-world cause: FlightSite reached over plain HTTP
     // on a LAN address (`docs/SECURITY.md` §1).

--- a/frontend/src/features/notifications/components/NotificationPermissionStatus.test.tsx
+++ b/frontend/src/features/notifications/components/NotificationPermissionStatus.test.tsx
@@ -40,6 +40,33 @@ describe("NotificationPermissionStatus", () => {
     ).toBeVisible();
   });
 
+  it("shows the ask in flight, and does not ask twice while it is", async () => {
+    // Headless Firefox does exactly this: it reports `default`, accepts the
+    // request, and never settles it, because settling it is the prompt's job
+    // and there is no prompt. A real user can also simply leave the prompt
+    // sitting on screen. Either way the button must say so and refuse to
+    // stack a second request behind the first.
+    const api = installNotificationMock({ permission: "default" });
+    api.requestPermission = vi.fn(
+      () => new Promise<NotificationPermission>(() => {}),
+    ) as unknown as typeof api.requestPermission;
+    const user = userEvent.setup();
+    render(<NotificationPermissionStatus enabled />);
+
+    const ask = screen.getByRole("button", { name: /allow notifications/i });
+    await user.click(ask);
+
+    const pending = screen.getByRole("button", { name: /asking/i });
+    expect(pending).toBeDisabled();
+    expect(
+      screen.getByText(/browser permission: not requested/i),
+    ).toBeVisible();
+
+    await user.click(pending);
+
+    expect(api.requestPermission).toHaveBeenCalledTimes(1);
+  });
+
   it("reports a denial the user just gave, and stops offering the button", async () => {
     installNotificationMock({ permission: "default", requestResult: "denied" });
     const user = userEvent.setup();

--- a/frontend/src/features/notifications/components/NotificationPermissionStatus.tsx
+++ b/frontend/src/features/notifications/components/NotificationPermissionStatus.tsx
@@ -1,0 +1,158 @@
+/**
+ * The browser's side of the notification story, made visible (roadmap slice
+ * 040): what this browser currently allows, the button that asks it, and what
+ * FlightSite could not show because it said no.
+ *
+ * Rendered inside the Notifications settings section — the place
+ * `docs/SECURITY.md` §5 names as one of the two opt-in surfaces, and the one
+ * the roadmap requires the request to be *re-promptable* from. Slice 042's
+ * health area shows the same permission from the same store
+ * (`docs/PRODUCT.md` §4.11).
+ *
+ * Each unhappy state gets its own sentence rather than a shared "unavailable",
+ * because the remedies are entirely different: a blocked permission is fixed
+ * in the browser's site settings, while an insecure origin cannot be fixed
+ * there at all. The insecure case is not hypothetical — FlightSite is normally
+ * reached over plain HTTP on a LAN address (`docs/SECURITY.md` §1), and every
+ * current browser withholds the Notification API outside HTTPS or `localhost`.
+ */
+
+import { BellOff, BellRing, ShieldAlert } from "lucide-react";
+
+import { useNotificationPermission } from "@/features/notifications/useNotificationPermission";
+import { canRequest } from "@/features/notifications/lib/permission";
+import { useNotificationStore } from "@/features/notifications/store/useNotificationStore";
+import { Button } from "@/components/ui/button";
+
+export interface NotificationPermissionStatusProps {
+  /** The saved master preference. When notifications are switched off, the
+   * permission is reported but not chased — asking a browser for a permission
+   * the user has just declined to use would be noise. */
+  enabled: boolean;
+}
+
+interface StatusCopy {
+  label: string;
+  detail: string;
+  tone: "ok" | "warn" | "muted";
+}
+
+function statusCopy(
+  permission: ReturnType<typeof useNotificationPermission>["permission"],
+): StatusCopy {
+  switch (permission) {
+    case "granted":
+      return {
+        label: "Allowed",
+        detail:
+          "This browser will show FlightSite alert notifications, including while the tab is in the background.",
+        tone: "ok",
+      };
+    case "denied":
+      return {
+        label: "Blocked",
+        detail:
+          "This browser is blocking notifications for FlightSite. Allow them in the browser's site settings for this address (usually the icon at the left of the address bar), then reload.",
+        tone: "warn",
+      };
+    case "insecure-context":
+      return {
+        label: "Unavailable on this address",
+        detail:
+          "Browsers only offer notifications over HTTPS or on localhost. FlightSite is open over plain HTTP, so the Notification API is not available here — everything else about alerts (the map, the interesting panel, the activity feed) is unaffected.",
+        tone: "warn",
+      };
+    case "unsupported":
+      return {
+        label: "Unavailable in this browser",
+        detail:
+          "This browser does not support the Notification API. Alerts still appear in the interesting-aircraft panel and the activity feed.",
+        tone: "warn",
+      };
+    default:
+      return {
+        label: "Not requested",
+        detail:
+          "FlightSite has not asked this browser for permission yet. It will ask only when you choose to.",
+        tone: "muted",
+      };
+  }
+}
+
+const TONE_CLASS: Record<StatusCopy["tone"], string> = {
+  ok: "text-accent-foreground",
+  warn: "text-destructive",
+  muted: "text-muted-foreground",
+};
+
+export function NotificationPermissionStatus({
+  enabled,
+}: NotificationPermissionStatusProps) {
+  const { permission, isRequesting, request } = useNotificationPermission();
+  const suppressed = useNotificationStore((state) => state.suppressed);
+  const lastError = useNotificationStore((state) => state.lastError);
+  const copy = statusCopy(permission);
+  const Icon =
+    permission === "granted"
+      ? BellRing
+      : permission === "denied"
+        ? ShieldAlert
+        : BellOff;
+
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-lg border border-border bg-muted/30 p-3"
+      data-testid="notification-permission-status"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex items-start gap-2"
+        >
+          <Icon
+            className={`mt-0.5 size-4 shrink-0 ${TONE_CLASS[copy.tone]}`}
+            aria-hidden="true"
+          />
+          <span className="flex flex-col gap-0.5">
+            <span className="text-sm font-medium">
+              Browser permission: {copy.label}
+            </span>
+            <span className="text-xs text-muted-foreground">{copy.detail}</span>
+          </span>
+        </div>
+        {canRequest(permission) && (
+          <Button
+            type="button"
+            variant="accent"
+            size="sm"
+            disabled={isRequesting}
+            onClick={() => {
+              // Fired straight from the click: `requestPermission()` needs the
+              // user activation this handler still holds (lib/permission.ts).
+              void request();
+            }}
+          >
+            {isRequesting ? "Asking…" : "Allow notifications"}
+          </Button>
+        )}
+      </div>
+
+      {permission === "granted" && !enabled && (
+        <p className="text-xs text-muted-foreground">
+          Notifications are switched off above, so nothing will be shown even
+          though the browser allows it.
+        </p>
+      )}
+
+      {suppressed > 0 && (
+        <p className="text-xs text-destructive">
+          {suppressed === 1
+            ? "1 alert this session could not be shown as a notification."
+            : `${suppressed.toLocaleString()} alerts this session could not be shown as notifications.`}
+          {lastError === null ? "" : ` Last error: ${lastError}`}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/notifications/components/NotificationPermissionStatus.tsx
+++ b/frontend/src/features/notifications/components/NotificationPermissionStatus.tsx
@@ -103,6 +103,12 @@ export function NotificationPermissionStatus({
     <div
       className="flex flex-col gap-2 rounded-lg border border-border bg-muted/30 p-3"
       data-testid="notification-permission-status"
+      // The state behind the prose. The E2E spec compares this against what
+      // the browser itself reports, which is the invariant worth pinning —
+      // asserting the sentence instead would turn a copy edit into a failing
+      // end-to-end test and would say nothing about whether FlightSite and
+      // the browser actually agree.
+      data-permission={permission}
     >
       <div className="flex items-start justify-between gap-3">
         <div

--- a/frontend/src/features/notifications/lib/compose.test.ts
+++ b/frontend/src/features/notifications/lib/compose.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import { composeAlertNotification } from "@/features/notifications/lib/compose";
+import {
+  activityEvent,
+  alertTriggeredEvent,
+  emergencySquawkEvent,
+} from "@/test/activityApiMock";
+
+describe("composeAlertNotification", () => {
+  it("includes everything SPEC §48 asks a notification to carry", () => {
+    const content = composeAlertNotification(alertTriggeredEvent(), "aviation");
+
+    expect(content).not.toBeNull();
+    // Callsign/tail and the match reason.
+    expect(content?.title).toBe("RCH485 · Rule: Military aircraft");
+    // Tail, aircraft type, operator, classification, distance and altitude.
+    expect(content?.body).toContain("05-5153");
+    expect(content?.body).toContain("C17 · Boeing C-17A Globemaster III");
+    expect(content?.body).toContain("United States Air Force");
+    expect(content?.body).toContain("Military");
+    expect(content?.body).toContain("12.4 nm");
+    expect(content?.body).toContain("24,000 ft");
+  });
+
+  it("carries the event's own identity for click-through and dedupe", () => {
+    const content = composeAlertNotification(
+      alertTriggeredEvent({ id: 91, icao: "ae1463" }),
+      "aviation",
+    );
+
+    expect(content?.icao).toBe("ae1463");
+    expect(content?.severity).toBe("high");
+    expect(content?.tag).toBe("flightsite-alert-91");
+  });
+
+  it("leads an emergency squawk with its code and keeps the reason in the body", () => {
+    const content = composeAlertNotification(
+      emergencySquawkEvent(),
+      "aviation",
+    );
+
+    expect(content?.title).toBe("RYR8213 · Emergency squawk 7700");
+    expect(
+      content?.body.startsWith("Emergency squawk 7700 (general emergency)"),
+    ).toBe(true);
+  });
+
+  it("does not repeat a rule match's reason in the body", () => {
+    const content = composeAlertNotification(alertTriggeredEvent(), "aviation");
+
+    const occurrences = `${content?.title}\n${content?.body}`.split(
+      "Rule: Military aircraft",
+    ).length;
+    expect(occurrences).toBe(2); // one split -> the string appears once
+  });
+
+  it("converts distance and altitude for a metric install", () => {
+    const content = composeAlertNotification(alertTriggeredEvent(), "metric");
+
+    expect(content?.body).toContain("23.0 km");
+    expect(content?.body).toContain("7,315 m");
+  });
+
+  it("lists every classification that applies", () => {
+    const content = composeAlertNotification(
+      alertTriggeredEvent({
+        payload: { government: true, law_enforcement: true },
+      }),
+      "aviation",
+    );
+
+    expect(content?.body).toContain("Military, Government, Law enforcement");
+  });
+
+  it("falls back through callsign, tail, then the ICAO address", () => {
+    const noCallsign = composeAlertNotification(
+      alertTriggeredEvent({ payload: { callsign: null } }),
+      "aviation",
+    );
+    expect(noCallsign?.title.startsWith("05-5153 ·")).toBe(true);
+    // The tail is the name now, so it is not repeated in the body.
+    expect(noCallsign?.body).not.toContain("05-5153 ·");
+
+    const anonymous = composeAlertNotification(
+      alertTriggeredEvent({
+        payload: { callsign: null, registration: null },
+      }),
+      "aviation",
+    );
+    expect(anonymous?.title.startsWith("AE1463 ·")).toBe(true);
+  });
+
+  it("drops absent fields instead of rendering them", () => {
+    const content = composeAlertNotification(
+      alertTriggeredEvent({
+        payload: {
+          registration: null,
+          type_code: null,
+          model: null,
+          operator: null,
+          distance_nm: null,
+          altitude_ft: null,
+          military: false,
+        },
+      }),
+      "aviation",
+    );
+
+    expect(content?.title).toBe("RCH485 · Rule: Military aircraft");
+    expect(content?.body).toBe("");
+    expect(content?.body).not.toContain("undefined");
+    expect(content?.body).not.toContain("null");
+  });
+
+  it("survives a payload whose fields are the wrong type", () => {
+    const content = composeAlertNotification(
+      alertTriggeredEvent({
+        payload: {
+          callsign: 42,
+          distance_nm: "far",
+          altitude_ft: Number.NaN,
+          military: "yes",
+        },
+      }),
+      "aviation",
+    );
+
+    expect(content?.title).toBe("05-5153 · Rule: Military aircraft");
+    expect(content?.body).not.toContain("far");
+    expect(content?.body).not.toContain("Military");
+  });
+
+  it("falls back to the rule name, then to a bare label, for a reasonless match", () => {
+    expect(
+      composeAlertNotification(
+        alertTriggeredEvent({ payload: { reason: null } }),
+        "aviation",
+      )?.title,
+    ).toBe("RCH485 · Military aircraft");
+
+    expect(
+      composeAlertNotification(
+        alertTriggeredEvent({ payload: { reason: null, rule_name: null } }),
+        "aviation",
+      )?.title,
+    ).toBe("RCH485 · Alert");
+  });
+
+  it("names an emergency without a squawk code generically", () => {
+    expect(
+      composeAlertNotification(
+        emergencySquawkEvent({ payload: { squawk: null } }),
+        "aviation",
+      )?.title,
+    ).toBe("RYR8213 · Emergency squawk");
+  });
+
+  it("is null for every activity event that is not an alert", () => {
+    expect(composeAlertNotification(activityEvent(), "aviation")).toBeNull();
+    expect(
+      composeAlertNotification(
+        activityEvent({ type: "range_record", severity: "interesting" }),
+        "aviation",
+      ),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/features/notifications/lib/compose.ts
+++ b/frontend/src/features/notifications/lib/compose.ts
@@ -1,0 +1,204 @@
+/**
+ * Turns an alert activity event into the text of one browser notification
+ * (SPEC §48, roadmap slice 040).
+ *
+ * SPEC §48 names the payload exactly — *"include useful information
+ * (callsign/tail, aircraft type, classification, altitude, distance, match
+ * reason)"* — and slice 038's `alert_events()` producer
+ * (`backend/src/flightsite/activity/producers.py`) ships every one of those
+ * fields on the `alert_triggered` / `emergency_squawk` payload. This module is
+ * the whole mapping from that payload to a title and a body, kept pure so the
+ * wording is testable without a browser, a socket, or a permission.
+ *
+ * **Only aircraft data crosses this boundary.** `docs/SECURITY.md` §5:
+ * *"Notification content includes aircraft data only — never secrets or
+ * configuration"*. Every field read here is named explicitly below; nothing
+ * reads the config document, and nothing forwards an unrecognised payload key
+ * into the text.
+ *
+ * **Wording follows the feed, not a second voice.** `reason` is the alert
+ * engine's own sentence for the match ("Rule: Military aircraft", "Emergency
+ * squawk 7700 (general emergency)"), and it is passed through rather than
+ * reworded — the same choice, for the same reason, that
+ * `features/activity/lib/describeActivityEvent.ts` documents: it names a rule
+ * the *user* wrote, so a notification and the feed row about the same match
+ * must not drift apart.
+ *
+ * Every field degrades. `payload` arrives as `Record<string, unknown>` from a
+ * WebSocket frame validated no further than its envelope, so an absent or
+ * wrong-typed value drops out of the text instead of rendering `undefined`.
+ */
+
+import {
+  formatAltitude,
+  formatDistance,
+} from "@/features/aircraft-detail/lib/format";
+import type { ActivityEvent } from "@/lib/api/activity";
+import type { UnitSystem } from "@/lib/api/config";
+import type { AlertSeverity } from "@/lib/api/sightings";
+
+/** The two `docs/API.md` §3.9 event types slice 038 emits for a recorded
+ * alert match. Every other activity type is somebody else's event and never
+ * becomes a notification. */
+const ALERT_EVENT_TYPES = new Set(["alert_triggered", "emergency_squawk"]);
+
+/** One notification, ready to hand to the browser. */
+export interface AlertNotificationContent {
+  title: string;
+  body: string;
+  /**
+   * The OS-level collapse key, `flightsite-alert-{event id}`.
+   *
+   * Deliberately derived from the event id, which is stable across clients:
+   * two FlightSite tabs open on the same receiver both fire for the same
+   * match, and a shared tag means the user sees **one** notification rather
+   * than one per tab. Within a single tab the id is also the dedupe key
+   * (`lib/dedupe.ts`), so the tag is a second, independent line of defence
+   * for the SPEC §48 "once per sighting per rule" guarantee.
+   */
+  tag: string;
+  /** The airframe to select when the notification is clicked; `null` for an
+   * alert the backend could not attribute to an ICAO address. */
+  icao: string | null;
+  severity: AlertSeverity;
+}
+
+type Payload = Record<string, unknown>;
+
+function str(payload: Payload, key: string): string | null {
+  const value = payload[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function num(payload: Payload, key: string): number | null {
+  const value = payload[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function join(
+  parts: readonly (string | null)[],
+  separator = " · ",
+): string | null {
+  const present = parts.filter((part): part is string => part !== null);
+  return present.length === 0 ? null : present.join(separator);
+}
+
+/**
+ * What to call this aircraft: callsign, else tail, else the ICAO address.
+ *
+ * Callsign first because it is what the user sees on the map label and what
+ * air traffic control says out loud; the ICAO hex is the last resort that
+ * guarantees the notification always names *something* (`docs/API.md` §2.7 —
+ * unknown is `null`, never a blank string).
+ */
+function identity(payload: Payload, icao: string | null): string {
+  return (
+    str(payload, "callsign") ??
+    str(payload, "registration") ??
+    (icao === null ? null : icao.toUpperCase()) ??
+    str(payload, "icao")?.toUpperCase() ??
+    "Unknown aircraft"
+  );
+}
+
+/** SPEC §48's "aircraft type": the resolved model, qualified by its type code
+ * when both are known (`"B77W · Boeing 777-300ER"`). */
+function aircraftType(payload: Payload): string | null {
+  const typeCode = str(payload, "type_code");
+  const model = str(payload, "model");
+  if (typeCode !== null && model !== null) {
+    return `${typeCode} · ${model}`;
+  }
+  return model ?? typeCode;
+}
+
+/**
+ * SPEC §48's "classification": the operator-category flags slice 038 resolves,
+ * as words.
+ *
+ * All three can be true at once (a government law-enforcement aircraft), so
+ * they are listed rather than collapsed to the first hit — the classification
+ * is *why* many rules fire, and dropping part of it would make the
+ * notification disagree with the reason beside it.
+ */
+function classification(payload: Payload): string | null {
+  return join(
+    [
+      payload.military === true ? "Military" : null,
+      payload.government === true ? "Government" : null,
+      payload.law_enforcement === true ? "Law enforcement" : null,
+    ],
+    ", ",
+  );
+}
+
+/**
+ * The headline half of the title.
+ *
+ * An emergency squawk leads with the code, because SPEC §47 wants these
+ * *prominent* rather than one alert among many and the code is the fact that
+ * makes it so — the fuller `reason` then moves into the body. Every other
+ * alert leads with the match reason itself, falling back to the rule's name
+ * and finally to a bare label for a payload carrying neither.
+ */
+function headline(event: ActivityEvent, payload: Payload): string {
+  if (event.type === "emergency_squawk") {
+    const squawk = str(payload, "squawk");
+    return squawk === null ? "Emergency squawk" : `Emergency squawk ${squawk}`;
+  }
+  return str(payload, "reason") ?? str(payload, "rule_name") ?? "Alert";
+}
+
+/**
+ * The notification for one alert event, or `null` when the event is not an
+ * alert at all.
+ *
+ * `units` is the receiver's display preference (`docs/API.md` §3.2): the wire
+ * is always nm/ft (`CLAUDE.md`), and the conversion happens here so a metric
+ * install reads a metric notification.
+ */
+export function composeAlertNotification(
+  event: ActivityEvent,
+  units: UnitSystem,
+): AlertNotificationContent | null {
+  if (!ALERT_EVENT_TYPES.has(event.type)) {
+    return null;
+  }
+  const payload = event.payload;
+  const name = identity(payload, event.icao);
+  const lead = headline(event, payload);
+
+  // The reason is already the headline for a rule match, so repeating it in
+  // the body would fill a two-line notification with one sentence twice.
+  const reason =
+    event.type === "emergency_squawk" ? str(payload, "reason") : null;
+  const tail = str(payload, "registration");
+
+  const body =
+    join(
+      [
+        reason,
+        join([
+          tail === name ? null : tail,
+          aircraftType(payload),
+          str(payload, "operator"),
+        ]),
+        classification(payload),
+        join([
+          formatDistance(num(payload, "distance_nm"), units),
+          formatAltitude(num(payload, "altitude_ft"), units),
+        ]),
+      ],
+      "\n",
+    ) ?? "";
+
+  return {
+    title: `${name} · ${lead}`,
+    body,
+    tag: `flightsite-alert-${event.id}`,
+    icao: event.icao,
+    severity: event.severity,
+  };
+}

--- a/frontend/src/features/notifications/lib/configSync.ts
+++ b/frontend/src/features/notifications/lib/configSync.ts
@@ -1,0 +1,24 @@
+/**
+ * Mirrors the server's notification settings into
+ * {@link useNotificationStore}, so the dispatcher can read the user's choices
+ * on a WebSocket frame without a React subscription.
+ *
+ * Called from `RootLayout` on every config load — the same seam, for the same
+ * reason, as `features/setup/lib/mapConfigSync.ts`'s
+ * `applyServerConfigToMapStore`: the config document is fetched once and
+ * cached by TanStack Query, and the stores that need a slice of it are fed
+ * from that one load rather than each opening a query of their own.
+ *
+ * This is a mirror, never a source. `config.notifications` (SPEC §46/§48) is
+ * written by the setup wizard and the Settings page and stored in
+ * `config.yaml`; nothing here writes back.
+ */
+
+import { useNotificationStore } from "@/features/notifications/store/useNotificationStore";
+import type { FlightSiteConfig } from "@/lib/api/config";
+
+export function applyServerConfigToNotificationStore(
+  config: FlightSiteConfig,
+): void {
+  useNotificationStore.getState().setPreferences(config.notifications);
+}

--- a/frontend/src/features/notifications/lib/dedupe.test.ts
+++ b/frontend/src/features/notifications/lib/dedupe.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  claimNotification,
+  DEDUPE_CAPACITY,
+  hasNotified,
+  resetNotificationDedupe,
+} from "@/features/notifications/lib/dedupe";
+
+beforeEach(() => {
+  resetNotificationDedupe();
+});
+
+describe("claimNotification", () => {
+  it("claims an event once", () => {
+    expect(claimNotification(11)).toBe(true);
+    expect(hasNotified(11)).toBe(true);
+  });
+
+  it("refuses a second claim on the same event", () => {
+    claimNotification(11);
+
+    expect(claimNotification(11)).toBe(false);
+  });
+
+  it("treats a different event as different, which is how a severity upgrade notifies again", () => {
+    // Slice 038 records an upgraded match as its own row with its own
+    // activity event, which is SPEC §48's allowed extra notification.
+    expect(claimNotification(11)).toBe(true);
+    expect(claimNotification(12)).toBe(true);
+  });
+
+  it("bounds what it remembers, evicting the oldest first", () => {
+    for (let id = 1; id <= DEDUPE_CAPACITY; id += 1) {
+      claimNotification(id);
+    }
+    expect(hasNotified(1)).toBe(true);
+
+    claimNotification(DEDUPE_CAPACITY + 1);
+
+    expect(hasNotified(1)).toBe(false);
+    expect(hasNotified(2)).toBe(true);
+    expect(hasNotified(DEDUPE_CAPACITY + 1)).toBe(true);
+  });
+
+  it("forgets everything on reset", () => {
+    claimNotification(11);
+    resetNotificationDedupe();
+
+    expect(hasNotified(11)).toBe(false);
+  });
+});

--- a/frontend/src/features/notifications/lib/dedupe.ts
+++ b/frontend/src/features/notifications/lib/dedupe.ts
@@ -1,0 +1,67 @@
+/**
+ * "One match, one notification", held for the life of the tab (SPEC §48).
+ *
+ * **The guarantee is the backend's; this is the client's half of keeping it.**
+ * Slice 038's two partial unique indexes on `alert_matches` are what make a
+ * rule fire once per sighting, and `alert_events()` emits exactly one activity
+ * event per row it actually recorded — so a distinct event id *is* a distinct
+ * match, and SPEC §48's allowed extra ("a newly matched higher-priority
+ * condition may create another notification") arrives as its own id with no
+ * special case here. Re-deriving the rule/sighting identity on the client
+ * would be a second, drifting implementation of a guarantee that already
+ * holds.
+ *
+ * What the client must still stop is the same *event* being handled twice:
+ * a socket that reconnects while a frame is in flight, a React StrictMode
+ * double effect, or a Live Map remount. Module scope rather than store state
+ * is deliberate — `useActivityFeedStore` resets on socket teardown (so its own
+ * id check cannot outlive a remount), while what a user has already been shown
+ * must outlive one.
+ *
+ * Bounded, because a tab left open for weeks must not accumulate ids without
+ * limit. The bound is far above any plausible burst, and eviction is oldest
+ * first, so re-notifying could only happen for an event pushed out by
+ * {@link DEDUPE_CAPACITY} more recent ones — by which point the notification
+ * is long gone from the user's screen anyway.
+ */
+
+/** How many recently notified event ids are remembered. A busy receiver fires
+ * a few alerts an hour, so this is weeks of history in a few kilobytes. */
+export const DEDUPE_CAPACITY = 500;
+
+/** Insertion-ordered, which is what makes "evict the oldest" a `keys().next()`
+ * away without a second structure. */
+const notified = new Set<number>();
+
+/**
+ * Marks an event id as notified, returning `false` when it already was.
+ *
+ * Call this at the moment of delivery, not on receipt: an alert the user has
+ * muted or has no permission for should not consume its id, so that turning
+ * notifications on does not silently swallow the next repeat of a frame.
+ */
+export function claimNotification(eventId: number): boolean {
+  if (notified.has(eventId)) {
+    return false;
+  }
+  notified.add(eventId);
+  if (notified.size > DEDUPE_CAPACITY) {
+    const oldest = notified.values().next();
+    if (!oldest.done) {
+      notified.delete(oldest.value);
+    }
+  }
+  return true;
+}
+
+/** Whether this event has already produced a notification. */
+export function hasNotified(eventId: number): boolean {
+  return notified.has(eventId);
+}
+
+/** Forgets everything — for tests, which must not leak claimed ids into one
+ * another. Production has no reason to call it: the set is scoped to the tab,
+ * and so is what the user has been shown. */
+export function resetNotificationDedupe(): void {
+  notified.clear();
+}

--- a/frontend/src/features/notifications/lib/dispatch.test.ts
+++ b/frontend/src/features/notifications/lib/dispatch.test.ts
@@ -1,0 +1,241 @@
+/**
+ * The slice-040 acceptance criteria, at the dispatch seam: "exactly one
+ * notification per rule per sighting; the upgrade path produces the allowed
+ * extra", "clicking selects the aircraft", and "denied permission degrades
+ * cleanly".
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resetNotificationDedupe } from "@/features/notifications/lib/dedupe";
+import { dispatchAlertNotification } from "@/features/notifications/lib/dispatch";
+import { useNotificationStore } from "@/features/notifications/store/useNotificationStore";
+import { useLiveAircraftStore } from "@/features/map/aircraft/store/useLiveAircraftStore";
+import {
+  activityEvent,
+  alertTriggeredEvent,
+  emergencySquawkEvent,
+} from "@/test/activityApiMock";
+import { defaultReceiverInfo } from "@/test/aircraftApiMock";
+import {
+  installNotificationMock,
+  lastNotification,
+} from "@/test/notificationMock";
+
+const ALL_ON = {
+  enabled: true,
+  info: true,
+  interesting: true,
+  high: true,
+  critical: true,
+};
+
+function enableAll(): void {
+  useNotificationStore.getState().setPreferences(ALL_ON);
+}
+
+beforeEach(() => {
+  resetNotificationDedupe();
+  useNotificationStore.getState().reset();
+  useLiveAircraftStore.getState().reset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetNotificationDedupe();
+  useNotificationStore.getState().reset();
+  useLiveAircraftStore.getState().reset();
+});
+
+describe("dispatchAlertNotification", () => {
+  it("shows one notification for an alert the user asked for", () => {
+    installNotificationMock({ permission: "granted" });
+    enableAll();
+
+    expect(dispatchAlertNotification(alertTriggeredEvent())).toBe("delivered");
+
+    const shown = lastNotification();
+    expect(shown?.title).toBe("RCH485 · Rule: Military aircraft");
+    expect(shown?.options.body).toContain("12.4 nm");
+    expect(shown?.options.tag).toBe("flightsite-alert-5100");
+    expect(useNotificationStore.getState().delivered).toBe(1);
+  });
+
+  it("shows exactly one notification when the same event arrives twice", () => {
+    // A reconnect overlapping a frame in flight, or a Live Map remount.
+    installNotificationMock({ permission: "granted" });
+    enableAll();
+    const event = alertTriggeredEvent();
+
+    expect(dispatchAlertNotification(event)).toBe("delivered");
+    expect(dispatchAlertNotification(event)).toBe("duplicate");
+
+    expect(useNotificationStore.getState().delivered).toBe(1);
+  });
+
+  it("survives a Live Map remount without re-notifying", () => {
+    installNotificationMock({ permission: "granted" });
+    enableAll();
+    const event = alertTriggeredEvent();
+    dispatchAlertNotification(event);
+
+    // What `useLiveConnection` does on unmount; the dedupe record must
+    // outlive it, which is why it does not live in the activity store.
+    useLiveAircraftStore.getState().reset();
+
+    expect(dispatchAlertNotification(event)).toBe("duplicate");
+  });
+
+  it("notifies again for the severity upgrade SPEC §48 allows", () => {
+    // Slice 038 records a higher-severity match as its own row — a different
+    // rule (or a second built-in key) against the same sighting — so it
+    // reaches the client as a distinct event id.
+    installNotificationMock({ permission: "granted" });
+    enableAll();
+
+    expect(
+      dispatchAlertNotification(
+        alertTriggeredEvent({
+          id: 5100,
+          severity: "interesting",
+          payload: { reason: "Rule: Watchlist match" },
+        }),
+      ),
+    ).toBe("delivered");
+    expect(
+      dispatchAlertNotification(
+        emergencySquawkEvent({ id: 5101, sighting_id: 88213 }),
+      ),
+    ).toBe("delivered");
+
+    expect(useNotificationStore.getState().delivered).toBe(2);
+    expect(lastNotification()?.title).toBe("RYR8213 · Emergency squawk 7700");
+  });
+
+  it("ignores every activity event that is not an alert", () => {
+    installNotificationMock({ permission: "granted" });
+    enableAll();
+
+    expect(dispatchAlertNotification(activityEvent())).toBe("not-an-alert");
+    expect(useNotificationStore.getState().delivered).toBe(0);
+  });
+
+  it("shows nothing while the master switch is off", () => {
+    installNotificationMock({ permission: "granted" });
+
+    expect(dispatchAlertNotification(alertTriggeredEvent())).toBe("disabled");
+    expect(lastNotification()).toBeUndefined();
+  });
+
+  it("respects the per-severity choice", () => {
+    installNotificationMock({ permission: "granted" });
+    useNotificationStore.getState().setPreferences({ ...ALL_ON, high: false });
+
+    expect(dispatchAlertNotification(alertTriggeredEvent())).toBe("muted");
+    expect(dispatchAlertNotification(emergencySquawkEvent())).toBe("delivered");
+  });
+
+  it("does not consume an event's dedupe claim while it is muted", () => {
+    // Turning a severity back on must not silently swallow the next repeat.
+    installNotificationMock({ permission: "granted" });
+    useNotificationStore.getState().setPreferences({ ...ALL_ON, high: false });
+    const event = alertTriggeredEvent();
+    dispatchAlertNotification(event);
+
+    enableAll();
+
+    expect(dispatchAlertNotification(event)).toBe("delivered");
+  });
+
+  it("degrades cleanly and countably when permission is denied", () => {
+    installNotificationMock({ permission: "denied" });
+    enableAll();
+
+    expect(dispatchAlertNotification(alertTriggeredEvent())).toBe("blocked");
+
+    const state = useNotificationStore.getState();
+    expect(state.permission).toBe("denied");
+    expect(state.suppressed).toBe(1);
+    expect(state.delivered).toBe(0);
+    expect(lastNotification()).toBeUndefined();
+  });
+
+  it("never prompts for permission from an incoming alert", () => {
+    // `docs/SECURITY.md` §5: requested only after the user opts in, never
+    // unprompted — and a socket frame carries no user gesture to ask from.
+    const api = installNotificationMock({ permission: "default" });
+    enableAll();
+
+    expect(dispatchAlertNotification(alertTriggeredEvent())).toBe("blocked");
+    expect(api.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("notices a permission revoked in the browser since the last read", () => {
+    const api = installNotificationMock({ permission: "granted" });
+    enableAll();
+    api.permission = "denied";
+
+    expect(dispatchAlertNotification(alertTriggeredEvent())).toBe("blocked");
+  });
+
+  it("degrades cleanly where the browser has no Notification API at all", () => {
+    // jsdom's default, and a real plain-HTTP LAN install's.
+    vi.stubGlobal("Notification", undefined);
+    enableAll();
+
+    expect(dispatchAlertNotification(alertTriggeredEvent())).toBe("blocked");
+    expect(useNotificationStore.getState().suppressed).toBe(1);
+  });
+
+  it("records a construction failure rather than throwing at the socket", () => {
+    const api = installNotificationMock({ permission: "granted" });
+    api.constructorError = new Error("Notifications are not supported here");
+    enableAll();
+
+    expect(dispatchAlertNotification(alertTriggeredEvent())).toBe("failed");
+    expect(useNotificationStore.getState().lastError).toBe(
+      "Notifications are not supported here",
+    );
+  });
+
+  it("formats for a metric receiver", () => {
+    installNotificationMock({ permission: "granted" });
+    enableAll();
+    useLiveAircraftStore.getState().applySnapshot({
+      aircraft: [],
+      receiver: { ...defaultReceiverInfo(), units: "metric" },
+    });
+
+    dispatchAlertNotification(alertTriggeredEvent());
+
+    expect(lastNotification()?.options.body).toContain("23.0 km");
+  });
+
+  it("selects the aircraft when the notification is clicked", () => {
+    installNotificationMock({ permission: "granted" });
+    enableAll();
+    const focus = vi.fn();
+    vi.spyOn(window, "focus").mockImplementation(focus);
+
+    dispatchAlertNotification(alertTriggeredEvent({ icao: "ae1463" }));
+    const shown = lastNotification();
+    shown?.onclick?.();
+
+    expect(useLiveAircraftStore.getState().selectedIcao).toBe("ae1463");
+    expect(focus).toHaveBeenCalled();
+    expect(shown?.closed).toBe(true);
+  });
+
+  it("still focuses for an alert with no ICAO to select", () => {
+    installNotificationMock({ permission: "granted" });
+    enableAll();
+    const focus = vi.fn();
+    vi.spyOn(window, "focus").mockImplementation(focus);
+
+    dispatchAlertNotification(alertTriggeredEvent({ icao: null }));
+    lastNotification()?.onclick?.();
+
+    expect(useLiveAircraftStore.getState().selectedIcao).toBeNull();
+    expect(focus).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/notifications/lib/dispatch.ts
+++ b/frontend/src/features/notifications/lib/dispatch.ts
@@ -1,0 +1,151 @@
+/**
+ * Delivery: one alert activity event in, at most one browser notification out
+ * (SPEC §48, roadmap slice 040).
+ *
+ * Called from `features/map/aircraft/useLiveConnection.ts` for every `activity`
+ * frame, beside the store write that feeds the activity panel — the socket is
+ * where live alerts actually arrive, and putting delivery anywhere downstream
+ * would mean re-deriving "is this new?" from a store that resets on teardown.
+ *
+ * **Why this never prompts.** A WebSocket frame carries no user activation, so
+ * calling `requestPermission()` from here would be refused by Firefox and
+ * Safari outright — and would be precisely the unprompted request
+ * `docs/SECURITY.md` §5 forbids. An alert that arrives without permission is
+ * counted as suppressed and shown as such in Settings; the ask stays with the
+ * two clicks that own it (the wizard's Finish, and the settings button).
+ *
+ * **Background and minimized tabs.** Nothing here consults
+ * `document.hidden`. SPEC §48 requires notifications to work *"including
+ * background/minimized tabs"* and asks for no suppression when the tab is
+ * focused, so a match is delivered whichever state the tab is in — the
+ * behaviour is then one rule rather than two, and the demo acceptance test can
+ * observe it in a visible tab.
+ *
+ * The single caveat, inherited rather than introduced: the live socket is
+ * owned by the Live Map (`useActivityFeedStore`'s docstring explains why it is
+ * not hoisted), so notifications flow while FlightSite's map is open — which
+ * is the case SPEC §48 describes, a tab left open and then backgrounded — and
+ * not while the only open tab sits on, say, Analytics.
+ */
+
+import { composeAlertNotification } from "@/features/notifications/lib/compose";
+import { claimNotification } from "@/features/notifications/lib/dedupe";
+import { canNotify } from "@/features/notifications/lib/permission";
+import {
+  useNotificationStore,
+  wantsSeverity,
+} from "@/features/notifications/store/useNotificationStore";
+import { useLiveAircraftStore } from "@/features/map/aircraft/store/useLiveAircraftStore";
+import type { ActivityEvent } from "@/lib/api/activity";
+
+/**
+ * Why an event did or did not become a notification.
+ *
+ * Returned rather than logged so the tests can assert the *reason*, and so the
+ * three "the user would have wanted this" outcomes (`blocked`, `failed`) stay
+ * distinguishable from the two where they would not (`disabled`, `muted`).
+ */
+export type DispatchOutcome =
+  | "not-an-alert"
+  | "disabled"
+  | "muted"
+  | "duplicate"
+  | "blocked"
+  | "failed"
+  | "delivered";
+
+/** Resolved at call time so `vi.stubGlobal` works and so an environment
+ * without the API (jsdom, an insecure origin) is a `null` rather than a
+ * `ReferenceError` on the socket's frame handler. */
+function notificationApi(): typeof Notification | null {
+  const candidate = (globalThis as { Notification?: unknown }).Notification;
+  return typeof candidate === "function"
+    ? (candidate as typeof Notification)
+    : null;
+}
+
+/**
+ * SPEC §48's *"clicking should open/select the aircraft in FlightSite where
+ * practical"*.
+ *
+ * Two steps, and no router navigation: focus brings the tab forward from the
+ * background case the notification exists for, and selecting the ICAO opens
+ * `AircraftDetailPanel` on it — the same pair `LiveMapJumpLink` uses. A route
+ * change is not among them because the socket that delivered this alert is
+ * owned by the Live Map, so the tab being clicked back to is already on it.
+ */
+function focusAircraft(icao: string | null): void {
+  try {
+    globalThis.window?.focus();
+  } catch {
+    // A browser that refuses to focus (a policy some engines apply outside a
+    // user gesture) must not stop the selection below from happening.
+  }
+  if (icao !== null) {
+    useLiveAircraftStore.getState().selectAircraft(icao);
+  }
+}
+
+/**
+ * Delivers one activity event as a notification if it should be, and reports
+ * what happened.
+ *
+ * The gates run cheapest-first and, deliberately, **dedupe last among the
+ * checks that consume it**: an event the user has muted or has no permission
+ * for does not claim its id, so nothing is silently swallowed by a preference
+ * that changes a moment later.
+ */
+export function dispatchAlertNotification(
+  event: ActivityEvent,
+): DispatchOutcome {
+  const store = useNotificationStore.getState();
+  const units = useLiveAircraftStore.getState().receiver?.units ?? "aviation";
+
+  const content = composeAlertNotification(event, units);
+  if (content === null) {
+    return "not-an-alert";
+  }
+  if (!store.preferences.enabled) {
+    return "disabled";
+  }
+  if (!wantsSeverity(store.preferences, content.severity)) {
+    return "muted";
+  }
+
+  // Read fresh rather than trusting the mirrored value: the user can grant or
+  // revoke permission in the browser's own UI at any moment, and a stale
+  // "granted" would mean constructing a notification that throws.
+  const permission = store.refreshPermission();
+  if (!canNotify(permission)) {
+    store.recordSuppressed();
+    return "blocked";
+  }
+
+  const api = notificationApi();
+  if (api === null) {
+    store.recordSuppressed();
+    return "blocked";
+  }
+
+  if (!claimNotification(event.id)) {
+    return "duplicate";
+  }
+
+  try {
+    const notification = new api(content.title, {
+      body: content.body,
+      tag: content.tag,
+    });
+    notification.onclick = () => {
+      focusAircraft(content.icao);
+      notification.close();
+    };
+    store.recordDelivered();
+    return "delivered";
+  } catch (error) {
+    store.recordError(
+      error instanceof Error ? error.message : "Notification failed",
+    );
+    return "failed";
+  }
+}

--- a/frontend/src/features/notifications/lib/permission.test.ts
+++ b/frontend/src/features/notifications/lib/permission.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  canNotify,
+  canRequest,
+  readPermissionState,
+  requestNotificationPermission,
+} from "@/features/notifications/lib/permission";
+import { installNotificationMock } from "@/test/notificationMock";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("readPermissionState", () => {
+  it("reports the browser's standing answer without prompting", () => {
+    const api = installNotificationMock({ permission: "granted" });
+
+    expect(readPermissionState()).toBe("granted");
+    expect(api.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("reports a denial", () => {
+    installNotificationMock({ permission: "denied" });
+
+    expect(readPermissionState()).toBe("denied");
+  });
+
+  it("treats an unrecognised value as not-yet-asked", () => {
+    const api = installNotificationMock();
+    api.permission = "nonsense" as NotificationPermission;
+
+    expect(readPermissionState()).toBe("default");
+  });
+
+  it("distinguishes an insecure origin from an unsupported browser", () => {
+    // The API is withheld on a plain-HTTP LAN address, which is how
+    // FlightSite is normally reached (`docs/SECURITY.md` §1) — the user needs
+    // to be told *that*, not a generic "unsupported".
+    vi.stubGlobal("Notification", undefined);
+    vi.stubGlobal("isSecureContext", false);
+
+    expect(readPermissionState()).toBe("insecure-context");
+  });
+
+  it("reports an unsupported browser when the context is secure", () => {
+    vi.stubGlobal("Notification", undefined);
+    vi.stubGlobal("isSecureContext", true);
+
+    expect(readPermissionState()).toBe("unsupported");
+  });
+
+  it("does not guess 'insecure' where the environment says nothing", () => {
+    vi.stubGlobal("Notification", undefined);
+    vi.stubGlobal("isSecureContext", undefined);
+
+    expect(readPermissionState()).toBe("unsupported");
+  });
+});
+
+describe("canNotify / canRequest", () => {
+  it("only a granted permission delivers", () => {
+    expect(canNotify("granted")).toBe(true);
+    for (const state of [
+      "default",
+      "denied",
+      "unsupported",
+      "insecure-context",
+    ] as const) {
+      expect(canNotify(state)).toBe(false);
+    }
+  });
+
+  it("only an unasked permission can still be prompted for", () => {
+    expect(canRequest("default")).toBe(true);
+    for (const state of [
+      "granted",
+      "denied",
+      "unsupported",
+      "insecure-context",
+    ] as const) {
+      expect(canRequest(state)).toBe(false);
+    }
+  });
+});
+
+describe("requestNotificationPermission", () => {
+  it("resolves with the answer from the promise-returning API", async () => {
+    const api = installNotificationMock({
+      permission: "default",
+      requestResult: "granted",
+    });
+
+    await expect(requestNotificationPermission()).resolves.toBe("granted");
+    expect(api.requestPermission).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves with a denial the user just gave", async () => {
+    installNotificationMock({
+      permission: "default",
+      requestResult: "denied",
+    });
+
+    await expect(requestNotificationPermission()).resolves.toBe("denied");
+  });
+
+  it("supports the legacy callback form that returns nothing", async () => {
+    // Older Safari's `requestPermission(callback)` returns `undefined`;
+    // awaiting that would resolve instantly with the wrong answer.
+    const api = installNotificationMock({ permission: "default" });
+    api.requestPermission = vi.fn(
+      (callback?: (permission: NotificationPermission) => void) => {
+        callback?.("granted");
+        return undefined;
+      },
+    ) as unknown as typeof api.requestPermission;
+
+    await expect(requestNotificationPermission()).resolves.toBe("granted");
+  });
+
+  it("falls back to the standing state when the browser refuses the request", async () => {
+    const api = installNotificationMock({ permission: "default" });
+    api.requestPermission = vi.fn(() => {
+      throw new DOMException("insecure", "SecurityError");
+    }) as unknown as typeof api.requestPermission;
+
+    await expect(requestNotificationPermission()).resolves.toBe("default");
+  });
+
+  it("is a no-op read where the API does not exist", async () => {
+    vi.stubGlobal("Notification", undefined);
+    vi.stubGlobal("isSecureContext", false);
+
+    await expect(requestNotificationPermission()).resolves.toBe(
+      "insecure-context",
+    );
+  });
+});

--- a/frontend/src/features/notifications/lib/permission.ts
+++ b/frontend/src/features/notifications/lib/permission.ts
@@ -1,0 +1,140 @@
+/**
+ * The browser Notification API's permission model, as one small typed surface
+ * (SPEC §48, roadmap slice 040).
+ *
+ * **Nothing here is called on page load.** `docs/SECURITY.md` §5 is explicit:
+ * *"Permission is requested only after the user opts in (setup wizard or
+ * settings), never unprompted"*. {@link readPermissionState} only *reads* the
+ * standing answer — it never prompts — and {@link requestNotificationPermission}
+ * has exactly two callers, both of them a click the user made about
+ * notifications: the setup wizard's Finish button when the notification
+ * preference is on, and the Notifications settings section's own button.
+ *
+ * **Why requesting must happen synchronously inside the click.** Firefox and
+ * Safari require *transient user activation* for `requestPermission()`, and
+ * that activation is consumed and expires within seconds. So both callers
+ * fire this from the event handler itself rather than from a `.then()` after
+ * an awaited network round trip — which is also why an incoming alert can
+ * never trigger the prompt: a WebSocket frame carries no user activation, and
+ * a permission prompt the user did not ask for is exactly what §5 forbids.
+ *
+ * **Insecure contexts are a first-class state, not an error.** FlightSite is
+ * normally reached over plain HTTP on a LAN address (`docs/SECURITY.md` §1–§2:
+ * a trusted home network, no TLS assumed), and every current browser withholds
+ * the Notification API outside a secure context — HTTPS, or a `localhost`
+ * origin. That is the single most likely reason a real install cannot notify,
+ * so it gets its own state and its own explanation in the UI rather than being
+ * flattened into a bare "unsupported".
+ */
+
+/**
+ * What the browser will currently let FlightSite do.
+ *
+ * The three `NotificationPermission` values, plus the two ways the API can be
+ * absent entirely. Only `"granted"` delivers; every other value degrades to
+ * showing the user why, and is counted for diagnostics
+ * ({@link import("@/features/notifications/store/useNotificationStore").useNotificationStore}).
+ */
+export type NotificationPermissionState =
+  "unsupported" | "insecure-context" | "default" | "granted" | "denied";
+
+/** True when notifications can actually be delivered right now. */
+export function canNotify(state: NotificationPermissionState): boolean {
+  return state === "granted";
+}
+
+/** True when asking the browser could still change the answer. A `"denied"`
+ * answer is the user's standing decision and browsers resolve a re-request
+ * immediately without prompting, so the UI offers guidance there instead of a
+ * button that appears to do nothing. */
+export function canRequest(state: NotificationPermissionState): boolean {
+  return state === "default";
+}
+
+/**
+ * The `Notification` constructor, or `null` where the API is unavailable.
+ *
+ * Resolved at every call rather than captured at module load: the constructor
+ * is a global the tests replace per case (`vi.stubGlobal`), and caching it
+ * would freeze whichever value happened to exist when this module was first
+ * imported.
+ */
+function notificationApi(): typeof Notification | null {
+  const candidate = (globalThis as { Notification?: unknown }).Notification;
+  return typeof candidate === "function"
+    ? (candidate as typeof Notification)
+    : null;
+}
+
+/** Whether the page is running somewhere the browser deliberately withholds
+ * powerful APIs. Only an explicit `false` counts — an environment that does
+ * not implement `isSecureContext` at all tells us nothing, and guessing
+ * "insecure" from its absence would mislabel every such case. */
+function isInsecureContext(): boolean {
+  const value = (globalThis as { isSecureContext?: unknown }).isSecureContext;
+  return value === false;
+}
+
+/** Narrows whatever `Notification.permission` returned to the three values
+ * the spec defines, treating anything else as "not asked yet". */
+function normalize(value: unknown): NotificationPermissionState {
+  return value === "granted" || value === "denied" ? value : "default";
+}
+
+/**
+ * The current permission, read without prompting.
+ *
+ * Safe to call from a render, an effect, or on load — it touches only
+ * `Notification.permission`, which is a plain property read.
+ */
+export function readPermissionState(): NotificationPermissionState {
+  const api = notificationApi();
+  if (api === null) {
+    return isInsecureContext() ? "insecure-context" : "unsupported";
+  }
+  return normalize(api.permission);
+}
+
+/**
+ * Asks the browser for permission, returning the resulting state.
+ *
+ * Call **only** from a user gesture about notifications (see the module
+ * docstring). A browser that has no API, or that refuses the request, yields
+ * the state as it stands rather than throwing: a failed request is a thing to
+ * display, not a thing to crash the settings page.
+ *
+ * Handles both shapes of `requestPermission` — the promise-returning form
+ * every current browser implements, and the legacy callback form older Safari
+ * only supports — because the callback form returns `undefined` and awaiting
+ * it would resolve instantly with the wrong answer.
+ */
+export async function requestNotificationPermission(): Promise<NotificationPermissionState> {
+  const api = notificationApi();
+  if (api === null) {
+    return readPermissionState();
+  }
+  try {
+    const outcome = await new Promise<unknown>((resolve, reject) => {
+      let returned: unknown;
+      try {
+        returned = (
+          api.requestPermission as (
+            callback?: (permission: NotificationPermission) => void,
+          ) => Promise<NotificationPermission> | undefined
+        )(resolve as (permission: NotificationPermission) => void);
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error(String(error)));
+        return;
+      }
+      if (returned instanceof Promise) {
+        returned.then(resolve, reject);
+      }
+    });
+    return normalize(outcome);
+  } catch {
+    // A `SecurityError` (insecure origin) or a browser that rejects the
+    // request leaves the standing answer untouched — report that rather
+    // than inventing a denial the user never made.
+    return readPermissionState();
+  }
+}

--- a/frontend/src/features/notifications/store/useNotificationStore.test.ts
+++ b/frontend/src/features/notifications/store/useNotificationStore.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  NO_NOTIFICATIONS,
+  useNotificationStore,
+  wantsSeverity,
+} from "@/features/notifications/store/useNotificationStore";
+import type { AlertSeverity } from "@/lib/api/sightings";
+import { installNotificationMock } from "@/test/notificationMock";
+
+const ALL_ON = {
+  enabled: true,
+  info: true,
+  interesting: true,
+  high: true,
+  critical: true,
+};
+
+beforeEach(() => {
+  useNotificationStore.getState().reset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  useNotificationStore.getState().reset();
+});
+
+describe("useNotificationStore", () => {
+  it("starts with nothing enabled, because the config has not loaded yet", () => {
+    // SPEC §45: "do not silently enable every possible notification".
+    expect(useNotificationStore.getState().preferences).toEqual(
+      NO_NOTIFICATIONS,
+    );
+  });
+
+  it("mirrors the server's preferences", () => {
+    useNotificationStore.getState().setPreferences(ALL_ON);
+
+    expect(useNotificationStore.getState().preferences).toEqual(ALL_ON);
+  });
+
+  it("re-reads the browser's permission without prompting", () => {
+    const api = installNotificationMock({ permission: "denied" });
+
+    expect(useNotificationStore.getState().refreshPermission()).toBe("denied");
+    expect(useNotificationStore.getState().permission).toBe("denied");
+    expect(api.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("counts what was delivered and what was not, for diagnostics", () => {
+    const store = useNotificationStore.getState();
+    store.recordDelivered();
+    store.recordSuppressed();
+    store.recordError("Notification is not a constructor");
+
+    const state = useNotificationStore.getState();
+    expect(state.delivered).toBe(1);
+    // A failure is also an alert the user wanted and did not get.
+    expect(state.suppressed).toBe(2);
+    expect(state.lastError).toBe("Notification is not a constructor");
+  });
+
+  it("clears the counters on reset", () => {
+    useNotificationStore.getState().recordSuppressed();
+    useNotificationStore.getState().reset();
+
+    expect(useNotificationStore.getState().suppressed).toBe(0);
+    expect(useNotificationStore.getState().lastError).toBeNull();
+  });
+});
+
+describe("wantsSeverity", () => {
+  it("is false for every severity while the master switch is off", () => {
+    const off = { ...ALL_ON, enabled: false };
+
+    for (const severity of [
+      "info",
+      "interesting",
+      "high",
+      "critical",
+    ] as const) {
+      expect(wantsSeverity(off, severity)).toBe(false);
+    }
+  });
+
+  it("keeps the per-severity choices independent", () => {
+    const preferences = { ...ALL_ON, info: false };
+
+    expect(wantsSeverity(preferences, "info")).toBe(false);
+    expect(wantsSeverity(preferences, "critical")).toBe(true);
+  });
+
+  it("does not notify for a severity this build has never heard of", () => {
+    expect(wantsSeverity(ALL_ON, "catastrophic" as AlertSeverity)).toBe(false);
+  });
+});

--- a/frontend/src/features/notifications/store/useNotificationStore.ts
+++ b/frontend/src/features/notifications/store/useNotificationStore.ts
@@ -1,0 +1,142 @@
+/**
+ * What FlightSite knows about browser notification delivery this session
+ * (roadmap slice 040).
+ *
+ * Three things live here, and they are together because every one of them is
+ * read by the dispatcher on a WebSocket frame — outside React, through
+ * `getState()`, exactly like `useLiveAircraftStore` and
+ * `useActivityFeedStore`, so an alert arriving never causes a render of its
+ * own:
+ *
+ * 1. **`permission`** — the browser's standing answer, refreshed from the API
+ *    rather than assumed. Nothing in this module ever prompts;
+ *    `lib/permission.ts` documents why the prompt belongs to a click.
+ * 2. **`preferences`** — the user's per-severity choices, mirrored from the
+ *    server config document (SPEC §46/§48). `RootLayout` syncs them on every
+ *    config load, the same way it syncs the map's receiver location.
+ * 3. **Delivery counters** — what was shown, and what was wanted but could not
+ *    be. `docs/SECURITY.md` §5 requires that *"denied/blocked degrades
+ *    cleanly and is surfaced in diagnostics"*, and `docs/PRODUCT.md` §4.11
+ *    lists notification permission status among the health area's items;
+ *    slice 042 reads this store for both rather than re-deriving them.
+ *
+ * `preferences` starts at "everything off" rather than at the server's
+ * defaults. Until the config document has actually loaded, FlightSite does not
+ * know what the user asked for, and SPEC §45's *"do not silently enable every
+ * possible notification"* makes silence the only safe answer to that.
+ */
+
+import { create } from "zustand";
+
+import {
+  readPermissionState,
+  type NotificationPermissionState,
+} from "@/features/notifications/lib/permission";
+import type { NotificationConfig } from "@/lib/api/config";
+import type { AlertSeverity } from "@/lib/api/sightings";
+
+/** Nothing enabled — the state before the config document has loaded. */
+export const NO_NOTIFICATIONS: NotificationConfig = {
+  enabled: false,
+  info: false,
+  interesting: false,
+  high: false,
+  critical: false,
+};
+
+export interface NotificationState {
+  /** The browser's standing answer, as last read. */
+  permission: NotificationPermissionState;
+  /** The user's choices, mirrored from `config.notifications`. */
+  preferences: NotificationConfig;
+  /** Notifications actually shown this session. */
+  delivered: number;
+  /**
+   * Alerts the user had enabled that could not be shown, because permission
+   * was missing, blocked, or the browser refused the construction. The number
+   * a denied-permission install needs to see to understand what it is missing.
+   */
+  suppressed: number;
+  /** The last delivery failure's message, for the same reason. */
+  lastError: string | null;
+
+  /** Re-reads `Notification.permission` (never prompts) and stores it. */
+  refreshPermission: () => NotificationPermissionState;
+  /** Records an answer the user just gave the browser's prompt. */
+  setPermission: (permission: NotificationPermissionState) => void;
+  /** Mirrors the server's notification settings. */
+  setPreferences: (preferences: NotificationConfig) => void;
+  recordDelivered: () => void;
+  recordSuppressed: () => void;
+  recordError: (message: string) => void;
+  reset: () => void;
+}
+
+function initialState(): Pick<
+  NotificationState,
+  "permission" | "preferences" | "delivered" | "suppressed" | "lastError"
+> {
+  return {
+    // A plain property read of `Notification.permission`, which is why it is
+    // safe at module scope: it neither prompts nor can it.
+    permission: readPermissionState(),
+    preferences: NO_NOTIFICATIONS,
+    delivered: 0,
+    suppressed: 0,
+    lastError: null,
+  };
+}
+
+export const useNotificationStore = create<NotificationState>((set) => ({
+  ...initialState(),
+
+  refreshPermission: () => {
+    const permission = readPermissionState();
+    set({ permission });
+    return permission;
+  },
+
+  setPermission: (permission) => {
+    set({ permission });
+  },
+
+  setPreferences: (preferences) => {
+    set({ preferences });
+  },
+
+  recordDelivered: () => {
+    set((state) => ({ delivered: state.delivered + 1 }));
+  },
+
+  recordSuppressed: () => {
+    set((state) => ({ suppressed: state.suppressed + 1 }));
+  },
+
+  recordError: (message) => {
+    set((state) => ({
+      suppressed: state.suppressed + 1,
+      lastError: message,
+    }));
+  },
+
+  reset: () => {
+    set(initialState());
+  },
+}));
+
+/** Whether the user asked to be notified about this severity. The master
+ * switch gates all four, so a user who turns notifications off keeps their
+ * per-severity choices for when they turn them back on. */
+export function wantsSeverity(
+  preferences: NotificationConfig,
+  severity: AlertSeverity,
+): boolean {
+  if (!preferences.enabled) {
+    return false;
+  }
+  // Indexed rather than switched so a severity this build has never heard of
+  // (`docs/API.md` §6 allows the backend to add one) is silently *not*
+  // notified, instead of throwing on the socket's frame handler.
+  const value = (preferences as unknown as Record<string, unknown>)[severity];
+  return value === true;
+}

--- a/frontend/src/features/notifications/useNotificationPermission.ts
+++ b/frontend/src/features/notifications/useNotificationPermission.ts
@@ -1,0 +1,64 @@
+/**
+ * The permission half of the notification feature, as a hook (roadmap slice
+ * 040).
+ *
+ * Read-and-refresh on mount, and a `request` the caller wires to a button.
+ * The hook never requests on its own — `lib/permission.ts` documents why the
+ * ask belongs to a click, and `docs/SECURITY.md` §5 requires it.
+ *
+ * The refresh on mount and on `visibilitychange` exists because the browser's
+ * own site-settings UI is outside FlightSite entirely: a user who unblocks
+ * notifications in the address-bar menu and switches back to the tab should
+ * see Settings agree with the browser, without a reload.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  requestNotificationPermission,
+  type NotificationPermissionState,
+} from "@/features/notifications/lib/permission";
+import { useNotificationStore } from "@/features/notifications/store/useNotificationStore";
+
+export interface NotificationPermissionControls {
+  permission: NotificationPermissionState;
+  /** True while the browser's prompt is open. */
+  isRequesting: boolean;
+  /** Asks the browser. Safe to call when a request is already in flight (it
+   * is ignored), and safe to call where the API does not exist (it resolves
+   * to the standing state). */
+  request: () => Promise<NotificationPermissionState>;
+}
+
+export function useNotificationPermission(): NotificationPermissionControls {
+  const permission = useNotificationStore((state) => state.permission);
+  const [isRequesting, setIsRequesting] = useState(false);
+
+  useEffect(() => {
+    const refresh = () => {
+      useNotificationStore.getState().refreshPermission();
+    };
+    refresh();
+    document.addEventListener("visibilitychange", refresh);
+    return () => {
+      document.removeEventListener("visibilitychange", refresh);
+    };
+  }, []);
+
+  const request = useCallback(async () => {
+    const store = useNotificationStore.getState();
+    if (isRequesting) {
+      return store.permission;
+    }
+    setIsRequesting(true);
+    try {
+      const result = await requestNotificationPermission();
+      useNotificationStore.getState().setPermission(result);
+      return result;
+    } finally {
+      setIsRequesting(false);
+    }
+  }, [isRequesting]);
+
+  return { permission, isRequesting, request };
+}

--- a/frontend/src/features/settings/sections/NotificationsSection.test.tsx
+++ b/frontend/src/features/settings/sections/NotificationsSection.test.tsx
@@ -1,19 +1,22 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { useNotificationStore } from "@/features/notifications/store/useNotificationStore";
 import { NotificationsSection } from "@/features/settings/sections/NotificationsSection";
+import type { FlightSiteConfig } from "@/lib/api/config";
 import {
   defaultFlightSiteConfig,
   installConfigApiMock,
 } from "@/test/configApiMock";
+import { installNotificationMock } from "@/test/notificationMock";
 
-function renderSection() {
+function renderSection(overrides: Partial<FlightSiteConfig> = {}) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  const config = defaultFlightSiteConfig();
+  const config = { ...defaultFlightSiteConfig(), ...overrides };
   return render(
     <QueryClientProvider client={queryClient}>
       <NotificationsSection config={config} />
@@ -21,8 +24,13 @@ function renderSection() {
   );
 }
 
+beforeEach(() => {
+  useNotificationStore.getState().reset();
+});
+
 afterEach(() => {
   vi.unstubAllGlobals();
+  useNotificationStore.getState().reset();
 });
 
 describe("NotificationsSection", () => {
@@ -73,5 +81,68 @@ describe("NotificationsSection", () => {
         critical: true,
       },
     });
+  });
+
+  it("shows the browser permission alongside the preferences", () => {
+    installConfigApiMock();
+    installNotificationMock({ permission: "granted" });
+    renderSection();
+
+    expect(
+      screen.getByTestId("notification-permission-status"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/browser permission: allowed/i)).toBeVisible();
+  });
+
+  it("never asks the browser just because the section rendered", () => {
+    installConfigApiMock();
+    const api = installNotificationMock({ permission: "default" });
+    renderSection();
+
+    expect(api.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("asks the browser when the user saves with notifications on", async () => {
+    // Saving an enabled preference is the opt-in `docs/SECURITY.md` §5
+    // requires before a permission request, and the click is the user
+    // activation the browser requires.
+    installConfigApiMock();
+    const api = installNotificationMock({
+      permission: "default",
+      requestResult: "granted",
+    });
+    const user = userEvent.setup();
+    renderSection();
+
+    await user.click(screen.getByRole("checkbox", { name: /^info/i }));
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(api.requestPermission).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not ask when the user saves with notifications switched off", async () => {
+    installConfigApiMock();
+    const api = installNotificationMock({ permission: "default" });
+    const user = userEvent.setup();
+    renderSection();
+
+    await user.click(
+      screen.getByRole("checkbox", { name: /enable browser notifications/i }),
+    );
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(api.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("does not re-ask a browser that has already answered", async () => {
+    installConfigApiMock();
+    const api = installNotificationMock({ permission: "denied" });
+    const user = userEvent.setup();
+    renderSection();
+
+    await user.click(screen.getByRole("checkbox", { name: /^info/i }));
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(api.requestPermission).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/features/settings/sections/NotificationsSection.tsx
+++ b/frontend/src/features/settings/sections/NotificationsSection.tsx
@@ -1,5 +1,8 @@
 import { useState } from "react";
 
+import { NotificationPermissionStatus } from "@/features/notifications/components/NotificationPermissionStatus";
+import { canRequest } from "@/features/notifications/lib/permission";
+import { useNotificationPermission } from "@/features/notifications/useNotificationPermission";
 import { SectionSaveBar } from "@/features/settings/components/SectionSaveBar";
 import { SettingsSection } from "@/features/settings/components/SettingsSection";
 import {
@@ -44,13 +47,20 @@ const SEVERITY_OPTIONS: readonly {
 ];
 
 /** Browser notification preferences: a master switch plus one toggle per
- * alert severity (SPEC §46/§48). Applies immediately. */
+ * alert severity (SPEC §46/§48), and the browser permission they depend on
+ * (slice 040). Applies immediately.
+ *
+ * This section is one of the two places `docs/SECURITY.md` §5 allows the
+ * permission to be requested from — the other being the setup wizard — and it
+ * is where a user comes back to when they declined the first time, so the ask
+ * is re-promptable here for as long as the browser will still prompt. */
 export function NotificationsSection({ config }: NotificationsSectionProps) {
   const [baseline, setBaseline] = useState(() =>
     pickNotifications(draftFromConfig(config)),
   );
   const [draft, setDraft] = useState(baseline);
   const mutation = usePutConfigMutation();
+  const { permission, request } = useNotificationPermission();
 
   const isDirty = isSectionDirty(draft, baseline);
   const fieldErrors: Record<string, string> = {};
@@ -60,6 +70,14 @@ export function NotificationsSection({ config }: NotificationsSectionProps) {
   }
 
   function handleSave() {
+    // Saving with notifications switched on *is* the opt-in, so this is the
+    // moment to ask — and it must happen synchronously inside the click, not
+    // in the mutation's `onSuccess`, because the user activation that
+    // `requestPermission()` requires does not survive a network round trip
+    // (`features/notifications/lib/permission.ts`).
+    if (draft.notifications.enabled && canRequest(permission)) {
+      void request();
+    }
     mutation.mutate(buildNotificationsPatch(draft), {
       onSuccess: (response) => {
         const next = pickNotifications(draftFromConfig(response.config));
@@ -121,6 +139,10 @@ export function NotificationsSection({ config }: NotificationsSectionProps) {
             </label>
           ))}
         </fieldset>
+
+        <NotificationPermissionStatus
+          enabled={baseline.notifications.enabled}
+        />
       </div>
 
       <SectionSaveBar

--- a/frontend/src/features/setup/SetupWizardPage.test.tsx
+++ b/frontend/src/features/setup/SetupWizardPage.test.tsx
@@ -12,6 +12,7 @@ import {
   installConfigApiMock,
 } from "@/test/configApiMock";
 import { resetMapLibreMock } from "@/test/maplibreGlMock";
+import { installNotificationMock } from "@/test/notificationMock";
 
 function renderSetupWizardPage() {
   const queryClient = new QueryClient({
@@ -175,5 +176,102 @@ describe("SetupWizardPage", () => {
 
     // The not-yet-reached "Review" step stays disabled.
     expect(screen.getByRole("button", { name: "Review" })).toBeDisabled();
+  });
+
+  /**
+   * Walks the wizard from Welcome to the Finish click, optionally switching
+   * the notification preference off on the way past step (e).
+   */
+  async function completeWizard(
+    user: ReturnType<typeof userEvent.setup>,
+    { wantsNotifications }: { wantsNotifications: boolean },
+  ): Promise<void> {
+    await screen.findByText(/welcome to flightsite/i);
+    await user.type(screen.getByLabelText(/site name/i), "Home");
+    await user.click(screen.getByRole("button", { name: /^next$/i }));
+
+    await screen.findByText(/receiver location/i);
+    await user.type(screen.getByLabelText(/latitude/i), "47.6");
+    await user.type(screen.getByLabelText(/longitude/i), "-122.3");
+    await user.click(screen.getByRole("button", { name: /^next$/i }));
+
+    await screen.findByText(/decoder endpoint/i);
+    await user.click(screen.getByRole("button", { name: /skip test/i }));
+    await user.click(screen.getByRole("button", { name: /^next$/i }));
+
+    await screen.findByText(/^units$/i);
+    await user.click(screen.getByRole("button", { name: /^next$/i }));
+
+    await screen.findByRole("heading", { name: /browser notifications/i });
+    if (!wantsNotifications) {
+      await user.click(
+        screen.getByRole("checkbox", { name: /enable browser notifications/i }),
+      );
+    }
+    await user.click(screen.getByRole("button", { name: /^next$/i }));
+
+    await screen.findByText(/metadata & enrichment/i);
+    await user.click(screen.getByRole("button", { name: /^next$/i }));
+
+    await screen.findByText(/alert templates/i);
+    await user.click(screen.getByRole("button", { name: /^next$/i }));
+
+    await screen.findByRole("heading", { name: /^review$/i });
+    await user.click(screen.getByRole("button", { name: /finish setup/i }));
+  }
+
+  describe("notification permission (slice 040)", () => {
+    it("never asks the browser while the wizard is merely open", async () => {
+      // `docs/SECURITY.md` §5: requested only after the user opts in, never
+      // unprompted — walking up to the notifications step is not an opt-in.
+      installConfigApiMock({ firstRun: true });
+      const api = installNotificationMock({ permission: "default" });
+      const user = userEvent.setup();
+      renderSetupWizardPage();
+
+      await screen.findByText(/welcome to flightsite/i);
+      await user.type(screen.getByLabelText(/site name/i), "Home");
+      await user.click(screen.getByRole("button", { name: /^next$/i }));
+
+      expect(api.requestPermission).not.toHaveBeenCalled();
+    });
+
+    it("asks once on Finish when the user opted in", async () => {
+      installConfigApiMock({ firstRun: true });
+      const api = installNotificationMock({
+        permission: "default",
+        requestResult: "granted",
+      });
+      const user = userEvent.setup();
+      renderSetupWizardPage();
+
+      await completeWizard(user, { wantsNotifications: true });
+
+      expect(await screen.findByText("Live Map Page")).toBeInTheDocument();
+      expect(api.requestPermission).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not ask when the user turned notifications off", async () => {
+      installConfigApiMock({ firstRun: true });
+      const api = installNotificationMock({ permission: "default" });
+      const user = userEvent.setup();
+      renderSetupWizardPage();
+
+      await completeWizard(user, { wantsNotifications: false });
+
+      expect(await screen.findByText("Live Map Page")).toBeInTheDocument();
+      expect(api.requestPermission).not.toHaveBeenCalled();
+    });
+
+    it("finishes setup even where the browser has no Notification API", async () => {
+      vi.stubGlobal("Notification", undefined);
+      installConfigApiMock({ firstRun: true });
+      const user = userEvent.setup();
+      renderSetupWizardPage();
+
+      await completeWizard(user, { wantsNotifications: true });
+
+      expect(await screen.findByText("Live Map Page")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/features/setup/SetupWizardPage.tsx
+++ b/frontend/src/features/setup/SetupWizardPage.tsx
@@ -6,6 +6,8 @@ import {
   WIZARD_STEPS,
   type WizardStepId,
 } from "@/features/setup/constants";
+import { canRequest } from "@/features/notifications/lib/permission";
+import { useNotificationPermission } from "@/features/notifications/useNotificationPermission";
 import { WizardNav } from "@/features/setup/components/WizardNav";
 import { WizardProgress } from "@/features/setup/components/WizardProgress";
 import { buildConfigPatch, draftFromConfig } from "@/features/setup/lib/draft";
@@ -41,6 +43,7 @@ export function SetupWizardPage() {
   const configQuery = useConfigQuery();
   const putConfigMutation = usePutConfigMutation();
   const navigate = useNavigate();
+  const notificationPermission = useNotificationPermission();
 
   const [draft, setDraft] = useState<WizardDraft | null>(null);
   // The config query can refetch in the background (e.g. React Query's
@@ -105,6 +108,21 @@ export function SetupWizardPage() {
       return;
     }
     setSubmitError(null);
+    // The notifications step (SPEC §45's "do not silently enable every
+    // possible notification") records a *preference*; this click is the opt-in
+    // `docs/SECURITY.md` §5 requires before the browser may be asked, so the
+    // ask happens here — synchronously, inside the handler, because the user
+    // activation `requestPermission()` needs does not survive the awaited
+    // config save below (`features/notifications/lib/permission.ts`). Its
+    // answer is deliberately not awaited: finishing setup must not wait on a
+    // browser prompt, and Settings shows and re-asks the permission later
+    // whatever the user does with it now.
+    if (
+      draft.notifications.enabled &&
+      canRequest(notificationPermission.permission)
+    ) {
+      void notificationPermission.request();
+    }
     putConfigMutation.mutate(buildConfigPatch(draft), {
       onSuccess: (response) => {
         applyServerConfigToMapStore(response.config);

--- a/frontend/src/features/setup/steps/NotificationsStep.tsx
+++ b/frontend/src/features/setup/steps/NotificationsStep.tsx
@@ -34,10 +34,14 @@ const SEVERITY_OPTIONS: readonly {
 ];
 
 /**
- * Step (e): the browser notification preference only. Per SPEC, requesting
- * the browser's notification permission is a separate concern (slice 040)
- * — this step never calls `Notification.requestPermission()`, it only
- * records what the user wants once that flow exists.
+ * Step (e): the browser notification preference only. This step never calls
+ * `Notification.requestPermission()` — it records what the user wants, and
+ * the wizard's Finish button is what asks the browser, once, if this
+ * preference is on (slice 040, `docs/SECURITY.md` §5: requested only after
+ * the user opts in, never unprompted). Asking from the Finish click rather
+ * than from this step also means the prompt cannot appear behind a user who
+ * is still deciding, and that it carries the user activation Firefox and
+ * Safari require.
  */
 export function NotificationsStep({ draft, onChange }: NotificationsStepProps) {
   function setNotification(patch: Partial<NotificationConfig>) {
@@ -51,9 +55,9 @@ export function NotificationsStep({ draft, onChange }: NotificationsStepProps) {
           Browser notifications
         </h2>
         <p className="text-sm text-muted-foreground">
-          This only records your preference — FlightSite will ask your browser
-          for notification permission separately, the first time it actually
-          needs to.
+          If you turn these on, FlightSite asks your browser for permission
+          once, when you finish setup. You can change your mind, and ask again,
+          in Settings.
         </p>
       </div>
 

--- a/frontend/src/test/activityApiMock.ts
+++ b/frontend/src/test/activityApiMock.ts
@@ -28,6 +28,80 @@ export function activityEvent(
   };
 }
 
+/**
+ * An `alert_triggered` event carrying the exact payload slice 038's
+ * `alert_events()` producer ships for a rule match
+ * (`backend/src/flightsite/activity/producers.py`) — the input the slice-040
+ * notification path is written against.
+ */
+export function alertTriggeredEvent(
+  overrides: Partial<ActivityEvent> = {},
+): ActivityEvent {
+  const { payload, ...rest } = overrides;
+  return {
+    id: 5100,
+    type: "alert_triggered",
+    severity: "high",
+    at: "2026-08-31T14:03:22.418Z",
+    icao: "ae1463",
+    sighting_id: 88213,
+    payload: {
+      icao: "ae1463",
+      callsign: "RCH485",
+      registration: "05-5153",
+      type_code: "C17",
+      model: "Boeing C-17A Globemaster III",
+      operator: "United States Air Force",
+      reason: "Rule: Military aircraft",
+      severity: "high",
+      distance_nm: 12.4,
+      altitude_ft: 24000,
+      military: true,
+      government: false,
+      law_enforcement: false,
+      rule_id: 7,
+      rule_name: "Military aircraft",
+      ...payload,
+    },
+    ...rest,
+  };
+}
+
+/** The built-in emergency-squawk counterpart (SPEC §47): no rule, a
+ * `builtin_key` and a squawk instead. */
+export function emergencySquawkEvent(
+  overrides: Partial<ActivityEvent> = {},
+): ActivityEvent {
+  const { payload, ...rest } = overrides;
+  return {
+    id: 5200,
+    type: "emergency_squawk",
+    severity: "critical",
+    at: "2026-08-31T14:05:02.000Z",
+    icao: "4ca7b3",
+    sighting_id: 88301,
+    payload: {
+      icao: "4ca7b3",
+      callsign: "RYR8213",
+      registration: "EI-DYK",
+      type_code: "B738",
+      model: "Boeing 737-800",
+      operator: "Ryanair",
+      reason: "Emergency squawk 7700 (general emergency)",
+      severity: "critical",
+      distance_nm: 31.8,
+      altitude_ft: 8500,
+      military: false,
+      government: false,
+      law_enforcement: false,
+      builtin_key: "emergency_7700",
+      squawk: "7700",
+      ...payload,
+    },
+    ...rest,
+  };
+}
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,

--- a/frontend/src/test/notificationMock.ts
+++ b/frontend/src/test/notificationMock.ts
@@ -1,0 +1,89 @@
+/**
+ * A stand-in for the browser `Notification` API (roadmap slice 040).
+ *
+ * Unlike the WebSocket and MapLibre mocks, this one is **not** installed in
+ * `src/test/setup.ts`. jsdom implements no `Notification` at all, and that
+ * absence is the correct default for the suite: it is exactly the "browser
+ * cannot notify" state FlightSite must degrade cleanly into, so every test
+ * that does not opt in proves, incidentally, that nothing tries to notify
+ * where it cannot. Tests that need the API install it themselves with
+ * {@link installNotificationMock} and let `vi.unstubAllGlobals()` remove it.
+ *
+ * It records rather than simulates: constructed notifications are kept so a
+ * test can assert on the exact title, body and tag the dispatcher composed,
+ * and `onclick` is invoked by the test rather than by any event plumbing.
+ */
+
+import { vi } from "vitest";
+
+export interface FakeNotificationOptions {
+  body?: string;
+  tag?: string;
+}
+
+export class FakeNotification {
+  /** Every notification constructed since the last install, in order. */
+  static instances: FakeNotification[] = [];
+  /** What `Notification.permission` reports. */
+  static permission: NotificationPermission = "granted";
+  /** What `Notification.requestPermission()` resolves to. */
+  static requestPermission = vi.fn<() => Promise<NotificationPermission>>();
+  /** When set, the constructor throws it — the "browser refused to
+   * construct" path (a platform that disallows non-persistent notifications,
+   * for instance). */
+  static constructorError: Error | null = null;
+
+  readonly title: string;
+  readonly options: FakeNotificationOptions;
+  onclick: (() => void) | null = null;
+  closed = false;
+
+  constructor(title: string, options: FakeNotificationOptions = {}) {
+    if (FakeNotification.constructorError) {
+      throw FakeNotification.constructorError;
+    }
+    this.title = title;
+    this.options = options;
+    FakeNotification.instances.push(this);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+export interface NotificationMockOptions {
+  /** The standing permission. Defaults to `"granted"`. */
+  permission?: NotificationPermission;
+  /** What a request resolves to. Defaults to the standing permission. */
+  requestResult?: NotificationPermission;
+}
+
+/**
+ * Installs {@link FakeNotification} as `globalThis.Notification` and returns
+ * it. Also marks the context secure, so a test never accidentally exercises
+ * the insecure-origin path it did not ask for.
+ */
+export function installNotificationMock(
+  options: NotificationMockOptions = {},
+): typeof FakeNotification {
+  const permission = options.permission ?? "granted";
+  FakeNotification.instances = [];
+  FakeNotification.permission = permission;
+  FakeNotification.constructorError = null;
+  FakeNotification.requestPermission = vi.fn<
+    () => Promise<NotificationPermission>
+  >(() => {
+    const result = options.requestResult ?? permission;
+    FakeNotification.permission = result;
+    return Promise.resolve(result);
+  });
+  vi.stubGlobal("isSecureContext", true);
+  vi.stubGlobal("Notification", FakeNotification);
+  return FakeNotification;
+}
+
+/** The last notification the code under test constructed. */
+export function lastNotification(): FakeNotification | undefined {
+  return FakeNotification.instances.at(-1);
+}

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1050,7 +1050,7 @@ slices:
     title: "Browser notifications"
     phase: 6
     branch: "040-browser-notifications"
-    status: planned
+    status: merged
     depends_on: ["038", "039"]
     objective: "Deliver alert notifications via the browser Notification API with correct permission handling and deduplication."
     scope:


### PR DESCRIPTION
## Slice 040 — Browser notifications

`frontend/src/features/notifications/` — the complete delivery path: five-state permission model (unsupported / insecure-context / default / granted / denied), pure SPEC §48 composer (unit-aware, field-by-field degradation), event-id dedupe honoring 038's upgrade semantics (a severity upgrade is a distinct match row → distinct event id → its own notification; `tag` collapses cross-tab duplicates), gated dispatch with suppressed/error counting, click-to-select.

Security posture per docs/SECURITY.md §5: permission is requested from exactly two user clicks (wizard Finish with the preference on; Settings button), fired synchronously inside the handler so transient activation isn't consumed by an awaited save. An incoming alert NEVER prompts. Content is aircraft data only. Denied/blocked/unsupported/insecure-context all degrade cleanly with status shown.

Notable: `insecure-context` is first-class — plain-HTTP LAN installs are the most likely real-world no-notification cause and get their own explanation (also recorded in docs/RISKS.md R-06). Delivery is Live-Map-scoped (socket ownership); actual behavior documented in docs/PRODUCT.md §4.8 rather than silently diverging.

Out of scope, tracked separately: `AlertMatchView.notified` persistence (needs an owning slice + internal endpoint), app-wide socket hoisting (ADR-sized).

Verification: lint, typecheck, 1411 tests (+78), format:check — all green; e2e spec (4 Chromium tests) typechecked, executed by CI (local stack was held by a parallel worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)