### PR TITLE
fix: live map forward-then-snap-back motion (slice 054)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -243,7 +243,10 @@ State model:
 
 - **Live data**: a WebSocket client (reconnect + backoff, snapshot-then-delta) feeds a
   Zustand live store. Map layers and live panels subscribe to it. Position
-  interpolation between 1 Hz updates happens client-side.
+  interpolation happens client-side, between successive position *fixes* rather
+  than between 1 Hz frames: frames arrive every second, but a distant aircraft
+  decodes a new position only every 2-10 s, and the store dates the two
+  separately so dead reckoning is anchored to the fix.
 - **Request/response data** (history, analytics, settings): TanStack Query against
   REST, with normal caching/invalidation.
 - **UI state** (selection, filters, theme, panel layout): Zustand + URL params where

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -134,6 +134,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 049 | Performance harness & Pi gates | 009, 010, 011, 012, 038, 053 | opus | high | SPEC §85 performance regression harness with hard gates |
 | 050 | Multi-year storage qualification | 031, 043, 044, 049 | opus | high | Synthetic multi-year dataset qualification of growth, queries, retention |
 | 051 | Documentation & install polish | 042, 045, 046 | sonnet | low | Docs complete enough for a fresh install from documentation alone |
+| 054 | Live map motion correctness | 014, 039 | opus | medium | Anchor dead reckoning to the last position change so markers stop creeping forward then teleporting back (issue #119) |
 
 ## Parallelization Guide
 

--- a/frontend/src/features/filters/lib/filteredLiveAircraftCache.test.ts
+++ b/frontend/src/features/filters/lib/filteredLiveAircraftCache.test.ts
@@ -7,13 +7,13 @@ import {
 } from "@/features/filters/lib/filteredLiveAircraftCache";
 import { DEFAULT_FILTERS } from "@/features/filters/types";
 import type { LiveAircraftRecord } from "@/features/map/aircraft/store/useLiveAircraftStore";
-import { makeAircraft } from "@/test/liveAircraftFixtures";
+import { makeRecord } from "@/test/liveAircraftFixtures";
 
 const CONFIG = { displayRadiusNm: 250 };
 
 function records(): Record<string, LiveAircraftRecord> {
   return {
-    aaaaaa: { aircraft: makeAircraft({ icao: "aaaaaa" }), receivedAt: 0 },
+    aaaaaa: makeRecord({ icao: "aaaaaa" }),
   };
 }
 

--- a/frontend/src/features/map/aircraft/aircraftLayers.test.ts
+++ b/frontend/src/features/map/aircraft/aircraftLayers.test.ts
@@ -338,6 +338,7 @@ describe("drawAircraftFrame", () => {
           ground_speed_kt: null,
         }),
         receivedAt: NOW,
+        positionChangedAt: NOW,
       },
     },
     departing: {},

--- a/frontend/src/features/map/aircraft/frame.test.ts
+++ b/frontend/src/features/map/aircraft/frame.test.ts
@@ -34,10 +34,18 @@ function fakeMap(): {
 function state(aircraftList: ReturnType<typeof makeAircraft>[]) {
   const aircraft: Record<
     string,
-    { aircraft: ReturnType<typeof makeAircraft>; receivedAt: number }
+    {
+      aircraft: ReturnType<typeof makeAircraft>;
+      receivedAt: number;
+      positionChangedAt: number;
+    }
   > = {};
   for (const entry of aircraftList) {
-    aircraft[entry.icao] = { aircraft: entry, receivedAt: 0 };
+    aircraft[entry.icao] = {
+      aircraft: entry,
+      receivedAt: 0,
+      positionChangedAt: 0,
+    };
   }
   return { aircraft, departing: {}, selectedIcao: null, track: null };
 }

--- a/frontend/src/features/map/aircraft/geojson.test.ts
+++ b/frontend/src/features/map/aircraft/geojson.test.ts
@@ -19,7 +19,7 @@ import {
   ZOOM_LABELS_MIN,
 } from "@/features/map/labels/priority";
 import type { LiveAircraft } from "@/lib/api/live";
-import { makeAircraft } from "@/test/liveAircraftFixtures";
+import { makeAircraft, makeRecord } from "@/test/liveAircraftFixtures";
 
 const NOW = 1_800_000_000_000;
 
@@ -28,8 +28,8 @@ function records(
 ): Record<string, LiveAircraftRecord> {
   const map: Record<string, LiveAircraftRecord> = {};
   for (const entry of entries) {
-    const aircraft = makeAircraft(entry);
-    map[aircraft.icao] = { aircraft, receivedAt: NOW };
+    const record = makeRecord(entry, { receivedAt: NOW });
+    map[record.aircraft.icao] = record;
   }
   return map;
 }

--- a/frontend/src/features/map/aircraft/interpolation.test.ts
+++ b/frontend/src/features/map/aircraft/interpolation.test.ts
@@ -2,21 +2,38 @@ import { describe, expect, it } from "vitest";
 
 import {
   displayPosition,
-  INTERPOLATION_MAX_MS,
+  INTERPOLATION_MAX_FIX_AGE_MS,
+  INTERPOLATION_STALL_GRACE_MS,
   normalizeLongitude,
   projectPosition,
 } from "@/features/map/aircraft/interpolation";
 import type { LiveAircraftRecord } from "@/features/map/aircraft/store/useLiveAircraftStore";
 import type { LiveAircraft } from "@/lib/api/live";
-import { makeAircraft } from "@/test/liveAircraftFixtures";
+import type { RecordTimes } from "@/test/liveAircraftFixtures";
+import { makeRecord } from "@/test/liveAircraftFixtures";
 
 const ONE_HOUR = 3_600_000;
 
+/** A record whose stream is healthy at `now`: `receivedAt` tracks the caller's
+ * clock, so these cases exercise the fix-age bound rather than the stall
+ * grace. Tests that care about a stalled stream set `receivedAt` explicitly. */
 function record(
   overrides: Partial<LiveAircraft>,
-  receivedAt = 0,
+  times: RecordTimes = {},
 ): LiveAircraftRecord {
-  return { aircraft: makeAircraft(overrides), receivedAt };
+  return makeRecord(overrides, times);
+}
+
+/** A record still receiving frames at `now`, with a fix `fixAgeMs` old. */
+function streaming(
+  overrides: Partial<LiveAircraft>,
+  now: number,
+  fixAgeMs: number,
+): LiveAircraftRecord {
+  return makeRecord(overrides, {
+    receivedAt: now,
+    positionChangedAt: now - fixAgeMs,
+  });
 }
 
 describe("projectPosition", () => {
@@ -118,23 +135,83 @@ describe("displayPosition", () => {
   });
 
   it("stops projecting once the stream has stalled", () => {
-    const far = displayPosition(
-      record({
-        position: { lat: 0, lon: 0 },
-        track_deg: 0,
-        ground_speed_kt: 60,
-      }),
-      INTERPOLATION_MAX_MS * 10,
-    );
+    // No frame since t=0: the projection may coast for the grace period and
+    // must then hold, however long the stall lasts.
+    const moving = {
+      position: { lat: 0, lon: 0 },
+      track_deg: 0,
+      ground_speed_kt: 60,
+    };
     const capped = displayPosition(
+      record(moving),
+      INTERPOLATION_STALL_GRACE_MS,
+    );
+    expect(
+      displayPosition(record(moving), INTERPOLATION_STALL_GRACE_MS * 10),
+    ).toEqual(capped);
+    expect(displayPosition(record(moving), ONE_HOUR)).toEqual(capped);
+  });
+
+  it("freezes at the projection it reached, not back at the raw fix", () => {
+    // The stall must look like the aircraft stopping, never like it jumping
+    // backwards — a rewind is the defect this module exists to avoid.
+    const frozen = displayPosition(
       record({
         position: { lat: 0, lon: 0 },
         track_deg: 0,
-        ground_speed_kt: 60,
+        ground_speed_kt: 600,
       }),
-      INTERPOLATION_MAX_MS,
+      ONE_HOUR,
     );
-    expect(far).toEqual(capped);
+    expect(frozen?.lat).toBeGreaterThan(0);
+    // 600 kt for the 4 s grace is 0.667 nm.
+    expect(frozen?.lat).toBeCloseTo(
+      (600 * INTERPOLATION_STALL_GRACE_MS) / ONE_HOUR / 60,
+      9,
+    );
+  });
+
+  it("keeps projecting a live aircraft whose fix is older than the grace", () => {
+    // The regression guard for the bound itself: a distant aircraft heard
+    // every second but positioned every 8 s must not freeze at 4 s.
+    const now = 100_000;
+    const drawn = displayPosition(
+      streaming(
+        { position: { lat: 0, lon: 0 }, track_deg: 0, ground_speed_kt: 360 },
+        now,
+        8_000,
+      ),
+      now,
+    );
+    // 360 kt for eight seconds is 0.8 nm.
+    expect(drawn?.lat).toBeCloseTo(0.8 / 60, 9);
+  });
+
+  it("stops dead-reckoning a fix older than the fix-age cap", () => {
+    // Heard every second, positioned never: a Mode S-only aircraft stays live
+    // but must not be flown across the map on an unconfirmed velocity.
+    const now = 100_000;
+    const moving = {
+      position: { lat: 0, lon: 0 },
+      track_deg: 0,
+      ground_speed_kt: 360,
+    };
+    const atCap = displayPosition(
+      streaming(moving, now, INTERPOLATION_MAX_FIX_AGE_MS),
+      now,
+    );
+    expect(
+      displayPosition(
+        streaming(moving, now, INTERPOLATION_MAX_FIX_AGE_MS * 20),
+        now,
+      ),
+    ).toEqual(atCap);
+  });
+
+  it("covers the distant-aircraft fix cadence with the fix-age cap", () => {
+    // The bound is only correct if it clears the 2-10 s CPR cadence that
+    // motivated it, with room to spare.
+    expect(INTERPOLATION_MAX_FIX_AGE_MS).toBeGreaterThan(10_000);
   });
 
   it("returns the reported position when velocity is unknown", () => {
@@ -163,7 +240,7 @@ describe("displayPosition", () => {
       displayPosition(
         record(
           { position: { lat: 1, lon: 2 }, track_deg: 0, ground_speed_kt: 400 },
-          5000,
+          { receivedAt: 5000 },
         ),
         1000,
       ),

--- a/frontend/src/features/map/aircraft/interpolation.ts
+++ b/frontend/src/features/map/aircraft/interpolation.ts
@@ -1,26 +1,62 @@
 /**
- * Position smoothing between 1 Hz updates.
+ * Position smoothing between position fixes.
  *
  * The socket delivers a batch about once a second (`docs/API.md` §4.3). Drawn
  * as-is, a 450 kt airliner jumps ~0.13 nm at a time — clearly a stutter at any
- * useful zoom. Between updates each aircraft is therefore dead-reckoned along
- * its last reported velocity: `track_deg` for direction, `ground_speed_kt` for
- * rate, and the store's `receivedAt` for elapsed time.
+ * useful zoom. Between fixes each aircraft is therefore dead-reckoned along its
+ * last reported velocity: `track_deg` for direction, `ground_speed_kt` for
+ * rate, and the store's `positionChangedAt` for elapsed time.
+ *
+ * **Why `positionChangedAt` and not `receivedAt`.** The two are not
+ * interchangeable, and treating them as such was issue #119. Every frame
+ * carries a *complete* aircraft object, so a delta reporting nothing but a new
+ * RSSI still repeats the last decoded position verbatim. A distant aircraft
+ * decodes a CPR position only every 2-10 s while transmitting Mode S every
+ * second, so anchoring to `receivedAt` reset elapsed time to zero several times
+ * between fixes: the marker crept forward, snapped back to the stale fix, and
+ * crept forward again. Elapsed time has to be measured from the moment the
+ * position was *fixed*, which is what the store now records.
  *
  * **Why dead reckoning rather than tweening between the last two positions.**
  * Tweening is smooth but wrong twice over: it renders the aircraft a full
  * update *behind* where it was last reported, and it needs two positions, which
  * a newly appeared aircraft does not have. Projecting forward from the latest
- * report keeps the marker at the receiver's best estimate of *now*, and the
- * next update simply supersedes it. Reported values are never modified — the
- * detail panel and every other consumer read the payload, not this projection.
+ * fix keeps the marker at the receiver's best estimate of *now*, and the next
+ * fix simply supersedes it. Reported values are never modified — the detail
+ * panel and every other consumer read the payload, not this projection.
  *
- * **Bounds.** Projection stops after {@link INTERPOLATION_MAX_MS}. If the
- * stream stalls — a suspended tab, a dead backend, a client mid-reconnect —
- * extrapolation would otherwise fly aircraft across the map on the strength of
- * a stale velocity, which is fabricated data, not smoothing. Stale aircraft are
- * never projected at all: staleness means the receiver has stopped hearing
- * them, so their last known position is the honest thing to draw.
+ * **Bounds.** Two limits, because the correct anchor separated two questions
+ * the old single cap had conflated.
+ *
+ * {@link INTERPOLATION_MAX_FIX_AGE_MS} asks *how stale is this fix?* An
+ * aircraft heard every second but not positioned for a minute — Mode S with no
+ * usable CPR pair — stays `live`, and projecting it indefinitely would fly it
+ * across the map on the strength of a velocity nothing has confirmed.
+ *
+ * {@link INTERPOLATION_STALL_GRACE_MS} asks *is the stream still running?* A
+ * suspended tab, a dead backend or a client mid-reconnect stops all frames, and
+ * a projection that kept advancing would be inventing motion out of a
+ * disconnect. It is measured from `receivedAt`, which is exactly the question
+ * that timestamp answers.
+ *
+ * Both caps freeze the marker where the projection had reached; neither rewinds
+ * it to the raw fix, since a rewind is the visible defect this module exists to
+ * avoid. Stale aircraft are not projected at all: staleness means the receiver
+ * has stopped hearing them, so their last known position is the honest thing to
+ * draw.
+ *
+ * **No correction blend on a new fix**, considered and declined in slice 054. A
+ * new fix still moves the marker by however far the projection had drifted, and
+ * easing into it instead of snapping was the obvious next refinement. It is not
+ * worth it: with the anchor correct that step is the dead-reckoning error over
+ * one fix interval — metres for an aircraft flying straight, against the ~0.8 nm
+ * the mis-anchored version jumped — so the blend would smooth something already
+ * near the noise floor. The cost is real, though. This function is pure and
+ * called once per aircraft per frame; a blend needs the previously *drawn*
+ * position kept per aircraft between frames, which means mutable render state
+ * with its own eviction, reset-on-reconnect and store-reset invalidation. And
+ * during the ease it would deliberately draw the aircraft behind the receiver's
+ * best estimate — the same objection that rules out tweening above.
  *
  * The flat-earth conversion (1 nm = 1/60°, longitude scaled by cos φ) is exact
  * enough by orders of magnitude at these distances: one second at 600 kt is
@@ -31,10 +67,34 @@
 import type { LiveAircraftRecord } from "@/features/map/aircraft/store/useLiveAircraftStore";
 import type { GeoPosition } from "@/lib/api/live";
 
-/** How far past the last update an aircraft may be projected. Four seconds is
- * a few missed deltas — enough to ride out a hiccup, short enough that a
- * genuinely dead stream freezes rather than inventing motion. */
-export const INTERPOLATION_MAX_MS = 4_000;
+/**
+ * How far past its last position fix an aircraft may be dead-reckoned.
+ *
+ * Sized against the backend's own definition of "still being heard":
+ * `sighting.stale_s` defaults to 15 s (`config.example.yaml`), after which an
+ * aircraft is marked `stale` and this module stops projecting it outright. A
+ * fix older than that interval has outlived the silence the backend treats as
+ * losing an aircraft altogether, so it is a fair place to stop inventing
+ * motion — while comfortably covering the 2-10 s CPR cadence of a distant
+ * aircraft, which is the case that has to project smoothly.
+ *
+ * The predecessor of this constant was 4 s, which was correct against the old
+ * per-delta anchor and far too short against this one: it would re-freeze a
+ * distant aircraft for most of every gap between fixes, reintroducing the
+ * stutter from the other side.
+ */
+export const INTERPOLATION_MAX_FIX_AGE_MS = 15_000;
+
+/**
+ * How far past the last delivered frame the projection may keep running.
+ *
+ * Four seconds is a few missed deltas at 1 Hz — enough to ride out a hiccup,
+ * short enough that a genuinely dead stream freezes rather than inventing
+ * motion. This is the bound the old `INTERPOLATION_MAX_MS` was really
+ * enforcing; it survives unchanged, now measured against the timestamp that
+ * actually tracks stream liveness.
+ */
+export const INTERPOLATION_STALL_GRACE_MS = 4_000;
 
 /** Nautical miles per degree of latitude. */
 const NM_PER_DEGREE = 60;
@@ -90,7 +150,7 @@ export function displayPosition(
   record: LiveAircraftRecord,
   now: number,
 ): GeoPosition | null {
-  const { aircraft, receivedAt } = record;
+  const { aircraft, receivedAt, positionChangedAt } = record;
   const position = aircraft.position;
   if (!position) {
     return null;
@@ -102,7 +162,14 @@ export function displayPosition(
   if (track === null || speed === null || speed <= 0) {
     return position;
   }
-  const elapsed = Math.min(INTERPOLATION_MAX_MS, Math.max(0, now - receivedAt));
+  // Advance the clock no further than the last frame plus its grace: past that
+  // the stream has stalled, and the projection holds where it had reached
+  // rather than running on or rewinding.
+  const advanceUntil = Math.min(now, receivedAt + INTERPOLATION_STALL_GRACE_MS);
+  const elapsed = Math.min(
+    INTERPOLATION_MAX_FIX_AGE_MS,
+    Math.max(0, advanceUntil - positionChangedAt),
+  );
   if (elapsed === 0) {
     return position;
   }

--- a/frontend/src/features/map/aircraft/snapback.regression.test.ts
+++ b/frontend/src/features/map/aircraft/snapback.regression.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression: markers crept forward then teleported back (issue #119).
+ *
+ * Driven through the real store rather than hand-built records, because the
+ * defect lived in the seam between the two: `displayPosition` dead-reckoned
+ * from `receivedAt`, which every delta refreshed, while `aircraft.position`
+ * only changed when a new CPR fix decoded — every 2-10 s for a distant
+ * aircraft. Each no-new-fix delta reset elapsed time to zero and snapped the
+ * marker back to the stale fix. A unit test over a fabricated record cannot
+ * see that; only applying a real delta sequence can.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { displayPosition } from "@/features/map/aircraft/interpolation";
+import { useLiveAircraftStore } from "@/features/map/aircraft/store/useLiveAircraftStore";
+import { makeAircraft } from "@/test/liveAircraftFixtures";
+
+const T0 = 1_700_000_000_000;
+const ICAO = "aaaaaa";
+
+/** Due north at 360 kt: 0.1 nm a second, or 1/600 of a degree of latitude. */
+const DEGREES_PER_SECOND = 0.1 / 60;
+
+function inbound(overrides = {}) {
+  return makeAircraft({
+    icao: ICAO,
+    position: { lat: 0, lon: 0 },
+    track_deg: 0,
+    ground_speed_kt: 360,
+    ...overrides,
+  });
+}
+
+function drawnLat(now: number): number {
+  const record = useLiveAircraftStore.getState().aircraft[ICAO];
+  if (!record) {
+    throw new Error(`${ICAO} is not in the store`);
+  }
+  const position = displayPosition(record, now);
+  if (!position) {
+    throw new Error(`${ICAO} has no drawable position`);
+  }
+  return position.lat;
+}
+
+beforeEach(() => {
+  useLiveAircraftStore.getState().reset();
+  useLiveAircraftStore
+    .getState()
+    .applySnapshot({ aircraft: [inbound()], receiver: null }, T0);
+});
+
+describe("live map motion across deltas that do not move the fix", () => {
+  it("keeps projecting when a delta carries the same fix", () => {
+    // Two seconds on, the receiver has re-reported the aircraft twice with a
+    // fresh RSSI but no new position decode.
+    for (const tick of [1000, 2000]) {
+      useLiveAircraftStore.getState().applyDelta(
+        {
+          updated: [inbound({ rssi_db: -20 - tick / 1000 })],
+          stale: [],
+          removed: [],
+        },
+        T0 + tick,
+      );
+    }
+
+    expect(drawnLat(T0 + 2000)).toBeCloseTo(2 * DEGREES_PER_SECOND, 9);
+  });
+
+  it("never draws the aircraft behind where it was a moment earlier", () => {
+    // The visible symptom: sample the drawn latitude either side of each
+    // delta. A backwards step anywhere in the sequence is the teleport.
+    let previous = drawnLat(T0);
+    for (let tick = 250; tick <= 8000; tick += 250) {
+      const now = T0 + tick;
+      if (tick % 1000 === 0) {
+        // A delta lands on the second, repeating the last known fix.
+        useLiveAircraftStore
+          .getState()
+          .applyDelta(
+            { updated: [inbound({ rssi_db: -20 })], stale: [], removed: [] },
+            now,
+          );
+      }
+      const current = drawnLat(now);
+      expect(
+        current,
+        `drew backwards at +${tick} ms: ${current} < ${previous}`,
+      ).toBeGreaterThanOrEqual(previous);
+      previous = current;
+    }
+  });
+
+  it("projects continuously across a realistic 8 s gap between fixes", () => {
+    // Distant aircraft decode a position every 2-10 s while still sending
+    // Mode S every second. The marker must keep moving the whole way.
+    for (let tick = 1000; tick <= 8000; tick += 1000) {
+      useLiveAircraftStore
+        .getState()
+        .applyDelta(
+          { updated: [inbound({ rssi_db: -21 })], stale: [], removed: [] },
+          T0 + tick,
+        );
+    }
+
+    expect(drawnLat(T0 + 8000)).toBeCloseTo(8 * DEGREES_PER_SECOND, 9);
+  });
+
+  it("re-anchors when a genuinely new fix arrives", () => {
+    useLiveAircraftStore.getState().applyDelta(
+      {
+        updated: [inbound({ position: { lat: 0.05, lon: 0 } })],
+        stale: [],
+        removed: [],
+      },
+      T0 + 3000,
+    );
+
+    // Elapsed restarts from the new fix, so one second on the marker is one
+    // second's travel past it — not four seconds past the old one.
+    expect(drawnLat(T0 + 4000)).toBeCloseTo(0.05 + DEGREES_PER_SECOND, 9);
+  });
+
+  it("keeps the anchor across a snapshot that repeats the same fix", () => {
+    // Snapshots rebuild the picture wholesale; an aircraft that survives one
+    // must not have its projection restarted.
+    useLiveAircraftStore
+      .getState()
+      .applySnapshot({ aircraft: [inbound()], receiver: null }, T0 + 2000);
+
+    expect(drawnLat(T0 + 2000)).toBeCloseTo(2 * DEGREES_PER_SECOND, 9);
+  });
+
+  it("freezes in place rather than rewinding when the stream dies", () => {
+    // No delta ever arrives. The marker may coast briefly, then must hold —
+    // and must never jump back to the fix it started from.
+    const coasted = drawnLat(T0 + 60_000);
+    expect(coasted).toBeGreaterThan(0);
+    expect(drawnLat(T0 + 600_000)).toBe(coasted);
+  });
+});

--- a/frontend/src/features/map/aircraft/store/useLiveAircraftStore.test.ts
+++ b/frontend/src/features/map/aircraft/store/useLiveAircraftStore.test.ts
@@ -361,3 +361,128 @@ describe("batching", () => {
     expect(notifications).toBe(2);
   });
 });
+
+describe("positionChangedAt", () => {
+  const AT = { icao: "aaaaaa", position: { lat: 47, lon: -122 } } as const;
+
+  function anchor(): number | undefined {
+    return store().aircraft.aaaaaa?.positionChangedAt;
+  }
+
+  beforeEach(() => {
+    store().applySnapshot({ aircraft: [makeAircraft(AT)], receiver: null }, T0);
+  });
+
+  it("starts at the frame the aircraft first appeared on", () => {
+    expect(anchor()).toBe(T0);
+  });
+
+  it("survives a delta that repeats the same fix", () => {
+    // Issue #119: the backend sends complete objects, so a frame reporting
+    // only a new RSSI still carries the last decoded position verbatim.
+    store().applyDelta(
+      {
+        updated: [makeAircraft({ ...AT, rssi_db: -30 })],
+        stale: [],
+        removed: [],
+      },
+      T0 + 1000,
+    );
+
+    expect(anchor()).toBe(T0);
+    expect(store().aircraft.aaaaaa?.receivedAt).toBe(T0 + 1000);
+  });
+
+  it("advances when the fix actually moves", () => {
+    store().applyDelta(
+      {
+        updated: [makeAircraft({ ...AT, position: { lat: 47.01, lon: -122 } })],
+        stale: [],
+        removed: [],
+      },
+      T0 + 1000,
+    );
+
+    expect(anchor()).toBe(T0 + 1000);
+  });
+
+  it("advances when only the longitude moves", () => {
+    store().applyDelta(
+      {
+        updated: [makeAircraft({ ...AT, position: { lat: 47, lon: -122.01 } })],
+        stale: [],
+        removed: [],
+      },
+      T0 + 1000,
+    );
+
+    expect(anchor()).toBe(T0 + 1000);
+  });
+
+  it("advances when a different source places the aircraft", () => {
+    // Identical coordinates from a different measurement chain is still a new
+    // report, and costs nothing to honour: an aircraft that has not moved has
+    // nothing to re-anchor.
+    store().applyDelta(
+      {
+        updated: [makeAircraft({ ...AT, position_source: "mlat" })],
+        stale: [],
+        removed: [],
+      },
+      T0 + 1000,
+    );
+
+    expect(anchor()).toBe(T0 + 1000);
+  });
+
+  it("advances when a position appears for a Mode S-only aircraft", () => {
+    store().applySnapshot(
+      {
+        aircraft: [
+          makeAircraft({
+            icao: "aaaaaa",
+            position: null,
+            position_source: "none",
+          }),
+        ],
+        receiver: null,
+      },
+      T0 + 1000,
+    );
+    store().applyDelta(
+      { updated: [makeAircraft(AT)], stale: [], removed: [] },
+      T0 + 2000,
+    );
+
+    expect(anchor()).toBe(T0 + 2000);
+  });
+
+  it("survives a snapshot that repeats the same fix", () => {
+    // A resync or reconnect is not evidence that the aircraft moved.
+    store().applySnapshot(
+      { aircraft: [makeAircraft(AT)], receiver: null },
+      T0 + 5000,
+    );
+
+    expect(anchor()).toBe(T0);
+  });
+
+  it("survives a stale flip", () => {
+    store().applyDelta(
+      { updated: [], stale: ["aaaaaa"], removed: [] },
+      T0 + 1000,
+    );
+
+    expect(anchor()).toBe(T0);
+  });
+
+  it("restarts for an aircraft removed and restored in the same batch", () => {
+    // A returning aircraft is a new track, not a continuation of the old one.
+    store().applyDelta(
+      { updated: [makeAircraft(AT)], stale: [], removed: ["aaaaaa"] },
+      T0 + 1000,
+    );
+
+    expect(anchor()).toBe(T0 + 1000);
+  });
+});

--- a/frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
+++ b/frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
@@ -14,9 +14,22 @@
  * `updated`**. Following it leaves the client holding exactly what
  * `GET /api/v1/aircraft/current` would have returned when the frame was built.
  *
- * Records keep `receivedAt` alongside the payload. That timestamp — not
- * `last_seen`, which is the receiver's clock and may be skewed from the
- * browser's — is the base the interpolator dead-reckons from.
+ * Records keep two local timestamps alongside the payload, both read from the
+ * browser's clock rather than `last_seen` (the receiver's clock, which may be
+ * skewed from the browser's):
+ *
+ * * `receivedAt` — when this object arrived. Dates the *data*: how long ago the
+ *   client last heard anything at all about this aircraft.
+ * * `positionChangedAt` — when the reported fix last actually moved. Dates the
+ *   *position*, which is a different thing entirely, because the backend sends
+ *   complete aircraft objects every frame: a delta carrying nothing but a new
+ *   RSSI still repeats the last decoded position verbatim.
+ *
+ * The interpolator dead-reckons from `positionChangedAt`. Anchoring it to
+ * `receivedAt` was issue #119: distant aircraft decode a CPR position only
+ * every 2-10 s while transmitting Mode S every second, so every intervening
+ * delta reset elapsed time to zero and snapped the marker back to the stale
+ * fix before it crept forward again.
  */
 
 import { create } from "zustand";
@@ -27,11 +40,15 @@ import type { LiveAircraft, ReceiverInfo } from "@/lib/api/live";
 import type { ConnectionStatus } from "@/lib/ws/liveSocket";
 import type { DeltaData, SnapshotData } from "@/lib/ws/protocol";
 
-/** One live aircraft plus the local clock reading that dates it. */
+/** One live aircraft plus the local clock readings that date it. */
 export interface LiveAircraftRecord {
   aircraft: LiveAircraft;
   /** `Date.now()` when this object was applied. */
   receivedAt: number;
+  /** `Date.now()` when `aircraft.position` last changed — the moment the
+   * receiver placed the aircraft where the record now says it is. Carried
+   * forward unchanged by every frame that repeats the same fix. */
+  positionChangedAt: number;
 }
 
 /** An aircraft the server has dropped, kept briefly so it fades out instead of
@@ -83,6 +100,46 @@ function initialState(): Omit<
   };
 }
 
+/**
+ * Whether `next` reports the aircraft at the same place `previous` did.
+ *
+ * Coordinate identity is the available signal: the payload has no "this is a
+ * fresh decode" flag, and two independent CPR solutions for a moving aircraft
+ * do not agree to the last float bit. A change of `position_source` counts as
+ * a new fix even at identical coordinates — a different measurement chain
+ * placed it there — which costs nothing, since a source flip without motion
+ * would only re-anchor an aircraft that is not moving anyway.
+ */
+function samePosition(previous: LiveAircraft, next: LiveAircraft): boolean {
+  const before = previous.position;
+  const after = next.position;
+  if (before === null || after === null) {
+    return before === after;
+  }
+  return (
+    before.lat === after.lat &&
+    before.lon === after.lon &&
+    previous.position_source === next.position_source
+  );
+}
+
+/** The record for a freshly delivered aircraft object, inheriting the position
+ * anchor from the record it replaces when the fix has not moved. */
+function upsert(
+  entry: LiveAircraft,
+  previous: LiveAircraftRecord | undefined,
+  now: number,
+): LiveAircraftRecord {
+  return {
+    aircraft: entry,
+    receivedAt: now,
+    positionChangedAt:
+      previous && samePosition(previous.aircraft, entry)
+        ? previous.positionChangedAt
+        : now,
+  };
+}
+
 function pruneDeparting(
   departing: Record<string, DepartingRecord>,
   now: number,
@@ -126,10 +183,12 @@ export const useLiveAircraftStore = create<LiveAircraftState>((set) => ({
   applySnapshot: (data, now = Date.now()) => {
     set((state) => {
       // A snapshot replaces the picture wholesale (§4.2), so the map is rebuilt
-      // rather than merged; anything it omits is simply gone.
+      // rather than merged; anything it omits is simply gone. An aircraft that
+      // survives the rebuild still keeps its position anchor — a reconnect or
+      // a periodic resync is not evidence that the aircraft moved.
       const aircraft: Record<string, LiveAircraftRecord> = {};
       for (const entry of data.aircraft) {
-        aircraft[entry.icao] = { aircraft: entry, receivedAt: now };
+        aircraft[entry.icao] = upsert(entry, state.aircraft[entry.icao], now);
       }
       return {
         aircraft,
@@ -160,6 +219,7 @@ export const useLiveAircraftStore = create<LiveAircraftState>((set) => ({
           aircraft[icao] = {
             aircraft: { ...record.aircraft, state: "stale" },
             receivedAt: record.receivedAt,
+            positionChangedAt: record.positionChangedAt,
           };
         }
       }
@@ -167,7 +227,7 @@ export const useLiveAircraftStore = create<LiveAircraftState>((set) => ({
       // aircraft that reappears here after being removed in the same batch is
       // restored, which is why this step runs last.
       for (const entry of data.updated) {
-        aircraft[entry.icao] = { aircraft: entry, receivedAt: now };
+        aircraft[entry.icao] = upsert(entry, aircraft[entry.icao], now);
         delete departing[entry.icao];
       }
 

--- a/frontend/src/features/watchlists/lib/liveMatchCounts.test.ts
+++ b/frontend/src/features/watchlists/lib/liveMatchCounts.test.ts
@@ -6,7 +6,7 @@ import {
   useLiveWatchlistCounts,
 } from "@/features/watchlists/lib/liveMatchCounts";
 import { useLiveAircraftStore } from "@/features/map/aircraft/store/useLiveAircraftStore";
-import { makeAircraft } from "@/test/liveAircraftFixtures";
+import { makeAircraft, makeRecord } from "@/test/liveAircraftFixtures";
 
 beforeEach(() => {
   useLiveAircraftStore.getState().reset();
@@ -15,13 +15,7 @@ beforeEach(() => {
 describe("computeLiveMatchCounts", () => {
   it("counts one aircraft toward every watchlist it matches", () => {
     const counts = computeLiveMatchCounts({
-      aaaaaa: {
-        aircraft: makeAircraft({
-          icao: "aaaaaa",
-          watchlists: ["Police", "Rare"],
-        }),
-        receivedAt: 0,
-      },
+      aaaaaa: makeRecord({ icao: "aaaaaa", watchlists: ["Police", "Rare"] }),
     });
 
     expect(counts).toEqual({ Police: 1, Rare: 1 });
@@ -29,14 +23,8 @@ describe("computeLiveMatchCounts", () => {
 
   it("sums across multiple aircraft matching the same watchlist", () => {
     const counts = computeLiveMatchCounts({
-      aaaaaa: {
-        aircraft: makeAircraft({ icao: "aaaaaa", watchlists: ["Police"] }),
-        receivedAt: 0,
-      },
-      bbbbbb: {
-        aircraft: makeAircraft({ icao: "bbbbbb", watchlists: ["Police"] }),
-        receivedAt: 0,
-      },
+      aaaaaa: makeRecord({ icao: "aaaaaa", watchlists: ["Police"] }),
+      bbbbbb: makeRecord({ icao: "bbbbbb", watchlists: ["Police"] }),
     });
 
     expect(counts).toEqual({ Police: 2 });
@@ -48,10 +36,7 @@ describe("computeLiveMatchCounts", () => {
 
   it("omits a watchlist name with no live match rather than reporting zero", () => {
     const counts = computeLiveMatchCounts({
-      aaaaaa: {
-        aircraft: makeAircraft({ icao: "aaaaaa", watchlists: [] }),
-        receivedAt: 0,
-      },
+      aaaaaa: makeRecord({ icao: "aaaaaa", watchlists: [] }),
     });
 
     expect(counts).toEqual({});

--- a/frontend/src/test/liveAircraftFixtures.ts
+++ b/frontend/src/test/liveAircraftFixtures.ts
@@ -5,8 +5,13 @@
  * present-and-`null` rather than absent, so a fixture that omitted keys would
  * let a test pass against a payload the backend never sends. `makeAircraft`
  * therefore starts from a complete object and takes overrides.
+ *
+ * `makeRecord` wraps one in the store's record shape so tests that only need
+ * "an aircraft in the live picture" do not each hand-assemble the local
+ * timestamps — and do not each need editing when the record grows a field.
  */
 
+import type { LiveAircraftRecord } from "@/features/map/aircraft/store/useLiveAircraftStore";
 import type { LiveAircraft } from "@/lib/api/live";
 
 const BASE: LiveAircraft = {
@@ -47,4 +52,24 @@ export function makeAircraft(
   overrides: Partial<LiveAircraft> = {},
 ): LiveAircraft {
   return { ...BASE, ...overrides };
+}
+
+/** Timestamps for {@link makeRecord}. `positionChangedAt` defaults to
+ * `receivedAt`: the anchor an aircraft gets on the frame it first appears. */
+export interface RecordTimes {
+  receivedAt?: number;
+  positionChangedAt?: number;
+}
+
+/** One aircraft in the store's record shape. */
+export function makeRecord(
+  overrides: Partial<LiveAircraft> = {},
+  times: RecordTimes = {},
+): LiveAircraftRecord {
+  const receivedAt = times.receivedAt ?? 0;
+  return {
+    aircraft: makeAircraft(overrides),
+    receivedAt,
+    positionChangedAt: times.positionChangedAt ?? receivedAt,
+  };
 }

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1290,6 +1290,34 @@ slices:
     preferred_agent: sonnet
     risk_level: low
 
+  - id: "054"
+    title: "Live map motion correctness"
+    phase: 8
+    branch: "054-live-map-motion"
+    status: merged
+    depends_on: ["014", "039"]
+    objective: "Fix live-map markers that creep forward then teleport back, by anchoring dead reckoning to the last position change rather than the last delta."
+    scope:
+      - "store records carry `positionChangedAt`: set only when the reported fix actually moves (lat/lon or position_source), preserved across deltas and snapshots that repeat the same fix"
+      - "`displayPosition` projects from that anchor instead of `receivedAt`, so a delta carrying only rssi/altitude no longer resets elapsed time to zero"
+      - "interpolation bounds re-derived for the new anchor: a fix-age cap sized to the 2-10 s CPR cadence of distant aircraft, plus a stall grace measured from the last delivered frame so a dead stream freezes in place instead of snapping backwards"
+      - interpolation module docstring corrected (it documented the faulty anchor as intentional design)
+    out_of_scope:
+      - "exponential correction blend on new fixes: analysed and rejected in-slice (needs per-aircraft render state in a pure path; residual step is second-order once the anchor is fixed)"
+      - renderer-side smoothing or MapLibre symbol animation (049)
+    acceptance_criteria:
+      - "a delta whose position is unchanged does not reset the projection anchor; the marker keeps advancing instead of snapping back to the stale fix"
+      - "an aircraft on a 2-10 s fix cadence is projected continuously between fixes; a stalled stream freezes at its last projected point and never rewinds"
+      - "500-aircraft frame-cost budget (slice 014 / frame.perf.test.ts) is not regressed"
+    required_tests: [store anchor-preservation tests, displayPosition regression tests for the snap-back, bound tests for fix-age cap and stall grace]
+    expected_artifacts:
+      - frontend/src/features/map/aircraft/interpolation.ts
+      - frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
+      - frontend/src/test/liveAircraftFixtures.ts
+    preferred_agent: opus
+    risk_level: medium
+    notes: "Unplanned fix slice for GitHub issue #119 (user-reported on a real install; mechanism confirmed). Added by Fable outside the phase plan."
+
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,
 # 027, 031, 033, 035, 037, 038, 052) are ADDITIONALLY serialized against each other


### PR DESCRIPTION
## Slice 054 — Live map motion correctness

Fixes #119 (user-reported on a real install): aircraft projected forward along track then teleported back.

Root cause: dead reckoning anchored to `receivedAt`, which resets on every delta batch — while distant aircraft only get a new CPR fix every 2–10 s, so each no-new-fix delta rewound the marker to the stale fix. The anchor is now `positionChangedAt`, advanced only when the fix genuinely moves (lat/lon or position_source), carried across deltas/stale flips/snapshots.

The conflated 4 s cap splits into its two real questions: `INTERPOLATION_MAX_FIX_AGE_MS = 15 s` (sized to the backend's stale_s — stop inventing motion for a fix older than what the backend treats as losing the aircraft) and `INTERPOLATION_STALL_GRACE_MS = 4 s` against receivedAt (stream liveness). Both freeze in place — never rewind, since the rewind was the defect. Correction-blend on new fixes analyzed out: residual step is metres (vs the ~0.8 nm mis-anchor jump) and a blend needs mutable per-aircraft render state plus deliberately drawing behind the best estimate — rationale recorded in the docstring and roadmap out_of_scope.

Tests: snapback.regression.test.ts drives the real store↔interpolator seam (4 of 6 cases fail on the old code, including the teleport verbatim); +9 store anchor cases, +5 bounds cases. Frame cost 0.21→0.24 ms median / 500 aircraft vs 10 ms budget. Roadmap gains the slice 054 entry; stale ARCHITECTURE.md line corrected.

Verification: frontend lint/typecheck/1521 tests/format:check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)