### PR TITLE
fix: batch activity WebSocket frames (slice 057)

### DIFF
--- a/backend/src/flightsite/api/ws.py
+++ b/backend/src/flightsite/api/ws.py
@@ -17,8 +17,8 @@ Every server-to-client frame is one JSON object (§4.1)::
 client can detect a gap; this server never leaves one, because a client it
 cannot deliver to in order is disconnected instead (see *Slow consumers*).
 ``ts`` is the server's UTC send time in the §2.2 format. ``type`` is one of
-``snapshot``, ``delta``, ``activity``, ``ping`` or ``pong``. Per §6 a client
-must ignore types it does not know.
+``snapshot``, ``delta``, ``activity_batch``, ``ping`` or ``pong``. Per §6 a
+client must ignore types it does not know.
 
 Frames
 ------
@@ -47,17 +47,35 @@ as a flag flip. A client that follows this order ends each batch holding
 exactly what ``GET /api/v1/aircraft/current`` would have returned at the moment
 the frame was built, which is roadmap slice 010's REST/WS agreement criterion.
 
-**activity** — one frame per activity event, emitted as the activity detector
-records it (§4.4, slice 035)::
+**activity_batch** — one frame per activity-detector pass, carrying everything
+that pass recorded (§4.4, slice 035; batched by slice 057)::
 
-    {"id": 42, "type": "first_ever_aircraft", "severity": "info",
-     "at": "...", "icao": "ae1463", "sighting_id": 9021, "payload": {...}}
+    [{"id": 42, "type": "first_ever_aircraft", "severity": "info",
+      "at": "...", "icao": "ae1463", "sighting_id": 9021, "payload": {...}}]
 
-The body is exactly the §3.9 object ``GET /api/v1/activity`` returns, built by
-the same serializer, so a client appends a live event to the page it fetched
-without a second shape to handle. One event per frame rather than a batch:
-they arrive a few a minute at most, and a client that has to unwrap a list to
-render one row is paying for a rate that does not exist.
+The body is a JSON **array** of the §3.9 objects ``GET /api/v1/activity``
+returns, built by the same serializer, so a client appends live events to the
+page it fetched without a second shape to handle. A pass that recorded nothing
+sends no frame, exactly like an empty delta.
+
+*One frame per pass, not one per event*, for the same reason a delta batches a
+tick: the frame count then depends on the detector's cadence rather than on how
+much it found. Slice 035 sent a frame per event on the reasoning that they
+arrive a few a minute — true of a settled receiver, false of a new one, where
+every aircraft is a first-ever sighting and a single five-second pass emitted
+hundreds of frames into a client's 32-frame queue and evicted **every**
+connected client under the slow-consumer rule below. The slice-049 harness
+measured that (``docs/PERFORMANCE.md`` §6) and slice 057 is the fix.
+
+The singular ``activity`` type slice 035 defined is **retired**: the server
+emits only ``activity_batch``, so there is one shape on the wire and one code
+path on each side rather than two that must agree. A client written against
+slice 035 sees an unknown type and ignores it per §6 — it stops receiving live
+events until it is updated, and its REST feed (§3.9) is unaffected, which is
+the behaviour §6 exists to make safe.
+
+At most :data:`MAX_ACTIVITY_EVENTS_PER_FRAME` events go in one frame, so a
+pathological pass sends a few bounded frames rather than one enormous one.
 
 These frames are **not** part of the snapshot/delta picture and carry no
 replay: a client that reconnects fetches the feed's first page over REST
@@ -162,6 +180,17 @@ MISSED_PING_LIMIT: Final = 2
 #: being defended against is a socket that has stopped draining at all.
 DEFAULT_CLIENT_QUEUE_SIZE: Final = 32
 
+#: Activity events carried by a single ``activity_batch`` frame (§4.4).
+#:
+#: A settled receiver's detector pass produces a handful and always fits in one
+#: frame; this bound exists for the pathological pass. On a fresh install every
+#: one of 500 aircraft is a first-ever sighting, and one frame holding all of
+#: them would sit in *every* client's queue at once and be rendered by every
+#: browser in one update. Splitting at 128 keeps the worst realistic pass to
+#: four frames — an eighth of :data:`DEFAULT_CLIENT_QUEUE_SIZE`, so it cannot
+#: evict anybody — while keeping a frame's body to tens of kilobytes.
+MAX_ACTIVITY_EVENTS_PER_FRAME: Final = 128
+
 #: Close code for a server-initiated drop. 1013 ("try again later") says
 #: exactly what the client should do: reconnect with backoff and take the
 #: fresh snapshot (§4.5).
@@ -179,8 +208,11 @@ class MessageType(StrEnum):
 
     SNAPSHOT = "snapshot"
     DELTA = "delta"
-    #: §4.4, added by slice 035. Carries one §3.9 activity event.
-    ACTIVITY = "activity"
+    #: §4.4, added by slice 035 and batched by slice 057. Carries the array of
+    #: §3.9 activity events one detector pass recorded. The singular
+    #: ``activity`` type it replaces is retired, not deprecated: the server
+    #: never sends it, so it is not in this vocabulary.
+    ACTIVITY_BATCH = "activity_batch"
     PING = "ping"
     PONG = "pong"
 
@@ -527,7 +559,7 @@ class LiveBroadcaster:
         self._maybe_ping()
 
     def publish_activity(self, events: Sequence[Mapping[str, Any]]) -> None:
-        """Broadcast one ``activity`` frame per event (§4.4, slice 035).
+        """Broadcast one pass's events as ``activity_batch`` frames (§4.4).
 
         The seam :class:`~flightsite.activity.service.ActivityService` calls
         after each of its passes commits, with the events that pass actually
@@ -535,20 +567,39 @@ class LiveBroadcaster:
         the socket inherits the table's exactly-once guarantee rather than
         needing one of its own.
 
+        **One frame per pass, not one per event** (slice 057), mirroring the
+        way :meth:`_emit_delta` collapses a tick. Slice 035 sent a frame per
+        event, which made the burst size a function of how much the detector
+        found: on a fresh install every aircraft is a first-ever sighting, so a
+        single five-second pass enqueued hundreds of frames into a
+        :data:`DEFAULT_CLIENT_QUEUE_SIZE`-frame queue and the slow-consumer
+        rule below evicted *every* connected client — measured by the slice-049
+        harness (``docs/PERFORMANCE.md`` §6). Batching makes the frame count a
+        function of the detector's cadence instead, which is bounded.
+
+        At most :data:`MAX_ACTIVITY_EVENTS_PER_FRAME` events go in one frame,
+        so even the pathological pass sends a few bounded frames rather than
+        one enormous one. The events keep the order the service supplied
+        (ascending event id, oldest first), and the split preserves it.
+
         Synchronous, non-awaiting and outside the broadcast tick, exactly like
         every other delivery here: it renders each frame once and enqueues it,
         and a client whose queue is full is dropped by the same slow-consumer
-        rule that governs deltas (§4.5). Detection therefore cannot be slowed
-        by a saturated socket, which is the same rule ingestion lives under.
+        rule that governs deltas (§4.5) — a rule this method now has far less
+        occasion to trip, but is still subject to. Detection therefore cannot
+        be slowed by a saturated socket, which is the rule ingestion lives
+        under too.
 
         With no clients connected this does nothing at all: the events are
         already durable in ``activity_events`` and a client that connects later
-        reads them over REST.
+        reads them over REST. A pass that created nothing sends no frame, the
+        same silence an empty delta keeps.
         """
-        if not self._clients:
+        if not self._clients or not events:
             return
-        for event in events:
-            self._deliver_all(Frame.build(MessageType.ACTIVITY, event))
+        for start in range(0, len(events), MAX_ACTIVITY_EVENTS_PER_FRAME):
+            batch = list(events[start : start + MAX_ACTIVITY_EVENTS_PER_FRAME])
+            self._deliver_all(Frame.build(MessageType.ACTIVITY_BATCH, batch))
 
     async def _loop(self) -> None:
         while True:

--- a/backend/src/flightsite/perf/workload.py
+++ b/backend/src/flightsite/perf/workload.py
@@ -327,18 +327,21 @@ class Workload:
         Deliberately *after* warm-up rather than at startup, and the reason is
         a first-run artefact rather than a preference. On an empty database
         every one of 500 aircraft is a first-ever sighting, so the activity
-        service's first pass publishes a burst of ~500 events — and
-        ``LiveBroadcaster.publish_activity`` sends one frame per event with no
-        await between them. That burst overflows every client's 32-frame queue
-        in a single call and the broadcaster evicts the lot as slow consumers,
-        which is the documented behaviour (``docs/API.md`` §4.5) and not a
-        product fault.
+        service's first pass publishes a burst of ~500 events.
 
-        It is, however, not the load this harness is trying to measure. A
-        browser connects to a system that is already running; it does not sit
-        through an install's first-ever backlog. So warm-up drains that backlog
-        with nobody connected — ``publish_activity`` is a no-op with no clients
-        — and the clients arrive afterwards, to steady-state traffic.
+        That burst is not the load this harness is trying to measure: a browser
+        connects to a system that is already running, it does not sit through
+        an install's first-ever backlog. So warm-up drains the backlog with
+        nobody connected — ``publish_activity`` is a no-op with no clients —
+        and the clients arrive afterwards, to steady-state traffic.
+
+        When this harness was written the ordering was load-bearing for a
+        second reason: ``publish_activity`` sent one frame per event, so the
+        burst overflowed every client's 32-frame queue in a single call and the
+        broadcaster evicted the lot as slow consumers (``docs/API.md`` §4.5).
+        Slice 057 made a pass one batched frame and that no longer happens —
+        the ordering now stands on the representativeness argument alone, which
+        was always the better half of it.
         """
         if self._clients:
             return

--- a/backend/tests/api/test_activity_api.py
+++ b/backend/tests/api/test_activity_api.py
@@ -208,7 +208,7 @@ async def test_the_endpoint_is_published_in_the_openapi_document(rest: AsyncClie
 async def test_the_websocket_frame_carries_the_same_object_as_the_feed(
     live_app: LiveApp, rest: AsyncClient
 ) -> None:
-    """§4.4's body *is* §3.9's shape, because one serializer builds both.
+    """§4.4's batch entries *are* §3.9's shape, because one serializer builds both.
 
     Recorded first and broadcast second, so the comparison is between two
     renderings of the same stored row rather than between a live object and a
@@ -229,5 +229,6 @@ async def test_the_websocket_frame_carries_the_same_object_as_the_feed(
         await probe.disconnect()
 
     page = await fetch(rest)
-    assert frame["type"] == "activity"
-    assert frame["data"] == page.items[0].model_dump()
+    assert frame["type"] == "activity_batch"
+    # The batch is an array of §3.9 objects; the elements are what must match.
+    assert frame["data"] == [page.items[0].model_dump()]

--- a/backend/tests/api/test_ws_activity.py
+++ b/backend/tests/api/test_ws_activity.py
@@ -1,14 +1,21 @@
-"""The ``activity`` frame on ``/api/v1/ws/live`` — ``docs/API.md`` §4.4.
+"""The ``activity_batch`` frame on ``/api/v1/ws/live`` — ``docs/API.md`` §4.4.
 
-The frame added by slice 035 to the slice-010 protocol, so the tests are about
-the two things that addition could have broken and the one thing it has to do:
+The frame added by slice 035 to the slice-010 protocol and batched by slice
+057, so the tests are about the things that addition could have broken and the
+things the frame has to do:
 
 * it must not disturb the ``seq`` discipline the live picture depends on — a
   gap in ``seq`` has a meaning (§4.1), so an interleaved activity frame has to
   take its number in sequence like everything else;
 * it must inherit the slow-consumer rule rather than acquire an exception to
   it (§4.5), because SPEC §5 says distribution must never stall;
-* and it must reach the clients that are connected, once each.
+* it must reach the clients that are connected, once each;
+* and — slice 057's whole point — **one pass must cost one frame**, so that the
+  number of frames a client is sent follows the detector's cadence and not the
+  size of what it found. The per-event form sent hundreds of frames on a fresh
+  install's first pass and the rule above then evicted every client
+  (``docs/PERFORMANCE.md`` §6); the burst test at the bottom of this file is
+  what keeps that from coming back.
 
 Every frame here exists because the test asked for it: the broadcaster's tick
 and ping clock are both driven by hand.
@@ -19,7 +26,12 @@ from __future__ import annotations
 from typing import Any
 
 from flightsite.api.schemas import ActivityEventView
-from flightsite.api.ws import RESYNC_CLOSE_CODE, MessageType
+from flightsite.api.ws import (
+    DEFAULT_CLIENT_QUEUE_SIZE,
+    MAX_ACTIVITY_EVENTS_PER_FRAME,
+    RESYNC_CLOSE_CODE,
+    MessageType,
+)
 from flightsite.counters import WS_DISCONNECTS, counters
 
 from ..live.conftest import make_update
@@ -52,17 +64,20 @@ async def test_an_activity_event_reaches_a_connected_client(live_app: LiveApp) -
         await probe.disconnect()
 
     assert snapshot["seq"] == 1
-    assert frame["type"] == MessageType.ACTIVITY.value
+    assert frame["type"] == MessageType.ACTIVITY_BATCH.value
     assert frame["seq"] == 2
     assert frame["ts"].endswith("Z")
-    ActivityEventView.model_validate(frame["data"])
+    # The body is an array even for a single event: one shape on the wire.
+    assert isinstance(frame["data"], list)
+    ActivityEventView.model_validate(frame["data"][0])
 
 
-async def test_each_event_is_its_own_frame(live_app: LiveApp) -> None:
-    """One event per frame, not a batch.
+async def test_a_pass_is_one_frame_carrying_every_event(live_app: LiveApp) -> None:
+    """Slice 057's contract: one frame per pass, not one per event.
 
-    They arrive a few a minute at most, and a client that has to unwrap a list
-    to render one row would be paying for a rate that does not exist.
+    A frame per event made the burst size a function of how much the detector
+    found, which is what overflowed client queues on a fresh install. Batching
+    makes it a function of the detector's cadence, which is bounded.
     """
     probe, _snapshot = await open_probe(live_app)
     try:
@@ -72,9 +87,71 @@ async def test_each_event_is_its_own_frame(live_app: LiveApp) -> None:
     finally:
         await probe.disconnect()
 
-    assert [frame["type"] for frame in frames] == ["activity", "activity"]
-    assert [frame["data"]["id"] for frame in frames] == [1, 2]
-    assert [frame["seq"] for frame in frames] == [2, 3]
+    assert [frame["type"] for frame in frames] == ["activity_batch"]
+    assert [event["id"] for event in frames[0]["data"]] == [1, 2]
+    assert [frame["seq"] for frame in frames] == [2]
+
+
+async def test_the_batch_keeps_the_order_the_service_supplied(live_app: LiveApp) -> None:
+    """Oldest first, as the repository returns them (sorted by event id).
+
+    The frontend store prepends a batch reversed to stay newest-first, so the
+    order on the wire is part of the contract rather than an accident.
+    """
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        live_app.broadcaster.publish_activity([activity_event(index) for index in (7, 8, 9)])
+        await settle()
+        frame = await probe.frame()
+    finally:
+        await probe.disconnect()
+
+    assert [event["id"] for event in frame["data"]] == [7, 8, 9]
+
+
+async def test_a_pass_that_recorded_nothing_sends_no_frame(live_app: LiveApp) -> None:
+    """The same silence an empty delta keeps (§4.3).
+
+    A re-derivation that wrote nothing has nothing to say, and an empty array
+    would still cost every client a frame of queue.
+    """
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        live_app.broadcaster.publish_activity([])
+        await settle()
+        frames = await probe.frames()
+    finally:
+        await probe.disconnect()
+
+    assert frames == []
+
+
+async def test_a_huge_pass_is_split_at_the_per_frame_cap(live_app: LiveApp) -> None:
+    """One frame per pass, but bounded (:data:`MAX_ACTIVITY_EVENTS_PER_FRAME`).
+
+    A fresh install's first pass is ~500 first-ever sightings. One frame would
+    fit the queue, but it would also sit in *every* client's queue at once and
+    land in every browser as a single update; a few bounded frames are still
+    an eighth of the queue and cannot evict anybody.
+    """
+    total = MAX_ACTIVITY_EVENTS_PER_FRAME * 2 + 5
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        live_app.broadcaster.publish_activity([activity_event(index) for index in range(total)])
+        await settle()
+        frames = await probe.frames()
+    finally:
+        await probe.disconnect()
+
+    assert [frame["type"] for frame in frames] == ["activity_batch"] * 3
+    assert [len(frame["data"]) for frame in frames] == [
+        MAX_ACTIVITY_EVENTS_PER_FRAME,
+        MAX_ACTIVITY_EVENTS_PER_FRAME,
+        5,
+    ]
+    # Split, not resampled: every event is delivered exactly once, in order.
+    delivered = [event["id"] for frame in frames for event in frame["data"]]
+    assert delivered == list(range(total))
 
 
 async def test_every_connected_client_receives_the_event(live_app: LiveApp) -> None:
@@ -84,8 +161,8 @@ async def test_every_connected_client_receives_the_event(live_app: LiveApp) -> N
         live_app.broadcaster.publish_activity([activity_event()])
         await settle()
 
-        assert (await first.frame())["data"]["id"] == 1
-        assert (await second.frame())["data"]["id"] == 1
+        assert [event["id"] for event in (await first.frame())["data"]] == [1]
+        assert [event["id"] for event in (await second.frame())["data"]] == [1]
     finally:
         await first.disconnect()
         await second.disconnect()
@@ -110,7 +187,7 @@ async def test_an_activity_frame_takes_its_place_in_the_sequence(live_app: LiveA
     finally:
         await probe.disconnect()
 
-    assert [frame["type"] for frame in frames] == ["delta", "activity", "delta"]
+    assert [frame["type"] for frame in frames] == ["delta", "activity_batch", "delta"]
     assert [frame["seq"] for frame in frames] == [2, 3, 4]
 
 
@@ -125,20 +202,60 @@ async def test_publishing_to_nobody_costs_nothing(live_app: LiveApp) -> None:
     assert live_app.broadcaster.client_count == 0
 
 
+async def test_a_fresh_install_backlog_no_longer_evicts_anybody(live_app: LiveApp) -> None:
+    """Slice 057's reason to exist, pinned against the production queue size.
+
+    A new database at 500 aircraft makes every one of them a first-ever
+    sighting, so a single 5-second pass used to publish ~500 frames into a
+    32-frame queue and shed every connected client (``docs/PERFORMANCE.md``
+    §6). The client here does not read *at all* — the harshest form of the
+    case — and still survives, because a pass is now four frames.
+
+    Deliberately not parameterised down to a small queue: the number that has
+    to hold is the one shipped installs run with.
+    """
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        probe.stall()
+        live_app.broadcaster.publish_activity([activity_event(index) for index in range(500)])
+        await settle()
+
+        assert live_app.broadcaster.client_count == 1
+        assert counters.snapshot()[WS_DISCONNECTS] == 0
+
+        probe.resume()
+        await settle()
+        frames = await probe.frames()
+    finally:
+        await probe.disconnect()
+
+    # Four frames, well inside the queue, carrying all 500 events once each.
+    assert len(frames) == -(-500 // MAX_ACTIVITY_EVENTS_PER_FRAME)
+    assert len(frames) < DEFAULT_CLIENT_QUEUE_SIZE
+    assert sum(len(frame["data"]) for frame in frames) == 500
+
+
 async def test_a_client_that_cannot_keep_up_is_dropped_not_buffered() -> None:
     """§4.5's rule, inherited rather than excepted.
 
-    SPEC §5 says distribution must never stall: one client on a saturated link
-    must not be able to slow detection down. The dropped client reconnects and
-    fetches the feed over REST, which is strictly better than a stream it is
-    already behind on.
+    Batching gives this method far fewer occasions to trip the rule; it does
+    not exempt it. SPEC §5 says distribution must never stall: one client on a
+    saturated link must not be able to slow detection down. The dropped client
+    reconnects and fetches the feed over REST, which is strictly better than a
+    stream it is already behind on.
+
+    Ten *passes* rather than one pass of ten events — since slice 057 the
+    frame count follows the detector's cadence, so a client is only outrun by
+    a socket that stays stalled across passes, which is exactly the failure
+    the rule is for.
     """
     harness = build_live_app(client_queue_size=2)
     async with harness.app.router.lifespan_context(harness.app):
         probe, _snapshot = await open_probe(harness)
         try:
             probe.stall()
-            harness.broadcaster.publish_activity([activity_event(index) for index in range(10)])
+            for index in range(10):
+                harness.broadcaster.publish_activity([activity_event(index)])
             await settle()
 
             assert harness.broadcaster.client_count == 0
@@ -155,7 +272,7 @@ async def test_the_frame_type_is_part_of_the_declared_vocabulary() -> None:
     assert {member.value for member in MessageType} == {
         "snapshot",
         "delta",
-        "activity",
+        "activity_batch",
         "ping",
         "pong",
     }

--- a/docs/API.md
+++ b/docs/API.md
@@ -512,8 +512,8 @@ still cannot reach this response.
 ## 4. WebSocket Protocol — `/api/v1/ws/live` (slice 010)
 
 One WebSocket carries the live picture and activity events. The base protocol
-(snapshot, delta, keepalive/resync) ships in slice 010; the `activity` frame type
-(§ 4.4) is added by slice 035.
+(snapshot, delta, keepalive/resync) ships in slice 010; the activity frame type
+(§ 4.4) is added by slice 035 and becomes the batched `activity_batch` in slice 057.
 
 ### 4.1 Message envelope
 
@@ -551,16 +551,34 @@ On connect the server immediately sends:
   robust, and cheap at 500-aircraft scale with batching.
 - `stale` lists ICAOs crossing the staleness threshold; `removed` lists ICAOs leaving
   live display. Interesting-status changes arrive as normal `updated` entries plus an
-  `activity` frame when an alert fires.
+  `activity_batch` frame when an alert fires.
 
-### 4.4 Activity events — added by slice 035
+### 4.4 Activity events — added by slice 035, batched by slice 057
 
 ```json
-{ "type": "activity", "seq": 3, "ts": "...", "data": { /* activity event, § 3.9 shape */ } }
+{ "type": "activity_batch", "seq": 3, "ts": "...", "data": [
+    /* one or more activity events, § 3.9 shape, oldest first */
+] }
 ```
 
 Drives the live activity feed and browser notifications (phase 6). Clients built
 against the slice-010 protocol ignore this frame type until they support it (§ 6).
+
+- **One frame per activity-detector pass**, carrying everything that pass recorded,
+  the same way a `delta` carries a whole tick. `data` is always an **array**, even
+  for a single event; a pass that recorded nothing sends no frame. At most 128
+  events go in one frame, so a pathological pass sends a few frames rather than one
+  enormous one.
+- Batching exists because the per-event form did not survive a first run: on a new
+  database every aircraft is a first-ever sighting, so one 5-second pass emitted a
+  burst larger than a client's outbound queue and § 4.5's slow-consumer rule evicted
+  every connected client (measured in `docs/PERFORMANCE.md` § 6).
+- **The singular `activity` frame type is retired.** The server no longer sends it.
+  A client written against slice 035 ignores `activity_batch` per § 6 — it stops
+  receiving live events until updated, and its `GET /activity` feed (§ 3.9) is
+  unaffected, which is precisely the degradation § 6 is written to make safe.
+- There is no replay: these frames are not part of the snapshot/delta picture, and a
+  reconnecting client refetches `GET /activity` rather than being re-sent them.
 
 ### 4.5 Keepalive, reconnect, slow consumers
 
@@ -633,6 +651,10 @@ reads return masked placeholders; logs and diagnostics never include them.
   semantics requires a deprecation note in release notes and is avoided after
   `v1.0.0`.
 - The WebSocket message set may add new `type`s; clients must ignore unknown types.
+  *Retiring* a `type` follows the field rule above — a note in the release notes,
+  and avoided after `v1.0.0`. The singular `activity` frame was retired pre-1.0 by
+  slice 057 in favour of `activity_batch` (§ 4.4); ignoring the unknown replacement
+  is what makes an un-updated client degrade to its REST feed instead of breaking.
 - `/api/internal` carries no compatibility promise.
 
 ---

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -366,6 +366,12 @@ reconnect as a browser would. This is first-run behaviour that decays as
 aircraft stop being novel, but it is worth knowing that a fresh install with a
 busy receiver will resync its clients every few seconds for a while; see §6.
 
+> **Fixed by slice 057.** The run above predates it. A detector pass is now one
+> `activity_batch` frame rather than one frame per event (`docs/API.md` §4.4),
+> so the burst cannot exceed the queue; the same run on the same machine goes
+> from 20 resync reconnects to 0. The reading is left as recorded, because a
+> baseline that gets edited is not a baseline.
+
 ---
 
 ## 6. Observations for later slices
@@ -374,20 +380,28 @@ Findings the harness surfaced that are outside slice 049's scope. Recorded here
 rather than acted on, because measuring is this slice's job and changing what
 it measures is not.
 
-**Activity bursts overflow WebSocket client queues on a fresh install.** The
-activity service publishes one frame per event, synchronously, with no await
-between them (`LiveBroadcaster.publish_activity`). A pass that detects more
-events than a client's outbound queue holds — 32 by default — evicts every
-connected client in a single call. On a new database at 500 aircraft this
-happens on essentially every 5-second pass, because every aircraft is a
-first-ever sighting.
+**Activity bursts overflow WebSocket client queues on a fresh install.**
+*(Resolved by slice 057 — issue #99. Kept as the record of what the harness
+found and what was done about it.)* The activity service published one frame
+per event, synchronously, with no await between them
+(`LiveBroadcaster.publish_activity`). A pass that detects more events than a
+client's outbound queue holds — 32 by default — evicted every connected client
+in a single call. On a new database at 500 aircraft this happened on
+essentially every 5-second pass, because every aircraft is a first-ever
+sighting.
 
-The behaviour is correct in the sense that it is the documented slow-consumer
-rule and the client is told to resync rather than left stalled. Whether it is
-*desirable* on a first run is a product question: a browser reconnecting every
-five seconds for the first hours of an install is not a good first impression,
-and coalescing a pass's events into fewer frames, or capping the burst, would
-avoid it. Worth a roadmap entry against the activity or WebSocket slice.
+The behaviour was correct in the sense that it was the documented slow-consumer
+rule and the client is told to resync rather than left stalled. Whether it was
+*desirable* on a first run was the product question: a browser reconnecting
+every five seconds for the first hours of an install is not a good first
+impression.
+
+Slice 057 took the first of the two options named here — coalescing a pass's
+events into fewer frames. `publish_activity` now sends one `activity_batch`
+frame per pass (`docs/API.md` §4.4), capped at 128 events per frame, so the
+frame count follows the detector's 5-second cadence rather than the size of the
+backlog. Re-running §5.5's command on a fresh database takes the reconnect
+count to zero.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -136,6 +136,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 051 | Documentation & install polish | 042, 045, 046 | sonnet | low | Docs complete enough for a fresh install from documentation alone |
 | 054 | Live map motion correctness | 014, 039 | opus | medium | Anchor dead reckoning to the last position change so markers stop creeping forward then teleporting back (issue #119) |
 | 055 | Alert template instantiation fixes | 038, 041, 046 | opus | medium | Instantiate newly enabled alert templates on config save, and fix the wizard/catalogue template-key mismatch (issues #110, #111) |
+| 057 | Activity WebSocket batching | 012, 035, 049 | opus | medium | Batch a detector pass's activity events into one WebSocket frame so a fresh install's backlog stops evicting every client (issue #99) |
 
 ## Parallelization Guide
 

--- a/frontend/src/features/activity/ActivityPanel.test.tsx
+++ b/frontend/src/features/activity/ActivityPanel.test.tsx
@@ -34,8 +34,8 @@ function renderPanel() {
  */
 function openSocket(): LiveSocket {
   const socket = new LiveSocket({
-    onActivity: (event) => {
-      useActivityFeedStore.getState().addEvent(event);
+    onActivityBatch: (events) => {
+      useActivityFeedStore.getState().addEvents(events);
     },
   });
   socket.start();
@@ -107,7 +107,7 @@ describe("ActivityPanel", () => {
     expect(screen.queryByTestId("activity-row")).not.toBeInTheDocument();
   });
 
-  it("appends an event delivered over the activity frame", async () => {
+  it("appends an event delivered over the activity_batch frame", async () => {
     installActivityApiMock({
       list: activityList([
         activityEvent({ id: 1, at: "2026-08-31T13:00:00.000Z" }),
@@ -128,17 +128,19 @@ describe("ActivityPanel", () => {
         data: { aircraft: [], receiver: null },
       });
       ws.emitFrame({
-        type: "activity",
+        type: "activity_batch",
         seq: 2,
-        data: {
-          id: 9,
-          type: "range_record",
-          severity: "interesting",
-          at: "2026-08-31T15:00:00.000Z",
-          icao: null,
-          sighting_id: null,
-          payload: { range_nm: 412.75, previous_nm: 401.2 },
-        },
+        data: [
+          {
+            id: 9,
+            type: "range_record",
+            severity: "interesting",
+            at: "2026-08-31T15:00:00.000Z",
+            icao: null,
+            sighting_id: null,
+            payload: { range_nm: 412.75, previous_nm: 401.2 },
+          },
+        ],
       });
     });
 
@@ -164,7 +166,7 @@ describe("ActivityPanel", () => {
     );
 
     act(() => {
-      useActivityFeedStore.getState().addEvent(duplicate);
+      useActivityFeedStore.getState().addEvents([duplicate]);
     });
     await expand();
 

--- a/frontend/src/features/activity/ActivityPanel.tsx
+++ b/frontend/src/features/activity/ActivityPanel.tsx
@@ -5,7 +5,7 @@
  *
  * Two sources, one list. The REST first page (`GET /api/v1/activity`) supplies
  * the history that was already there when the tab opened, and the WebSocket's
- * `activity` frames (§4.4) append to it live through
+ * `activity_batch` frames (§4.4) append to it live through
  * `useActivityFeedStore` — merged and deduped by `id`, because a reconnect
  * plus a refetch can legitimately deliver the same row twice.
  *

--- a/frontend/src/features/activity/store/useActivityFeedStore.test.ts
+++ b/frontend/src/features/activity/store/useActivityFeedStore.test.ts
@@ -12,26 +12,75 @@ beforeEach(() => {
 });
 
 describe("useActivityFeedStore", () => {
-  it("keeps live events newest first", () => {
+  it("keeps live events newest first across successive batches", () => {
     const store = useActivityFeedStore.getState;
-    store().addEvent(activityEvent({ id: 1 }));
-    store().addEvent(activityEvent({ id: 2 }));
+    store().addEvents([activityEvent({ id: 1 })]);
+    store().addEvents([activityEvent({ id: 2 })]);
 
     expect(store().events.map((event) => event.id)).toEqual([2, 1]);
   });
 
+  it("reverses one batch, which arrives oldest first", () => {
+    // `docs/API.md` §4.4: the frame carries a pass in the order it was
+    // recorded (ascending event id). The store is newest first, so a batch
+    // ingested in one update has to land reversed — the case a per-event loop
+    // got right by accident and a batch update has to get right on purpose.
+    const store = useActivityFeedStore.getState;
+    store().addEvents([
+      activityEvent({ id: 1 }),
+      activityEvent({ id: 2 }),
+      activityEvent({ id: 3 }),
+    ]);
+
+    expect(store().events.map((event) => event.id)).toEqual([3, 2, 1]);
+  });
+
+  it("puts a whole batch in front of what it already held", () => {
+    const store = useActivityFeedStore.getState;
+    store().addEvents([activityEvent({ id: 1 })]);
+    store().addEvents([activityEvent({ id: 2 }), activityEvent({ id: 3 })]);
+
+    expect(store().events.map((event) => event.id)).toEqual([3, 2, 1]);
+  });
+
   it("ignores an event id it already holds", () => {
     const store = useActivityFeedStore.getState;
-    store().addEvent(activityEvent({ id: 7 }));
-    store().addEvent(activityEvent({ id: 7 }));
+    store().addEvents([activityEvent({ id: 7 })]);
+    store().addEvents([activityEvent({ id: 7 })]);
 
     expect(store().events).toHaveLength(1);
+  });
+
+  it("drops ids repeated within one batch", () => {
+    const store = useActivityFeedStore.getState;
+    store().addEvents([activityEvent({ id: 7 }), activityEvent({ id: 7 })]);
+
+    expect(store().events).toHaveLength(1);
+  });
+
+  it("leaves the state object untouched when a batch is all duplicates", () => {
+    // Identity matters: an unchanged reference is what stops zustand
+    // re-rendering the panel for a batch that added nothing.
+    const store = useActivityFeedStore.getState;
+    store().addEvents([activityEvent({ id: 7 })]);
+    const before = store().events;
+    store().addEvents([activityEvent({ id: 7 })]);
+
+    expect(store().events).toBe(before);
+  });
+
+  it("does nothing with an empty batch", () => {
+    const store = useActivityFeedStore.getState;
+    const before = store().events;
+    store().addEvents([]);
+
+    expect(store().events).toBe(before);
   });
 
   it("caps the stream so a long-lived tab cannot grow without bound", () => {
     const store = useActivityFeedStore.getState;
     for (let id = 1; id <= MAX_LIVE_EVENTS + 10; id += 1) {
-      store().addEvent(activityEvent({ id }));
+      store().addEvents([activityEvent({ id })]);
     }
 
     expect(store().events).toHaveLength(MAX_LIVE_EVENTS);
@@ -39,9 +88,32 @@ describe("useActivityFeedStore", () => {
     expect(store().events[0]?.id).toBe(MAX_LIVE_EVENTS + 10);
   });
 
+  it("caps a single batch larger than the whole store", () => {
+    // A fresh install's first pass is hundreds of events at once — the case
+    // that only exists now that a batch arrives as one update.
+    const store = useActivityFeedStore.getState;
+    const batch = Array.from({ length: MAX_LIVE_EVENTS + 50 }, (_, index) =>
+      activityEvent({ id: index + 1 }),
+    );
+    store().addEvents(batch);
+
+    expect(store().events).toHaveLength(MAX_LIVE_EVENTS);
+    // Newest first means the highest id survives and the oldest are dropped.
+    expect(store().events[0]?.id).toBe(MAX_LIVE_EVENTS + 50);
+    expect(store().events.at(-1)?.id).toBe(51);
+  });
+
+  it("does not mutate the caller's array", () => {
+    const store = useActivityFeedStore.getState;
+    const batch = [activityEvent({ id: 1 }), activityEvent({ id: 2 })];
+    store().addEvents(batch);
+
+    expect(batch.map((event) => event.id)).toEqual([1, 2]);
+  });
+
   it("empties on reset, so a remount shows no dead connection's stream", () => {
     const store = useActivityFeedStore.getState;
-    store().addEvent(activityEvent({ id: 1 }));
+    store().addEvents([activityEvent({ id: 1 })]);
     store().reset();
 
     expect(store().events).toEqual([]);

--- a/frontend/src/features/activity/store/useActivityFeedStore.ts
+++ b/frontend/src/features/activity/store/useActivityFeedStore.ts
@@ -41,8 +41,20 @@ export const MAX_LIVE_EVENTS = 100;
 export interface ActivityFeedState {
   /** Newest first, capped at {@link MAX_LIVE_EVENTS}. */
   events: ActivityEvent[];
-  /** Appends one event from an `activity` frame (§4.4). */
-  addEvent: (event: ActivityEvent) => void;
+  /**
+   * Ingests one `activity_batch` frame — a whole detector pass — in a single
+   * update (§4.4).
+   *
+   * A batch, not an event, because that is what the socket now delivers: the
+   * server sends one frame per pass so a first-run backlog cannot evict the
+   * client (slice 057). One `set` per pass rather than per event is the
+   * incidental win — a 500-event first-run pass renders the panel once.
+   *
+   * The frame carries the pass oldest-first (the server sorts by event id, and
+   * `docs/API.md` §3.9 numbers them in the order they were recorded), so it is
+   * prepended reversed to keep this list newest-first.
+   */
+  addEvents: (events: readonly ActivityEvent[]) => void;
   /** Returns the store to its initial state — used when the socket is torn
    * down, so a remount never shows a stream from a dead connection. */
   reset: () => void;
@@ -55,16 +67,33 @@ function initialState(): Pick<ActivityFeedState, "events"> {
 export const useActivityFeedStore = create<ActivityFeedState>((set) => ({
   ...initialState(),
 
-  addEvent: (event) => {
+  addEvents: (incoming) => {
+    if (incoming.length === 0) {
+      return;
+    }
     set((state) => {
-      // The server never re-sends an event, but a reconnect can overlap with
-      // a REST refetch and the panel merges both — so dropping a duplicate id
-      // here as well keeps the store itself a set, and costs one scan of a
-      // hundred-item array per event at a rate of a few an hour.
-      if (state.events.some((existing) => existing.id === event.id)) {
+      // The server never re-sends an event, but a reconnect can overlap with a
+      // REST refetch and the panel merges both — so dropping a duplicate id
+      // here as well keeps the store itself a set. The seen-set is built once
+      // per pass rather than rescanning the array per event, which is what
+      // keeps a 500-event first-run batch linear instead of quadratic.
+      const seen = new Set(state.events.map((existing) => existing.id));
+      const fresh: ActivityEvent[] = [];
+      for (const event of incoming) {
+        if (!seen.has(event.id)) {
+          seen.add(event.id);
+          fresh.push(event);
+        }
+      }
+      if (fresh.length === 0) {
         return state;
       }
-      return { events: [event, ...state.events].slice(0, MAX_LIVE_EVENTS) };
+      // `reverse` is safe: `fresh` is this call's own array, never the
+      // caller's. Newest event of the pass ends up at the head.
+      fresh.reverse();
+      return {
+        events: [...fresh, ...state.events].slice(0, MAX_LIVE_EVENTS),
+      };
     });
   },
 

--- a/frontend/src/features/map/aircraft/useLiveConnection.test.tsx
+++ b/frontend/src/features/map/aircraft/useLiveConnection.test.tsx
@@ -1,8 +1,8 @@
 /**
  * The socket-to-notification path, end to end through the real protocol
- * client: an `activity` frame arrives and becomes exactly one browser
- * notification (roadmap slice 040), while the activity store gets the same
- * event for the panel.
+ * client: an `activity_batch` frame arrives and each alert event in it becomes
+ * exactly one browser notification (roadmap slice 040), while the activity
+ * store gets the whole batch in one update for the panel.
  */
 
 import { act, renderHook } from "@testing-library/react";
@@ -28,7 +28,14 @@ const ALL_ON = {
   critical: true,
 };
 
+/** Each event as its own single-event batch frame — successive detector
+ * passes, which is what a settled receiver actually produces. */
 function connectAndDeliver(...events: unknown[]): void {
+  connectAndDeliverBatches(...events.map((event) => [event]));
+}
+
+/** One frame per argument, each carrying a whole pass. */
+function connectAndDeliverBatches(...batches: unknown[][]): void {
   const ws = getLastWebSocket();
   act(() => {
     ws.emitFrame({
@@ -36,8 +43,8 @@ function connectAndDeliver(...events: unknown[]): void {
       seq: 1,
       data: { aircraft: [], receiver: null },
     });
-    events.forEach((data, index) => {
-      ws.emitFrame({ type: "activity", seq: index + 2, data });
+    batches.forEach((data, index) => {
+      ws.emitFrame({ type: "activity_batch", seq: index + 2, data });
     });
   });
 }
@@ -117,6 +124,32 @@ describe("useLiveConnection", () => {
 
     expect(FakeNotification.instances).toHaveLength(0);
     expect(useActivityFeedStore.getState().events).toHaveLength(1);
+  });
+
+  it("notifies per event in one batch, and feeds the store once", () => {
+    // One pass carrying several alerts is the case slice 057 created: the
+    // store takes the batch as a single update, while notifications stay one
+    // per event because a notification is a per-event user-visible thing.
+    installNotificationMock({ permission: "granted" });
+    useNotificationStore.getState().setPreferences(ALL_ON);
+    renderHook(() => {
+      useLiveConnection();
+    });
+
+    connectAndDeliverBatches([
+      alertTriggeredEvent({ id: 1 }),
+      alertTriggeredEvent({
+        id: 2,
+        severity: "critical",
+        payload: { reason: "Rule: Emergency" },
+      }),
+    ]);
+
+    expect(FakeNotification.instances).toHaveLength(2);
+    // Newest first: the batch arrives oldest first and is reversed on ingest.
+    expect(
+      useActivityFeedStore.getState().events.map((event) => event.id),
+    ).toEqual([2, 1]);
   });
 
   it("delivers nothing, and breaks nothing, when the user has not opted in", () => {

--- a/frontend/src/features/map/aircraft/useLiveConnection.ts
+++ b/frontend/src/features/map/aircraft/useLiveConnection.ts
@@ -9,13 +9,13 @@
  *
  * Two stores, because the socket carries two unrelated things (`docs/API.md`
  * §4). `snapshot`/`delta` are the live *picture*: replaced wholesale, and
- * meaningless once the connection is gone. `activity` frames (§4.4) are
+ * meaningless once the connection is gone. `activity_batch` frames (§4.4) are
  * notifications about durable history, appended to `useActivityFeedStore` so
  * `ActivityPanel` can show them arriving while the map is open — while
  * `/activity` reads the same events from the database when it is not. Both
  * stores are reset on unmount for the same reason.
  *
- * An `activity` frame also goes to `dispatchAlertNotification` (slice 040),
+ * The events in a batch also go to `dispatchAlertNotification` (slice 040),
  * which turns the two alert event types into a browser notification when the
  * user has asked for one. It is called here rather than downstream of the
  * store because delivery must survive the store's reset on teardown: "already
@@ -40,9 +40,14 @@ export function useLiveConnection(): void {
       onDelta: (data) => {
         store().applyDelta(data);
       },
-      onActivity: (event) => {
-        activity().addEvent(event);
-        dispatchAlertNotification(event);
+      onActivityBatch: (events) => {
+        activity().addEvents(events);
+        // Per event, unlike the store: a notification is one user-visible
+        // thing per event, and `dispatchAlertNotification` decides for itself
+        // which of them are worth raising.
+        for (const event of events) {
+          dispatchAlertNotification(event);
+        }
       },
       onStatus: (status) => {
         store().setConnection(status);

--- a/frontend/src/lib/ws/liveSocket.test.ts
+++ b/frontend/src/lib/ws/liveSocket.test.ts
@@ -139,17 +139,121 @@ describe("LiveSocket", () => {
     socket.stop();
   });
 
-  it("ignores an activity frame when the consumer does not handle them", () => {
-    // Slice 035 added `activity` to this socket, and `onActivity` is optional
-    // precisely so a consumer that predates it — or simply does not want the
-    // feed — keeps the slice-010 behaviour: the frame falls through to §6's
-    // ignore path, the sequence still advances, and nothing resyncs.
+  it("ignores an activity_batch frame when the consumer does not handle them", () => {
+    // Slice 035 added activity frames to this socket and `onActivityBatch` is
+    // optional precisely so a consumer that predates them — or simply does not
+    // want the feed — keeps the slice-010 behaviour: the frame falls through
+    // to §6's ignore path, the sequence still advances, and nothing resyncs.
     const { socket, deltas } = harness();
     socket.start();
     const ws = getLastWebSocket();
     ws.emitFrame(snapshotFrame(1));
     ws.emitFrame({
-      type: "activity",
+      type: "activity_batch",
+      seq: 2,
+      data: [{ id: 4021, type: "milestone" }],
+    });
+    ws.emitFrame({
+      type: "delta",
+      seq: 3,
+      data: { updated: [], stale: [], removed: [] },
+    });
+
+    expect(ws.closed).toBe(false);
+    expect(deltas).toHaveLength(1);
+    socket.stop();
+  });
+
+  it("hands a whole batch to a consumer that does handle them", () => {
+    const batches: ActivityEvent[][] = [];
+    const socket = new LiveSocket({
+      url: "ws://test/api/v1/ws/live",
+      socketFactory: (url) =>
+        new FakeWebSocket(url) as unknown as LiveSocketLike,
+      random: () => 0,
+      onActivityBatch: (events) => batches.push(events),
+    });
+    socket.start();
+    const ws = getLastWebSocket();
+    ws.emitFrame(snapshotFrame(1));
+    ws.emitFrame({
+      type: "activity_batch",
+      seq: 2,
+      data: [
+        {
+          id: 4021,
+          type: "range_record",
+          severity: "interesting",
+          at: "2026-08-31T14:03:22.418Z",
+          icao: "ae1463",
+          sighting_id: 88213,
+          payload: { range_nm: 412.75 },
+        },
+        { id: 4022, type: "milestone" },
+      ],
+    });
+
+    // One call per frame, not one per event: a pass is one update downstream.
+    expect(batches).toHaveLength(1);
+    expect(batches[0]?.map((event) => event.id)).toEqual([4021, 4022]);
+    expect(batches[0]?.[0]?.type).toBe("range_record");
+    expect(batches[0]?.[0]?.payload).toEqual({ range_nm: 412.75 });
+    expect(ws.closed).toBe(false);
+    socket.stop();
+  });
+
+  it("does not call the handler for a batch with nothing readable in it", () => {
+    const batches: ActivityEvent[][] = [];
+    const deltas: DeltaData[] = [];
+    const socket = new LiveSocket({
+      url: "ws://test/api/v1/ws/live",
+      socketFactory: (url) =>
+        new FakeWebSocket(url) as unknown as LiveSocketLike,
+      random: () => 0,
+      onActivityBatch: (events) => batches.push(events),
+      onDelta: (data) => deltas.push(data),
+    });
+    socket.start();
+    const ws = getLastWebSocket();
+    ws.emitFrame(snapshotFrame(1));
+    // No `id`: nothing the feed could dedupe on or render. The event is
+    // dropped and the batch is empty, so the handler is not called with
+    // nothing — but the frame's `seq` was consumed, so the next delta applies.
+    ws.emitFrame({
+      type: "activity_batch",
+      seq: 2,
+      data: [{ type: "milestone" }],
+    });
+    ws.emitFrame({
+      type: "delta",
+      seq: 3,
+      data: { updated: [], stale: [], removed: [] },
+    });
+
+    expect(batches).toEqual([]);
+    expect(deltas).toHaveLength(1);
+    expect(ws.closed).toBe(false);
+    socket.stop();
+  });
+
+  it("ignores a batch frame whose body is not an array", () => {
+    // The singular §4.4 body shape arriving under the batch type would be a
+    // server that half-upgraded; §6 says ignore it, not resync on it.
+    const batches: ActivityEvent[][] = [];
+    const deltas: DeltaData[] = [];
+    const socket = new LiveSocket({
+      url: "ws://test/api/v1/ws/live",
+      socketFactory: (url) =>
+        new FakeWebSocket(url) as unknown as LiveSocketLike,
+      random: () => 0,
+      onActivityBatch: (events) => batches.push(events),
+      onDelta: (data) => deltas.push(data),
+    });
+    socket.start();
+    const ws = getLastWebSocket();
+    ws.emitFrame(snapshotFrame(1));
+    ws.emitFrame({
+      type: "activity_batch",
       seq: 2,
       data: { id: 4021, type: "milestone" },
     });
@@ -159,19 +263,24 @@ describe("LiveSocket", () => {
       data: { updated: [], stale: [], removed: [] },
     });
 
-    expect(ws.closed).toBe(false);
+    expect(batches).toEqual([]);
     expect(deltas).toHaveLength(1);
+    expect(ws.closed).toBe(false);
     socket.stop();
   });
 
-  it("hands an activity frame to a consumer that does handle them", () => {
-    const events: ActivityEvent[] = [];
+  it("still reads the retired singular activity frame, as a one-event batch", () => {
+    // Slice 057 retired the singular type server-side; this client keeps
+    // reading it for one release so a tab holding the new bundle survives
+    // reconnecting to a backend that has not been upgraded yet. Removable
+    // with the `activity` case in `liveSocket.ts`.
+    const batches: ActivityEvent[][] = [];
     const socket = new LiveSocket({
       url: "ws://test/api/v1/ws/live",
       socketFactory: (url) =>
         new FakeWebSocket(url) as unknown as LiveSocketLike,
       random: () => 0,
-      onActivity: (event) => events.push(event),
+      onActivityBatch: (events) => batches.push(events),
     });
     socket.start();
     const ws = getLastWebSocket();
@@ -179,50 +288,11 @@ describe("LiveSocket", () => {
     ws.emitFrame({
       type: "activity",
       seq: 2,
-      data: {
-        id: 4021,
-        type: "range_record",
-        severity: "interesting",
-        at: "2026-08-31T14:03:22.418Z",
-        icao: "ae1463",
-        sighting_id: 88213,
-        payload: { range_nm: 412.75 },
-      },
+      data: { id: 4021, type: "range_record" },
     });
 
-    expect(events).toHaveLength(1);
-    expect(events[0]?.id).toBe(4021);
-    expect(events[0]?.type).toBe("range_record");
-    expect(events[0]?.payload).toEqual({ range_nm: 412.75 });
-    expect(ws.closed).toBe(false);
-    socket.stop();
-  });
-
-  it("drops an unreadable activity frame without breaking the stream", () => {
-    const events: ActivityEvent[] = [];
-    const deltas: DeltaData[] = [];
-    const socket = new LiveSocket({
-      url: "ws://test/api/v1/ws/live",
-      socketFactory: (url) =>
-        new FakeWebSocket(url) as unknown as LiveSocketLike,
-      random: () => 0,
-      onActivity: (event) => events.push(event),
-      onDelta: (data) => deltas.push(data),
-    });
-    socket.start();
-    const ws = getLastWebSocket();
-    ws.emitFrame(snapshotFrame(1));
-    // No `id`: nothing the feed could dedupe on or render. The frame is
-    // dropped, but its `seq` was still consumed, so the next delta applies.
-    ws.emitFrame({ type: "activity", seq: 2, data: { type: "milestone" } });
-    ws.emitFrame({
-      type: "delta",
-      seq: 3,
-      data: { updated: [], stale: [], removed: [] },
-    });
-
-    expect(events).toEqual([]);
-    expect(deltas).toHaveLength(1);
+    expect(batches).toHaveLength(1);
+    expect(batches[0]?.map((event) => event.id)).toEqual([4021]);
     expect(ws.closed).toBe(false);
     socket.stop();
   });

--- a/frontend/src/lib/ws/liveSocket.ts
+++ b/frontend/src/lib/ws/liveSocket.ts
@@ -34,6 +34,7 @@ import type { BackoffOptions } from "@/lib/ws/backoff";
 import { backoffDelayMs, DEFAULT_BACKOFF } from "@/lib/ws/backoff";
 import type { DeltaData, SnapshotData } from "@/lib/ws/protocol";
 import {
+  asActivityBatch,
   asActivityEvent,
   asDeltaData,
   asSnapshotData,
@@ -72,7 +73,19 @@ export interface LiveSocketHandlers {
   /** Connection state changed. Called only on a genuine transition. */
   onStatus: (status: ConnectionStatus) => void;
   /**
-   * An `activity` frame: one event (§4.4, roadmap slice 035).
+   * An `activity_batch` frame: everything one detector pass recorded
+   * (§4.4, roadmap slice 035, batched by slice 057).
+   *
+   * Called with a whole pass rather than an event at a time, which is the
+   * shape the wire now has: the server sends one frame per pass so that a
+   * fresh install's first-run backlog cannot overflow a client's queue and get
+   * it evicted. A consumer that wants events singly loops; a consumer that
+   * wants one state update per pass — the activity feed store — gets it for
+   * free, which is the direction the cost actually runs.
+   *
+   * Never called with an empty array: a pass that recorded nothing sends no
+   * frame, and a frame whose entries were all unreadable has nothing to hand
+   * over either.
    *
    * Optional, unlike the three above, and that is the point of how slice 035
    * touched this client at all. A caller that does not pass it gets exactly
@@ -81,12 +94,12 @@ export interface LiveSocketHandlers {
    * the feed is opt-in per consumer rather than something every socket owner
    * now has to handle.
    *
-   * There is no replay: `activity` frames are not part of the snapshot/delta
+   * There is no replay: activity frames are not part of the snapshot/delta
    * picture and a reconnect re-sends none of them. A consumer that needs the
    * events it missed refetches `GET /api/v1/activity` and resumes appending,
    * which is what `features/activity` does.
    */
-  onActivity?: (event: ActivityEvent) => void;
+  onActivityBatch?: (events: ActivityEvent[]) => void;
 }
 
 export interface LiveSocketOptions extends Partial<LiveSocketHandlers> {
@@ -142,9 +155,9 @@ export class LiveSocket {
       onDelta: options.onDelta ?? (() => {}),
       onStatus: options.onStatus ?? (() => {}),
       // Left genuinely absent rather than defaulted to a no-op: the dispatch
-      // switch reads its presence to decide whether an `activity` frame is
+      // switch reads its presence to decide whether an activity frame is
       // something this consumer handles or something it ignores.
-      onActivity: options.onActivity,
+      onActivityBatch: options.onActivityBatch,
     };
     this.url = options.url ?? liveSocketUrl();
     this.socketFactory = options.socketFactory ?? defaultSocketFactory;
@@ -229,16 +242,36 @@ export class LiveSocket {
         }
         return;
       }
+      case "activity_batch": {
+        // A consumer without an `onActivityBatch` handler falls through to
+        // exactly the ignore path below — no narrowing work, no error, no
+        // resync.
+        const handler = this.handlers.onActivityBatch;
+        if (!handler) {
+          return;
+        }
+        const events = asActivityBatch(frame.data);
+        // An empty pass is not delivered: the server does not send one, and a
+        // frame whose entries were all unreadable has nothing to append.
+        if (events && events.length > 0) {
+          handler(events);
+        }
+        return;
+      }
       case "activity": {
-        // A consumer without an `onActivity` handler falls through to exactly
-        // the ignore path below — no narrowing work, no error, no resync.
-        const handler = this.handlers.onActivity;
+        // The singular frame slice 035 defined and slice 057 retired. The
+        // server no longer sends it; this case is here for the one window
+        // where it can still arrive — a tab holding a new bundle that
+        // reconnects to a backend not yet upgraded — and it hands the event
+        // over as a one-event pass so there is a single consumer contract
+        // rather than two. Removable one release after 057 ships.
+        const handler = this.handlers.onActivityBatch;
         if (!handler) {
           return;
         }
         const event = asActivityEvent(frame.data);
         if (event) {
-          handler(event);
+          handler([event]);
         }
         return;
       }
@@ -249,8 +282,9 @@ export class LiveSocket {
       default:
         // §6: unknown types (and `pong`, which this client never provokes)
         // are ignored, not errors — the rule that let a slice-010 client
-        // survive slice 035 adding `activity` above, and that will let this
-        // one survive whatever comes next.
+        // survive slice 035 adding `activity`, and a slice-035 client survive
+        // slice 057 replacing it with `activity_batch` above, and that will
+        // let this one survive whatever comes next.
         return;
     }
   }

--- a/frontend/src/lib/ws/protocol.test.ts
+++ b/frontend/src/lib/ws/protocol.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  asActivityBatch,
   asActivityEvent,
   asDeltaData,
   asSnapshotData,
@@ -169,6 +170,61 @@ describe("asActivityEvent", () => {
     // feed dedupes on and `type` is what decides the rendering, so an event
     // missing either could only ever be a blank row.
     expect(asActivityEvent(data)).toBeNull();
+  });
+});
+
+describe("asActivityBatch", () => {
+  it("narrows the array of §3.9 events one pass recorded", () => {
+    const events = asActivityBatch([
+      { id: 1, type: "milestone" },
+      { id: 2, type: "range_record" },
+    ]);
+    expect(events?.map((event) => event.id)).toEqual([1, 2]);
+  });
+
+  it("keeps the order the frame carries, oldest first", () => {
+    // The store reverses a batch to stay newest-first, so this narrowing must
+    // not quietly reorder it first.
+    const events = asActivityBatch([
+      { id: 7, type: "milestone" },
+      { id: 8, type: "milestone" },
+      { id: 9, type: "milestone" },
+    ]);
+    expect(events?.map((event) => event.id)).toEqual([7, 8, 9]);
+  });
+
+  it("narrows a single-event batch, the common steady-state case", () => {
+    const events = asActivityBatch([{ id: 4021, type: "range_record" }]);
+    expect(events).toHaveLength(1);
+  });
+
+  it("accepts an empty array", () => {
+    // The server does not send one, but an empty pass is legible rather than
+    // corrupt: the caller has nothing to ingest, not a frame to distrust.
+    expect(asActivityBatch([])).toEqual([]);
+  });
+
+  it("drops a malformed entry without discarding the rest of the pass", () => {
+    // One unreadable event costs one row, not the whole batch — which is the
+    // difference batching makes to the blast radius of a bad entry.
+    const events = asActivityBatch([
+      { id: 1, type: "milestone" },
+      { id: "2", type: "milestone" },
+      null,
+      { type: "milestone" },
+      { id: 5, type: "milestone" },
+    ]);
+    expect(events?.map((event) => event.id)).toEqual([1, 5]);
+  });
+
+  it.each([
+    ["a non-array object", { id: 1, type: "milestone" }],
+    ["a bare string", "activity_batch"],
+    ["null", null],
+    ["undefined", undefined],
+  ])("returns null for %s", (_label, data) => {
+    // Not an array is not a batch: §6 says ignore the frame.
+    expect(asActivityBatch(data)).toBeNull();
   });
 });
 

--- a/frontend/src/lib/ws/protocol.ts
+++ b/frontend/src/lib/ws/protocol.ts
@@ -18,6 +18,13 @@
  *   010 had to survive that without reconnecting — so parsing keeps the
  *   envelope and lets the caller decide it has nothing to do with the payload.
  *   The rule still governs whatever a later slice adds next.
+ *
+ * Slice 057 is the next such change: the server now sends `activity_batch`,
+ * one frame carrying a whole detector pass, and no longer sends the singular
+ * `activity` frame at all. This module narrows **both**, because a browser
+ * holding a cached bundle can outlive a backend upgrade in either direction
+ * for the length of one release; the singular path is marked for removal
+ * there rather than here.
  */
 
 import type { ActivityEvent } from "@/lib/api/activity";
@@ -28,9 +35,11 @@ import type { LiveAircraft, ReceiverInfo } from "@/lib/api/live";
  * backend, exactly like the REST paths in `@/lib/api/client`. */
 export const LIVE_WS_PATH = "/api/v1/ws/live";
 
-/** Frame types this client understands. Anything else is ignored per §6. */
+/** Frame types this client understands. Anything else is ignored per §6.
+ * `activity` is the retired singular form (slice 035), still understood for
+ * one release so a running tab survives meeting an older backend. */
 export type ServerFrameType =
-  "snapshot" | "delta" | "activity" | "ping" | "pong";
+  "snapshot" | "delta" | "activity_batch" | "activity" | "ping" | "pong";
 
 /** `docs/API.md` §4.2: the complete live picture, replacing whatever the
  * client held. Sent on connect and again whenever the server resyncs. */
@@ -171,4 +180,30 @@ export function asActivityEvent(data: unknown): ActivityEvent | null {
     sighting_id: typeof sighting_id === "number" ? sighting_id : null,
     payload: isRecord(payload) ? payload : {},
   };
+}
+
+/**
+ * Narrows a frame body to an `activity_batch`: the array of §3.9 events one
+ * detector pass recorded (§4.4, slice 057).
+ *
+ * Returns `null` only when the body is not an array at all — that is a frame
+ * this client cannot read, and §6 says ignore it. An array whose *entries* are
+ * malformed is a different case: each entry is narrowed by
+ * {@link asActivityEvent} and the ones that fail are dropped individually, so
+ * one unreadable event costs one row rather than the whole pass. An array that
+ * survives as empty is returned as such; the caller decides that nothing to
+ * ingest means nothing to do.
+ */
+export function asActivityBatch(data: unknown): ActivityEvent[] | null {
+  if (!Array.isArray(data)) {
+    return null;
+  }
+  const events: ActivityEvent[] = [];
+  for (const entry of data) {
+    const event = asActivityEvent(entry);
+    if (event) {
+      events.push(event);
+    }
+  }
+  return events;
 }

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1346,6 +1346,44 @@ slices:
     risk_level: medium
     notes: "Unplanned fix slice for GitHub issues #110 and #111 (found by slice 046). Added by Fable outside the phase plan."
 
+  - id: "057"
+    title: "Activity WebSocket batching"
+    phase: 8
+    branch: "057-activity-ws-batching"
+    status: merged
+    depends_on: ["012", "035", "049"]
+    objective: "Stop a fresh install's activity backlog from evicting every WebSocket client, by sending one batched frame per detector pass instead of one frame per event."
+    scope:
+      - "new `activity_batch` frame type carrying an array of §3.9 activity events; one frame per detector pass, mirroring the delta's one-frame-per-tick shape"
+      - "the singular `activity` frame type is retired: the server emits only batches, so there is one server code path and one client path to keep correct"
+      - "events per frame capped so a pathological first-run pass sends a few frames instead of one enormous one, still far under the 32-frame client queue"
+      - "frontend: batch narrowing in the protocol module, a batch handler on the live socket, and single-update batch ingestion in the activity feed store (newest-first, 100-event cap preserved)"
+      - "docs/API.md §4.4 and the ws.py protocol docstring updated to the batched contract"
+    out_of_scope:
+      - client queue sizing, the slow-consumer rule itself, or the close code (§4.5 is unchanged)
+      - activity detection cadence, dedupe, or the §3.9 event shape
+      - "delta/snapshot batching: they already emit one frame per tick"
+      - activity replay on reconnect (still REST, deliberately)
+    acceptance_criteria:
+      - "a detector pass emitting hundreds of events no longer evicts a connected client; the slice-049 harness WS scenario reports zero activity-driven evictions"
+      - "one pass produces one frame (or the few a cap implies), taking its place in the `seq` sequence with no gap"
+      - "a client that only understands the slice-035 protocol ignores the new type per §6 rather than erroring or resyncing"
+      - "the activity feed store ingests a batch in one update, newest-first, capped at MAX_LIVE_EVENTS"
+    required_tests:
+      - broadcaster batch-contract tests (one frame per pass, array body, seq continuity, per-frame cap)
+      - fresh-install-scale burst test asserting no eviction where the pre-slice behaviour evicted
+      - frontend protocol narrowing tests (array accepted, malformed entries dropped)
+      - store batch-ingestion tests (order, dedupe, cap) and live-socket handler tests
+    expected_artifacts:
+      - backend/src/flightsite/api/ws.py
+      - frontend/src/lib/ws/protocol.ts
+      - frontend/src/lib/ws/liveSocket.ts
+      - frontend/src/features/activity/store/useActivityFeedStore.ts
+      - docs/API.md
+    preferred_agent: opus
+    risk_level: medium
+    notes: "Unplanned fix slice for GitHub issue #99 (observed by the slice-049 harness and recorded in docs/PERFORMANCE.md §6). Added by Fable outside the phase plan."
+
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,
 # 027, 031, 033, 035, 037, 038, 052) are ADDITIONALLY serialized against each other


### PR DESCRIPTION
## Slice 057 — Activity WS batching

Fixes #99: a detector pass emitted one frame per activity event with no await; a fresh install's pass exceeded the 32-frame client queue and evicted every connected client (1013) — measured 20 times per 600-tick run.

- New `activity_batch` frame type: one frame per pass, data = array of §3.9 events, capped at 128 events/frame (order-preserving split — the cap bounds per-frame size, not eviction)
- The singular `activity` type is retired server-side (one wire shape, one code path); un-updated clients degrade safely per API.md §6's ignore-unknown rule, and the frontend still reads the singular form for one release (reconnect-to-old-backend case, pinned by test and marked removable)
- docs/API.md §4.4 updated; §6 gains the type-retirement clause; ws.py module docstring updated

**Measured: 20 → 0 resync reconnects** on identical fresh-data harness runs (2504→2432 frames consumed, fan-out max 284→235 ms, all 12 budget gates pass both sides).

Tests: one-frame-per-pass pin, cap/split, empty pass, fresh-install-backlog non-eviction (500 events at a non-reading client on the production queue), §4.5 slow-consumer rule retained; frontend narrowing/store/handler/batch-notification coverage.

Verification: backend ruff/format/mypy clean, 4134 passed / 98.96% coverage; frontend lint/typecheck/1589 tests/format:check green.

Note: app.py untouched (producer already passed the whole list) — zero overlap with slice 056; one stale comment at app.py:755 to fix when 056 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)