### PR TITLE
feat: start ingestion on first config save (slice 056)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,9 @@ docker compose pull
 docker compose up -d
 ```
 
-Open **`http://<host-ip>:8090/`** and complete the setup wizard.
-
-> **Then restart the backend once — aircraft will not appear until you do.**
->
-> ```bash
-> docker compose restart flightsite-backend
-> ```
->
-> Ingestion starts at boot when a saved configuration exists, and on a fresh install
-> there is none at that moment. This applies only to the first save.
+Open **`http://<host-ip>:8090/`** and complete the setup wizard. Saving starts the
+decoder connection straight away — aircraft appear on the Live Map within seconds, with
+no restart.
 
 Just want to look around? No decoder, no configuration, no hardware:
 

--- a/backend/src/flightsite/api/ingestion.py
+++ b/backend/src/flightsite/api/ingestion.py
@@ -1,0 +1,133 @@
+"""Starting decoder ingestion: at boot, and on the save that first configures it.
+
+Two callers, one implementation:
+
+* :func:`flightsite.app._start_ingestion`, once, from the lifespan hook;
+* :func:`flightsite.api.internal._apply_live_settings`, when ``PUT
+  /api/internal/config`` writes the configuration a first-run install did not
+  have.
+
+Why the second caller exists (issue #122)
+-----------------------------------------
+
+A first-run install starts no ingestion — there is no ``config.yaml``, so
+there is no receiver the user has actually chosen, and polling model defaults
+would report a decoder ``down`` before the setup wizard had even been opened.
+That guard was right, but it was permanent: ``app.state.ingestion`` stayed
+``None`` for the life of the process, so the very save that ended the
+first-run state changed nothing until someone restarted the backend. A user
+who completed the wizard watched an empty map and was told, correctly but
+uselessly, that their install was working.
+
+So the save that ends the first-run state now starts ingestion against the
+receiver it just wrote — which is exactly what the *next* boot would have
+done with the same file. That equivalence is the point, and it is why this
+module builds the endpoint from ``app.state.settings`` rather than from the
+request body: hot-start and cold-start must not be two ways to decide what to
+poll.
+
+Hot-**start** only
+------------------
+
+Nothing → running. This module never restarts, reconfigures or replaces a
+service that is already running, and :func:`ingestion_startable` refuses to
+even build a second one. Changing the endpoint of a *running* adapter is a
+different problem — an in-flight poll, a health history and a readiness
+registration all belong to the old endpoint — and it stays restart-required,
+which is what the Settings UI's decoder and receiver sections say on their
+badges. The narrow case fixed here is the one where there is nothing running
+to disturb.
+
+Mid-life readiness registration is safe
+---------------------------------------
+
+:meth:`~flightsite.ingest.service.IngestionService.start` registers the
+``ingestion`` subsystem and marks it ready, and on this path that happens
+*after* ``mark_startup_complete()``. It cannot make ``/api/v1/ready`` flap:
+:meth:`~flightsite.readiness.ReadinessRegistry.register` seeds the subsystem
+not-ready, but the ``mark_ready`` that follows it runs in the same synchronous
+block with no ``await`` between the two, and the ``/ready`` handler is a
+coroutine on the same event loop — so no request can be served in the window
+where the new subsystem is registered but not yet ready. The registry's own
+lock keeps the pair atomic for any non-``asyncio`` reader.
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import FastAPI
+
+from flightsite.config import ConfigStore, Settings
+from flightsite.ingest import DecoderEndpoint, IngestionService, build_ingestion_service
+from flightsite.live import LiveStore
+
+logger = structlog.get_logger(__name__)
+
+
+def decoder_endpoint(settings: Settings) -> DecoderEndpoint:
+    """Translate the receiver section of settings into an ingestion endpoint."""
+    receiver = settings.receiver
+    return DecoderEndpoint(
+        host=receiver.host,
+        port=receiver.port,
+        path=receiver.path,
+        poll_interval_s=receiver.poll_interval_s,
+    )
+
+
+def ingestion_startable(app: FastAPI) -> bool:
+    """True when there is nothing ingesting and a saved configuration to ingest from.
+
+    Three conditions, and all three are about *this* process's state rather
+    than about what changed in the request:
+
+    * nothing is running. A service that already exists owns the adapter, the
+      task and the readiness registration; this module never displaces one.
+      This is also what makes a second save a no-op rather than a second
+      service — ``IngestionService.start`` is idempotent, but the guard is
+      here so a redundant service is never constructed to begin with.
+    * not demo mode. Demo ingestion is started unconditionally at boot from
+      :class:`~flightsite.demo.DemoAdapter` and has no endpoint to configure;
+      a config save must not swap simulated traffic for a real decoder poll
+      under a user who set ``FLIGHTSITE_DEMO=1``.
+    * the install is no longer on its first run, i.e. ``config.yaml`` now
+      exists. That is the same condition the boot path tests, and it is what
+      "the user has chosen a receiver" actually means: the receiver section is
+      always complete after validation (its fields carry model defaults), so
+      the fact worth testing is whether a configuration was ever saved, not
+      whether the endpoint differs from the defaults.
+    """
+    if getattr(app.state, "ingestion", None) is not None:
+        return False
+    if app.state.demo_enabled:
+        return False
+    store: ConfigStore = app.state.config_store
+    return not store.first_run
+
+
+async def start_decoder_ingestion(app: FastAPI) -> IngestionService:
+    """Build, start and install the decoder ingestion service.
+
+    The live store is the sole consumer: every normalized batch goes straight
+    into the in-memory registry, and nothing on this path touches the database
+    (``docs/ARCHITECTURE.md`` §3.1).
+
+    ``app.state.ingestion`` is assigned here, last, so that a failed
+    ``start()`` leaves it ``None`` and a later save can try again — and so
+    that there is one place that decides what "ingestion is now running" means
+    for application state. Both readers pick the assignment up with no further
+    wiring: :func:`flightsite.app._decoder_health` reads it lazily on every
+    probe, and the lifespan hook's shutdown reads it when it stops.
+    """
+    live: LiveStore = app.state.live
+    service = build_ingestion_service(
+        decoder_endpoint(app.state.settings),
+        readiness=app.state.readiness,
+        consumers=(live.apply,),
+    )
+    await service.start()
+    app.state.ingestion = service
+    return service
+
+
+__all__ = ["decoder_endpoint", "ingestion_startable", "start_decoder_ingestion"]

--- a/backend/src/flightsite/api/ingestion.py
+++ b/backend/src/flightsite/api/ingestion.py
@@ -112,12 +112,24 @@ async def start_decoder_ingestion(app: FastAPI) -> IngestionService:
     into the in-memory registry, and nothing on this path touches the database
     (``docs/ARCHITECTURE.md`` §3.1).
 
-    ``app.state.ingestion`` is assigned here, last, so that a failed
-    ``start()`` leaves it ``None`` and a later save can try again — and so
-    that there is one place that decides what "ingestion is now running" means
-    for application state. Both readers pick the assignment up with no further
-    wiring: :func:`flightsite.app._decoder_health` reads it lazily on every
-    probe, and the lifespan hook's shutdown reads it when it stops.
+    ``app.state.ingestion`` is assigned *before* the service is started, and
+    that ordering is load-bearing rather than incidental. Constructing the
+    service opens nothing — no client, no task, no connection — so everything
+    from :func:`ingestion_startable`'s check through this assignment runs with
+    no ``await`` in it, and two saves arriving back to back on the same event
+    loop cannot both observe "nothing running" and both build an adapter. It
+    is the same check-and-claim shape, and the same reasoning, as
+    ``POST /metadata/update`` coalescing a double-clicked button onto the run
+    already happening. Assigning after ``start()`` instead would leave a window
+    across the adapter's own startup in which a second save saw an empty slot.
+
+    A failed ``start()`` releases the slot again, so the failure is not
+    sticky: ``app.state.ingestion`` is back to ``None`` and the next save
+    simply tries again.
+
+    Both readers pick the assignment up with no further wiring:
+    :func:`flightsite.app._decoder_health` reads it lazily on every probe, and
+    the lifespan hook's shutdown reads it when it stops.
     """
     live: LiveStore = app.state.live
     service = build_ingestion_service(
@@ -125,8 +137,12 @@ async def start_decoder_ingestion(app: FastAPI) -> IngestionService:
         readiness=app.state.readiness,
         consumers=(live.apply,),
     )
-    await service.start()
     app.state.ingestion = service
+    try:
+        await service.start()
+    except Exception:
+        app.state.ingestion = None
+        raise
     return service
 
 

--- a/backend/src/flightsite/api/internal.py
+++ b/backend/src/flightsite/api/internal.py
@@ -38,6 +38,13 @@ Writing the file and swapping ``app.state.settings`` is not always the whole of
 saving a setting: ``alerts.enabled_templates`` names alert rules to create, and
 until this existed a fresh install that chose its templates in the setup wizard
 had no alert rules until the backend was restarted (issue #110).
+
+Slice 056 adds the other half of that same first-run story to the same step:
+the save that ends the first-run state now starts decoder ingestion and anchors
+the live store at the saved location, so a user who finishes the setup wizard
+sees aircraft without restarting the backend (issue #122). Endpoint *changes*
+on an already-running adapter remain restart-required — see
+:mod:`flightsite.api.ingestion` for where that line is drawn and why.
 """
 
 from __future__ import annotations
@@ -52,10 +59,12 @@ from pydantic import ValidationError
 
 from flightsite.alerts import AlertService
 from flightsite.api.alert_rules import router as alert_rules_router
+from flightsite.api.ingestion import ingestion_startable, start_decoder_ingestion
 from flightsite.api.serializers import iso_utc
 from flightsite.config import ConfigError, ConfigStore, ReceiverSettings, Settings
 from flightsite.db import from_epoch_ms, utc_now_ms
-from flightsite.ingest import ConnectionTestResult, DecoderEndpoint, check_connection
+from flightsite.ingest import ConnectionTestResult, DecoderEndpoint, Position, check_connection
+from flightsite.live import LiveStore
 from flightsite.metadata import ImportRun, MetadataService
 from flightsite.metadata.registry import SourceStatus, SourceStatusRecord
 from flightsite.watchlists import (
@@ -165,25 +174,97 @@ async def _apply_live_settings(app: FastAPI, settings: Settings) -> None:
     those rows, which decides what the change means (see
     :meth:`~flightsite.alerts.AlertService.apply_enabled_templates`).
 
-    This is the seam for that third kind of setting, and it stays a short
-    explicit list rather than a registry until there is more than one entry.
-    Failures are logged and swallowed, exactly as
+    This is the seam for that third kind of setting. Slice 056 adds the two
+    entries below it, which are the same shape and come from the same bug
+    report: on a fresh install the save that ends the first-run state is the
+    moment ingestion becomes possible, so it is also the moment ingestion must
+    start (issue #122) against a live store that finally has a location to
+    measure from. Ordered deliberately — the anchor is set before the first
+    batch can arrive, so no aircraft is ever observed into a store that has no
+    receiver location.
+
+    Each entry is independently guarded and independently isolated: none can
+    skip another by returning early, and a failure in one is logged and
+    swallowed exactly as
     :meth:`flightsite.watchlists.WatchlistService._notify_index` swallows a
-    listener's: the configuration is already validated, written and live, so an
-    exception here could only turn a save that succeeded into a 500 about it.
+    listener's. The configuration is already validated, written and live by the
+    time any of this runs, so an exception here could only turn a save that
+    succeeded into a 500 about it. Three entries is still a short explicit list
+    rather than a registry; a fourth is the point to reconsider that.
     """
+    await _apply_enabled_templates(app, settings)
+    _apply_receiver_location(app, settings)
+    await _apply_ingestion_start(app)
+
+
+def _apply_failed(setting: str, exc: Exception, **fields: Any) -> None:
+    """Report an apply step that raised, without failing the save it followed."""
+    logger.warning(
+        "config_apply_failed",
+        setting=setting,
+        error=str(exc),
+        error_type=type(exc).__name__,
+        **fields,
+    )
+
+
+async def _apply_enabled_templates(app: FastAPI, settings: Settings) -> None:
+    """Instantiate newly enabled alert templates (slice 055, issue #110)."""
     alerts: AlertService | None = getattr(app.state, "alerts", None)
     if alerts is None:  # pragma: no cover - the app always builds the service
         return
     try:
         await alerts.apply_enabled_templates(settings.alerts.enabled_templates)
     except Exception as exc:  # pragma: no cover - defensive
-        logger.warning(
-            "config_apply_failed",
-            setting="alerts.enabled_templates",
-            error=str(exc),
-            error_type=type(exc).__name__,
-        )
+        _apply_failed("alerts.enabled_templates", exc)
+
+
+def _apply_receiver_location(app: FastAPI, settings: Settings) -> None:
+    """Anchor the live store's derived distance and bearing, if it has no anchor.
+
+    Only ever fills a blank. The store is built with the location that was
+    effective at construction, and on a first run there is none — so without
+    this, ingestion started by the entry below would fill the map with aircraft
+    whose distance and bearing are ``null``.
+
+    Changing a location the store already has is a different operation and is
+    deliberately not done here: every already-observed aircraft would keep a
+    distance measured from the old position until it was seen again, which is
+    why a location *change* is restart-required and says so on its Settings
+    badge. It also keeps demo mode alone — that path installs
+    :data:`~flightsite.demo.DEFAULT_CENTER` at boot and generates its traffic
+    around it, so a saved location must not move the anchor out from under it.
+    """
+    live: LiveStore = app.state.live
+    latitude = settings.location.latitude
+    longitude = settings.location.longitude
+    if live.receiver_location is not None or latitude is None or longitude is None:
+        return
+    try:
+        live.set_receiver_location(Position(latitude=latitude, longitude=longitude))
+    except Exception as exc:  # pragma: no cover - defensive
+        _apply_failed("location", exc)
+    else:
+        logger.info("receiver_location_applied")
+
+
+async def _apply_ingestion_start(app: FastAPI) -> None:
+    """Start decoder ingestion if this save is what made it possible (issue #122).
+
+    Hot-*start* only, and :func:`~flightsite.api.ingestion.ingestion_startable`
+    is what keeps it that way: nothing → running, never a second service beside
+    a running one and never a reconfiguration of one. See
+    :mod:`flightsite.api.ingestion` for why that line is drawn there.
+
+    A failure leaves ``app.state.ingestion`` unassigned rather than poisoned,
+    so a later save simply tries again.
+    """
+    if not ingestion_startable(app):
+        return
+    try:
+        await start_decoder_ingestion(app)
+    except Exception as exc:
+        _apply_failed("receiver", exc, action="start_ingestion")
 
 
 @router.post("/decoder/test")

--- a/backend/src/flightsite/app.py
+++ b/backend/src/flightsite/app.py
@@ -29,6 +29,7 @@ from flightsite.airports import (
 from flightsite.alerts import AlertListener, AlertService
 from flightsite.analytics import AnalyticsService
 from flightsite.api.context import LiveApiContext
+from flightsite.api.ingestion import decoder_endpoint, start_decoder_ingestion
 from flightsite.api.internal import router as internal_router
 from flightsite.api.serializers import activity_event_payload
 from flightsite.api.v1 import router as v1_router
@@ -40,7 +41,7 @@ from flightsite.demo import DEFAULT_CENTER, DemoAdapter, demo_enabled
 from flightsite.diagnostics.errors import error_ring, secrets_from_settings
 from flightsite.enrichment import EnrichmentService, RouteCacheRepository
 from flightsite.enrichment.service import build_provider
-from flightsite.ingest import DecoderEndpoint, IngestionService, Position, build_ingestion_service
+from flightsite.ingest import IngestionService, Position
 from flightsite.ingest.health import AdapterHealth
 from flightsite.live import LiveStore
 from flightsite.logging import DEFAULT_LOG_DIR, configure_logging, install_error_capture
@@ -55,17 +56,6 @@ from flightsite.sightings import PersistenceWorker
 from flightsite.watchlists import WatchlistService
 
 logger = structlog.get_logger(__name__)
-
-
-def _decoder_endpoint(settings: Settings) -> DecoderEndpoint:
-    """Translate the receiver section of settings into an ingestion endpoint."""
-    receiver = settings.receiver
-    return DecoderEndpoint(
-        host=receiver.host,
-        port=receiver.port,
-        path=receiver.path,
-        poll_interval_s=receiver.poll_interval_s,
-    )
 
 
 def _build_live_store(settings: Settings) -> LiveStore:
@@ -151,9 +141,13 @@ def _decoder_health(app: FastAPI) -> HealthProbe:
 
     A callable rather than a service reference because ``app.state.ingestion``
     is assigned *during* the lifespan hook, after the activity service has been
-    constructed and started; and it can be ``None`` for the whole life of the
-    process on a first-run install, which is exactly the case the feed must
-    stay silent about rather than report as an outage.
+    constructed and started; and on a first-run install it is ``None`` until a
+    configuration is saved — which is exactly the case the feed must stay
+    silent about rather than report as an outage.
+
+    Reading late is also what makes the hot start of issue #122 invisible
+    here: when a config save assigns ``app.state.ingestion`` mid-life, the
+    very next probe reports the new service's health with no re-registration.
     """
 
     def probe() -> AdapterHealth | None:
@@ -247,7 +241,7 @@ def _build_receiver_metrics(app: FastAPI, settings: Settings) -> ReceiverMetrics
     """
     store: ConfigStore = app.state.config_store
     poller = (
-        None if store.first_run or demo_enabled() else StatsJsonPoller(_decoder_endpoint(settings))
+        None if store.first_run or demo_enabled() else StatsJsonPoller(decoder_endpoint(settings))
     )
     return ReceiverMetricsService(
         database=app.state.database,
@@ -258,24 +252,29 @@ def _build_receiver_metrics(app: FastAPI, settings: Settings) -> ReceiverMetrics
     )
 
 
-async def _start_ingestion(app: FastAPI) -> IngestionService | None:
+async def _start_ingestion(app: FastAPI) -> None:
     """Start decoder ingestion, unless this install has never been configured.
 
     On a first run there is no ``config.yaml``, so there is no receiver the
     user has actually chosen — only model defaults. Polling those would
     produce a stream of connection failures and a ``down`` decoder before the
-    setup wizard has even been opened, so ingestion is skipped and starts on
-    the next boot after a configuration is saved.
+    setup wizard has even been opened, so ingestion is skipped here.
 
-    Demo mode (``FLIGHTSITE_DEMO=1``, slice 011) is the one exception: it
-    starts :class:`~flightsite.demo.DemoAdapter` regardless of first-run
-    state, because demo mode's whole purpose is a full stack with zero
-    configuration (SPEC §76). A receiver location is injected into the live
-    store when none is configured, so distance and bearing still compute.
+    Skipped, not skipped-until-reboot: the save that ends the first-run state
+    starts ingestion itself, through the same
+    :func:`~flightsite.api.ingestion.start_decoder_ingestion` this function
+    calls (issue #122). Before that, ``app.state.ingestion`` stayed ``None``
+    for the life of the process and a user who had just completed the setup
+    wizard saw an empty map until the backend was restarted.
 
-    The live store is the sole consumer: every normalized batch goes straight
-    into the in-memory registry, and nothing on this path touches the database
-    (``docs/ARCHITECTURE.md`` §3.1).
+    Demo mode (``FLIGHTSITE_DEMO=1``, slice 011) is the one exception to the
+    first-run skip: it starts :class:`~flightsite.demo.DemoAdapter` regardless
+    of first-run state, because demo mode's whole purpose is a full stack with
+    zero configuration (SPEC §76). A receiver location is injected into the
+    live store when none is configured, so distance and bearing still compute.
+
+    ``app.state.ingestion`` is assigned on every path, including the skip, so
+    the shutdown half of the lifespan hook can read it unconditionally.
 
     Decoder health deliberately never affects ``/ready``; the reasoning is in
     :mod:`flightsite.ingest.service`.
@@ -291,20 +290,16 @@ async def _start_ingestion(app: FastAPI) -> IngestionService | None:
             consumers=(live.apply,),
         )
         await service.start()
-        return service
+        app.state.ingestion = service
+        return
 
     store: ConfigStore = app.state.config_store
     if store.first_run:
         logger.info("ingestion_skipped", reason="first_run")
-        return None
+        app.state.ingestion = None
+        return
 
-    service = build_ingestion_service(
-        _decoder_endpoint(app.state.settings),
-        readiness=app.state.readiness,
-        consumers=(live.apply,),
-    )
-    await service.start()
-    return service
+    await start_decoder_ingestion(app)
 
 
 @asynccontextmanager
@@ -415,7 +410,10 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     # startup then gets a snapshot and a continuous delta stream, never a
     # snapshot followed by a gap.
     await broadcaster.start()
-    app.state.ingestion = await _start_ingestion(app)
+    # Assigns app.state.ingestion itself, on every path — including the
+    # first-run skip, which assigns None. A save that later ends the first-run
+    # state assigns it through the same helper (issue #122).
+    await _start_ingestion(app)
     readiness.mark_startup_complete()
     logger.info("app_startup_complete")
     try:

--- a/backend/src/flightsite/ingest/service.py
+++ b/backend/src/flightsite/ingest/service.py
@@ -27,6 +27,15 @@ not-ready afterwards. Decoder connectivity is reported through
 service is not started at all and nothing is registered, so a first-run
 install is ready immediately.
 
+That last case is also why :meth:`IngestionService.start` may run long after
+startup completed: since slice 056 the configuration save that ends the
+first-run state starts ingestion in place, so ``register`` can add a subsystem
+to an already-ready registry. It cannot make ``/ready`` flap. ``register``
+seeds the subsystem not-ready, but the ``mark_ready`` below it runs in the same
+synchronous block with no ``await`` in between, and the ``/ready`` handler is a
+coroutine on that same event loop — so the intermediate state is never
+observable, and the registry's lock covers any non-``asyncio`` reader.
+
 Consumer isolation
 ------------------
 

--- a/backend/tests/ingest/test_app_wiring.py
+++ b/backend/tests/ingest/test_app_wiring.py
@@ -3,9 +3,11 @@
 Two decisions are pinned here, because both are easy to regress and expensive
 to get wrong in production:
 
-* a first-run install starts no ingestion at all, so a machine that has never
-  been configured does not spend its first boot logging connection failures
-  against a receiver nobody chose;
+* a first-run install starts no ingestion *at boot*, so a machine that has
+  never been configured does not spend its first boot logging connection
+  failures against a receiver nobody chose. That is a statement about boot
+  only: since slice 056 the save that ends the first-run state starts
+  ingestion in place, and ``test_hot_start`` pins that half;
 * a decoder that is unreachable does **not** fail ``/ready``. The app is fully
   usable without one, and an orchestrator restarting the backend because
   something outside it went offline would take away the very UI that explains
@@ -49,6 +51,14 @@ def point_decoder_at(
 
 
 def test_first_run_starts_no_ingestion() -> None:
+    """Nothing is polled, and nothing is registered, until a configuration exists.
+
+    Unchanged by slice 056: booting an unconfigured install must still start
+    no adapter. What that slice changed is how long this lasts — a
+    configuration save now ends it without a restart
+    (``test_hot_start.test_a_first_run_save_starts_ingestion_and_aircraft_flow``)
+    — so this asserts the boot state, not the fate of the process.
+    """
     app = create_app()
 
     with TestClient(app) as client:

--- a/backend/tests/ingest/test_hot_start.py
+++ b/backend/tests/ingest/test_hot_start.py
@@ -17,6 +17,7 @@ it that way — it is the difference between "start what is not running" and
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from pathlib import Path
@@ -26,12 +27,18 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 
+from flightsite.api.internal import _apply_ingestion_start
 from flightsite.app import create_app
+from flightsite.config import ConfigStore
 from flightsite.ingest import Position
+from flightsite.ingest import build_ingestion_service as real_build
 from flightsite.ingest.service import READINESS_SUBSYSTEM, IngestionService
 from flightsite.live import LiveStore
 
 from .conftest import CountingClientFactory, ScriptedTransport, json_response
+
+#: The real implementations, captured before any test monkeypatches them.
+real_start = IngestionService.start
 
 #: The document a first-run setup wizard save sends: a receiver endpoint and a
 #: location, which between them are everything ingestion needs to start.
@@ -155,6 +162,53 @@ def test_a_second_save_constructs_no_second_service(
         # polling in parallel with the first.
         assert app.state.ingestion is started
         assert app.state.settings.receiver.host == "other.test"
+
+
+async def test_two_saves_arriving_together_start_one_service(
+    isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch, readsb_document: Any
+) -> None:
+    """A double-clicked Finish button must not start two adapters.
+
+    Both requests observe "nothing running" unless the claim on
+    ``app.state.ingestion`` is made in the same synchronous block as the check
+    — assigning after ``start()`` leaves a window across the adapter's own
+    startup, and two adapters polling the same decoder into the same live
+    store is the kind of thing that is only ever noticed in production.
+
+    ``start()`` is given a suspension point deliberately. Today's readsb
+    adapter happens to reach its first ``await`` without yielding, which hides
+    the race rather than removing it; this pins the ordering that stays
+    correct when that stops being true.
+    """
+    point_decoder_at(monkeypatch, json_response(readsb_document))
+    app = create_app(isolated_data_dir)
+
+    built: list[IngestionService] = []
+
+    def counting_build(*args: Any, **kwargs: Any) -> IngestionService:
+        service = real_build(*args, **kwargs)
+        built.append(service)
+        return service
+
+    async def suspending_start(service: IngestionService) -> None:
+        await asyncio.sleep(0)
+        await real_start(service)
+
+    monkeypatch.setattr("flightsite.api.ingestion.build_ingestion_service", counting_build)
+    monkeypatch.setattr(IngestionService, "start", suspending_start)
+
+    async with app.router.lifespan_context(app):
+        assert app.state.ingestion is None
+        # End the first-run state the way the endpoint does, then run the
+        # apply step twice concurrently — which is what two overlapping
+        # requests reach.
+        store: ConfigStore = app.state.config_store
+        app.state.settings = store.apply_update(FIRST_RUN_SAVE)
+
+        await asyncio.gather(_apply_ingestion_start(app), _apply_ingestion_start(app))
+
+        assert len(built) == 1
+        assert app.state.ingestion is built[0]
 
 
 def test_a_failed_hot_start_still_saves_the_configuration(

--- a/backend/tests/ingest/test_hot_start.py
+++ b/backend/tests/ingest/test_hot_start.py
@@ -1,0 +1,317 @@
+"""Ingestion starting on the config save that ends the first-run state.
+
+The defect this pins (issue #122): a fresh install starts no ingestion — it
+has no configuration, so there is no receiver to poll — and *nothing ever
+started it afterwards*. ``app.state.ingestion`` stayed ``None`` for the life
+of the process, so a user who completed the setup wizard watched an empty map
+until they restarted the backend. ``docs/INSTALL.md`` documented the restart
+as a known limitation rather than a bug, which is exactly how a wart survives.
+
+What is pinned here is deliberately narrow: **nothing → running**, on the save
+that first configures the install. Changing the endpoint of an adapter that is
+*already* running stays restart-required, and
+:func:`test_a_second_save_constructs_no_second_service` is the test that keeps
+it that way — it is the difference between "start what is not running" and
+"reconfigure what is", and only the first is safe to do under a live map.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from flightsite.app import create_app
+from flightsite.ingest import Position
+from flightsite.ingest.service import READINESS_SUBSYSTEM, IngestionService
+from flightsite.live import LiveStore
+
+from .conftest import CountingClientFactory, ScriptedTransport, json_response
+
+#: The document a first-run setup wizard save sends: a receiver endpoint and a
+#: location, which between them are everything ingestion needs to start.
+FIRST_RUN_SAVE: dict[str, Any] = {
+    "location": {"latitude": 51.5, "longitude": -0.12, "site_name": "London"},
+    "receiver": {
+        "host": "decoder.test",
+        "port": 8080,
+        "path": "/data/aircraft.json",
+        "poll_interval_s": 0.05,
+    },
+}
+
+
+def point_decoder_at(
+    monkeypatch: pytest.MonkeyPatch, entry: httpx.Response | Exception
+) -> CountingClientFactory:
+    """Make every adapter client the app builds talk to a mock transport."""
+    factory = CountingClientFactory(ScriptedTransport([entry]))
+    monkeypatch.setattr(
+        "flightsite.ingest.readsb.build_client", lambda *_args, **_kwargs: factory()
+    )
+    return factory
+
+
+def wait_for_aircraft(live: LiveStore, *, timeout_s: float = 5.0) -> int:
+    """Block the test thread until the store fills, or the timeout expires.
+
+    ``TestClient`` runs the app on its own event loop in another thread, so a
+    blocking wait here is what lets the ingestion poll actually happen. This
+    waits on an *outcome* and never asserts how long anything took, so it
+    cannot flake into a false pass or a timing-dependent failure.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if len(live) > 0:
+            break
+        time.sleep(0.01)
+    return len(live)
+
+
+def emitted_events(output: str) -> list[dict[str, Any]]:
+    """Every structured log line the app printed, decoded.
+
+    Read from the process's own output rather than through ``caplog``, because
+    :func:`~flightsite.logging.configure_logging` runs inside ``create_app``
+    and would reconfigure structlog out from under a fixture that had already
+    redirected it. The JSON line is also what an operator actually sees.
+    """
+    events = []
+    for line in output.splitlines():
+        try:
+            events.append(json.loads(line))
+        except ValueError:
+            continue  # interleaved non-JSON output, e.g. a traceback
+    return events
+
+
+def test_a_first_run_save_starts_ingestion_and_aircraft_flow(
+    isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch, readsb_document: Any
+) -> None:
+    """The whole point of the slice: finish the wizard, see aircraft."""
+    point_decoder_at(monkeypatch, json_response(readsb_document))
+    app = create_app(isolated_data_dir)
+
+    with TestClient(app) as client:
+        assert app.state.ingestion is None
+
+        response = client.put("/api/internal/config", json=FIRST_RUN_SAVE)
+
+        assert response.status_code == 200
+        assert response.json()["first_run"] is False
+
+        service: IngestionService | None = app.state.ingestion
+        assert service is not None
+        assert service.running is True
+        assert wait_for_aircraft(app.state.live) > 0
+
+
+def test_the_hot_start_polls_the_endpoint_that_was_just_saved(
+    isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch, readsb_document: Any
+) -> None:
+    """Hot-start and the next boot must not be two ways to decide what to poll.
+
+    The endpoint comes from the settings the save installed, so a request
+    actually reaches the host the wizard collected — not the model default the
+    app booted with.
+    """
+    factory = point_decoder_at(monkeypatch, json_response(readsb_document))
+    app = create_app(isolated_data_dir)
+
+    with TestClient(app) as client:
+        client.put("/api/internal/config", json=FIRST_RUN_SAVE)
+        wait_for_aircraft(app.state.live)
+
+    transport = factory.handler
+    assert isinstance(transport, ScriptedTransport)
+    assert transport.requests, "the hot-started adapter never polled"
+    assert transport.requests[0].url.host == "decoder.test"
+    assert transport.requests[0].url.path == "/data/aircraft.json"
+
+
+def test_a_second_save_constructs_no_second_service(
+    isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch, readsb_document: Any
+) -> None:
+    """Endpoint *changes* stay restart-required, so a later save must leave the
+    running service — its adapter, its task, its readiness registration —
+    exactly where it is, not build a second one beside it."""
+    point_decoder_at(monkeypatch, json_response(readsb_document))
+    app = create_app(isolated_data_dir)
+
+    with TestClient(app) as client:
+        client.put("/api/internal/config", json=FIRST_RUN_SAVE)
+        started: IngestionService | None = app.state.ingestion
+
+        moved = {"receiver": {**FIRST_RUN_SAVE["receiver"], "host": "other.test"}}
+        response = client.put("/api/internal/config", json=moved)
+
+        assert response.status_code == 200
+        # Identity, not equality: a second service would be a second adapter
+        # polling in parallel with the first.
+        assert app.state.ingestion is started
+        assert app.state.settings.receiver.host == "other.test"
+
+
+def test_a_failed_hot_start_still_saves_the_configuration(
+    isolated_data_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The configuration is validated, written and live before ingestion is
+    touched, so a failure starting it can only turn a save that succeeded into
+    a 500 about it. Same rule as the alerts entry beside it."""
+    monkeypatch.setattr(
+        "flightsite.api.ingestion.build_ingestion_service",
+        _raising("decoder went up in smoke"),
+    )
+    app = create_app(isolated_data_dir)
+
+    with TestClient(app) as client:
+        response = client.put("/api/internal/config", json=FIRST_RUN_SAVE)
+
+        assert response.status_code == 200
+        assert response.json()["first_run"] is False
+        assert app.state.ingestion is None
+        # And the save that failed to start it is still on disk.
+        assert app.state.settings.receiver.host == "decoder.test"
+
+    captured = capsys.readouterr()
+    failures = [
+        event
+        for event in emitted_events(captured.out + captured.err)
+        if event.get("event") == "config_apply_failed"
+    ]
+    assert failures, "a swallowed failure must still be reported"
+    assert failures[0]["action"] == "start_ingestion"
+    assert failures[0]["error_type"] == "RuntimeError"
+    # The reason is reported without echoing the configuration that provoked it.
+    assert "decoder.test" not in json.dumps(failures[0])
+
+
+def test_ingestion_can_still_start_on_a_later_save_after_a_failure(
+    isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch, readsb_document: Any
+) -> None:
+    """A failed hot-start leaves ``app.state.ingestion`` unassigned rather than
+    poisoned, so the guard lets the next save try again."""
+    monkeypatch.setattr(
+        "flightsite.api.ingestion.build_ingestion_service", _raising("not this time")
+    )
+    app = create_app(isolated_data_dir)
+
+    with TestClient(app) as client:
+        client.put("/api/internal/config", json=FIRST_RUN_SAVE)
+        assert app.state.ingestion is None
+
+        monkeypatch.undo()
+        point_decoder_at(monkeypatch, json_response(readsb_document))
+        client.put("/api/internal/config", json=FIRST_RUN_SAVE)
+
+        service: IngestionService | None = app.state.ingestion
+        assert service is not None
+        assert service.running is True
+
+
+def test_ready_stays_ready_across_the_mid_life_registration(
+    isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch, readsb_document: Any
+) -> None:
+    """``IngestionService.start`` registers its readiness subsystem, and on this
+    path that happens after ``mark_startup_complete()``.
+
+    ``register`` seeds a subsystem *not*-ready, so the question is whether
+    ``/ready`` can be observed in the window between registering and marking
+    ready. It cannot: the two calls run in one synchronous block with no
+    ``await`` between them and the handler is a coroutine on the same loop.
+    This pins the outcome — a first-run install answers 200 before the save,
+    200 after it, and reports the new subsystem once it is there.
+    """
+    point_decoder_at(monkeypatch, json_response(readsb_document))
+    app = create_app(isolated_data_dir)
+
+    with TestClient(app) as client:
+        before = client.get("/api/v1/ready")
+        assert before.status_code == 200
+        assert before.json()["subsystems"] == {"database": True}
+
+        client.put("/api/internal/config", json=FIRST_RUN_SAVE)
+
+        after = client.get("/api/v1/ready")
+        assert after.status_code == 200
+        assert after.json()["ready"] is True
+        assert after.json()["subsystems"] == {"database": True, READINESS_SUBSYSTEM: True}
+
+
+def test_the_saved_location_anchors_the_live_store(
+    isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch, readsb_document: Any
+) -> None:
+    """Starting ingestion without this would fill the map with aircraft whose
+    distance and bearing are ``null``: the store is built with the location
+    that was effective at construction, and on a first run there is none."""
+    point_decoder_at(monkeypatch, json_response(readsb_document))
+    app = create_app(isolated_data_dir)
+
+    with TestClient(app) as client:
+        live: LiveStore = app.state.live
+        assert live.receiver_location is None
+
+        client.put("/api/internal/config", json=FIRST_RUN_SAVE)
+
+        assert live.receiver_location == Position(latitude=51.5, longitude=-0.12)
+
+
+def test_a_save_never_moves_a_location_the_store_already_has(
+    isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch, readsb_document: Any
+) -> None:
+    """Filling in a blank is not the same as changing a value.
+
+    Moving the anchor under a running store would leave every already-observed
+    aircraft carrying a distance measured from somewhere else until it is seen
+    again, which is why a location *change* is restart-required and says so on
+    its Settings badge. Only the first-run blank is filled here.
+    """
+    point_decoder_at(monkeypatch, json_response(readsb_document))
+    app = create_app(isolated_data_dir)
+
+    with TestClient(app) as client:
+        client.put("/api/internal/config", json=FIRST_RUN_SAVE)
+        live: LiveStore = app.state.live
+        assert live.receiver_location == Position(latitude=51.5, longitude=-0.12)
+
+        client.put(
+            "/api/internal/config",
+            json={"location": {"latitude": -33.86, "longitude": 151.2, "site_name": "Sydney"}},
+        )
+
+        assert live.receiver_location == Position(latitude=51.5, longitude=-0.12)
+        assert app.state.settings.location.latitude == -33.86
+
+
+def test_demo_mode_keeps_its_own_ingestion(
+    isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A config save must not swap simulated traffic for a real decoder poll
+    under a user who asked for demo mode (SPEC §76)."""
+    monkeypatch.setenv("FLIGHTSITE_DEMO", "1")
+    app = create_app(isolated_data_dir)
+
+    with TestClient(app) as client:
+        demo_service: IngestionService | None = app.state.ingestion
+        assert demo_service is not None
+
+        response = client.put("/api/internal/config", json=FIRST_RUN_SAVE)
+
+        assert response.status_code == 200
+        assert app.state.ingestion is demo_service
+
+
+def _raising(message: str) -> Any:
+    """A stand-in that fails the way a broken hot-start would."""
+
+    def fail(*_args: Any, **_kwargs: Any) -> IngestionService:
+        raise RuntimeError(message)
+
+    return fail

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -85,8 +85,8 @@ the Alerts page also apply immediately — the engine reloads them on every chan
 
 | Setting | Why |
 |---|---|
-| `receiver.*` | The decoder endpoint is read once when ingestion starts |
-| `location.*` | The receiver reference point is fixed when the live store is built |
+| `receiver.*` | The decoder endpoint is read once when ingestion starts (see the first-run exception below) |
+| `location.*` | The receiver reference point is fixed when the live store is built (see the first-run exception below) |
 | `sighting.*` | Lifecycle thresholds are captured by the live store and persistence worker |
 | `retention.high_res_metric_days` | Read when the metrics service is constructed |
 | `timezone` | Analytics and receiver-metric day bucketing bind the zone at construction |
@@ -95,9 +95,16 @@ the Alerts page also apply immediately — the engine reloads them on every chan
 | `alerts.enabled_templates` | Shipped templates are instantiated at startup |
 
 The Settings UI marks the Decoder and Receiver sections **"Applies on next
-restart"**. The other rows above are not currently badged in the UI
-([issue #122](https://github.com/stevenpickles/flightsite/issues/122)) — when in
-doubt, restart; it costs a few seconds and loses nothing.
+restart"**. The other rows above are not badged in the UI — when in doubt, restart; it
+costs a few seconds and loses nothing.
+
+**The first-run exception.** `receiver.*` and `location.*` are restart-required only
+once there is something running to disturb. On a fresh install nothing is polling yet,
+so the setup wizard's save starts ingestion in place and anchors the live store at the
+location it just wrote — finishing the wizard needs no restart. It is *changing* an
+endpoint or a location afterwards that waits: the running adapter owns its connection
+and its health history, and every already-observed aircraft carries a distance measured
+from the old reference point until it is seen again.
 
 ### Two behaviors that will surprise you
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -12,7 +12,7 @@ thirty seconds and between them account for most first-install failures.
 - [3. Install Docker](#3-install-docker)
 - [4. Create the data directory](#4-create-the-data-directory)
 - [5. Get FlightSite and start it](#5-get-flightsite-and-start-it)
-- [6. First-run setup](#6-first-run-setup-and-the-one-restart-you-need)
+- [6. First-run setup](#6-first-run-setup)
 - [7. Verify the install](#7-verify-the-install)
 - [8. Upgrading](#8-upgrading)
 - [9. Troubleshooting](#9-troubleshooting)
@@ -250,39 +250,25 @@ data in your real database (see `FLIGHTSITE_HOST_DATA_DIR` in
 
 ---
 
-## 6. First-run setup, and the one restart you need
+## 6. First-run setup
 
 On first load FlightSite redirects you to the setup wizard at `/setup`. It collects
 your site name and location, your decoder endpoint (with a live connection test),
 units and timezone, aircraft metadata, alert templates and notification preference.
 
-> ### After you finish the wizard, restart the backend once.
->
-> ```bash
-> docker compose restart flightsite-backend
-> ```
->
-> **Aircraft will not appear until you do.** This is expected in the current release,
-> not a fault in your setup.
+**Finishing the wizard is the whole of setup — no restart needed.** Saving starts the
+decoder connection in the running backend and anchors distance and bearing at the
+location you entered, so aircraft begin appearing on the Live Map within seconds. The
+alert templates you chose are created on the same save.
 
-**Why:** ingestion is started once, during backend startup, and only when a saved
-configuration already exists. On a genuinely fresh install there is no configuration
-at that moment, so the backend deliberately starts without a decoder connection
-(`backend/src/flightsite/app.py`, `_start_ingestion`). Saving the wizard writes your
-configuration to disk but does not start the ingestion loop in the already-running
-process. One restart picks it up, and it never applies again — subsequent restarts and
-reboots start ingestion normally.
+If the map stays empty, the decoder endpoint is the thing to check rather than the
+restart: the Health page (§7 below) reports the decoder connection state directly, and
+the wizard's connection test is available again from **Settings → Decoder**.
 
-The same applies to the alert templates you chose in the wizard: they are instantiated
-at startup, so they also arrive with that restart
-([issue #110](https://github.com/stevenpickles/flightsite/issues/110)).
-
-This is a known first-run wart
-([issue #122](https://github.com/stevenpickles/flightsite/issues/122)); the restart
-requirement goes away once a configuration save can start ingestion in place.
-
-Settings changed later behave the same way for decoder and receiver-location fields —
-the Settings UI marks those sections **"Applies on next restart"**. See
+Settings changed *later* are a different matter for two sections: the decoder endpoint
+and the receiver location are read when ingestion starts, so changing either one after
+setup does need a backend restart, and the Settings UI marks those sections **"Applies
+on next restart"**. See
 [CONFIGURATION.md](CONFIGURATION.md#which-settings-need-a-restart) for the full list
 of which settings apply live and which wait for a restart.
 
@@ -290,7 +276,7 @@ of which settings apply live and which wait for a restart.
 
 ## 7. Verify the install
 
-Give it a minute after the restart, then check, in order:
+Give it a minute after finishing the wizard, then check, in order:
 
 1. **The Live Map** at `http://<host-ip>:8090/` shows aircraft.
 2. **The Health page** at `http://<host-ip>:8090/health` — reachable from the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -136,6 +136,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 051 | Documentation & install polish | 042, 045, 046 | sonnet | low | Docs complete enough for a fresh install from documentation alone |
 | 054 | Live map motion correctness | 014, 039 | opus | medium | Anchor dead reckoning to the last position change so markers stop creeping forward then teleporting back (issue #119) |
 | 055 | Alert template instantiation fixes | 038, 041, 046 | opus | medium | Instantiate newly enabled alert templates on config save, and fix the wizard/catalogue template-key mismatch (issues #110, #111) |
+| 056 | First-run ingestion hot-start | 007, 019, 055 | opus | medium | Start decoder ingestion on the config save that ends the first-run state, so a fresh install needs no backend restart (issue #122) |
 
 ## Parallelization Guide
 

--- a/frontend/src/features/settings/components/SettingsSection.tsx
+++ b/frontend/src/features/settings/components/SettingsSection.tsx
@@ -6,8 +6,11 @@ export interface SettingsSectionProps {
   title: string;
   description: string;
   /** Shown when a change in this section only takes effect after the
-   * backend restarts (SPEC: ingestion reads the receiver endpoint and
-   * location once at process startup — see `flightsite.app`). */
+   * backend restarts — the decoder endpoint and receiver location, which a
+   * running ingestion loop and live store hold for their lifetime (see
+   * `flightsite.api.ingestion`). This is about *changing* a value: a fresh
+   * install's first save starts ingestion in place, which is why the setup
+   * wizard makes no such promise. */
   restartRequired?: boolean;
   children: ReactNode;
 }

--- a/frontend/src/features/settings/sections/DecoderSection.tsx
+++ b/frontend/src/features/settings/sections/DecoderSection.tsx
@@ -35,8 +35,11 @@ export interface DecoderSectionProps {
 }
 
 /** Decoder host/port/path/poll interval (SPEC §11), plus the same live
- * connection test the setup wizard offers. Restart required: the ingestion
- * loop reads the receiver endpoint once at process startup. */
+ * connection test the setup wizard offers. Restart required: an ingestion
+ * loop is already running by the time this section can be edited, and it
+ * holds the endpoint it started on. (The wizard's first save is the one case
+ * with no loop to disturb, and it starts one in place — so the wizard shows
+ * no such badge.) */
 export function DecoderSection({ config }: DecoderSectionProps) {
   const [baseline, setBaseline] = useState(() =>
     pickDecoder(draftFromConfig(config)),

--- a/frontend/src/features/settings/sections/ReceiverSection.tsx
+++ b/frontend/src/features/settings/sections/ReceiverSection.tsx
@@ -30,8 +30,11 @@ export interface ReceiverSectionProps {
 
 /** Site name, location, and antenna height (SPEC §13) — the same fields the
  * setup wizard's Location step collects, editable afterward here. Restart
- * required: bearing/distance/range-ring computation and the ingestion
- * endpoint are both anchored on the location effective at process startup. */
+ * required: bearing, distance and range rings are measured from the reference
+ * point the running live store holds, so moving it here would leave every
+ * already-observed aircraft carrying a distance from the old one until it was
+ * seen again. (Filling the blank on a fresh install has nothing to disturb,
+ * so the wizard's first save applies immediately.) */
 export function ReceiverSection({ config }: ReceiverSectionProps) {
   const [baseline, setBaseline] = useState(() =>
     pickReceiverLocation(draftFromConfig(config)),

--- a/frontend/src/features/settings/types.ts
+++ b/frontend/src/features/settings/types.ts
@@ -8,17 +8,23 @@ import type { NotificationConfig, UnitSystem } from "@/lib/api/config";
  * wizard does not manage (display, alert radius, map, retention) as well.
  */
 export interface SettingsDraft {
-  // Receiver location (SPEC §13). Restart-required: ingestion reads the
-  // receiver endpoint once at process startup (see `flightsite.app`), and
-  // downstream bearing/distance/range-ring computation is anchored on
-  // whatever location was effective at that time.
+  // Receiver location (SPEC §13). Restart-required to *change*: bearing,
+  // distance and range rings are computed against the reference point the
+  // running live store holds, so moving it would leave every aircraft
+  // already observed carrying a distance measured from somewhere else until
+  // it is next seen. Note this is about changing an established value — the
+  // setup wizard's first save fills the blank in place and needs no restart
+  // (`flightsite.api.internal._apply_receiver_location`).
   siteName: string;
   latitude: string;
   longitude: string;
   antennaHeightFt: string;
 
-  // Decoder endpoint (SPEC §11). Restart-required for the same reason as
-  // the receiver location above.
+  // Decoder endpoint (SPEC §11). Restart-required to *change* for the
+  // parallel reason: a running adapter owns its connection, its poll loop
+  // and its health history, all of which belong to the endpoint it started
+  // on. The first-run save, where there is no adapter yet, starts one in
+  // place (`flightsite.api.ingestion`).
   receiverHost: string;
   receiverPort: string;
   receiverPath: string;

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1346,6 +1346,43 @@ slices:
     risk_level: medium
     notes: "Unplanned fix slice for GitHub issues #110 and #111 (found by slice 046). Added by Fable outside the phase plan."
 
+  - id: "056"
+    title: "First-run ingestion hot-start"
+    phase: 8
+    branch: "056-ingestion-hot-start"
+    status: merged
+    depends_on: ["007", "019", "055"]
+    objective: "Make the setup wizard's save start decoder ingestion in the running process, so a fresh install shows aircraft without the one manual backend restart the first run has always needed."
+    scope:
+      - "shared start helper used by both the boot path and the config-apply seam, so hot-start and cold-start decide what to poll the same way"
+      - "`PUT /api/internal/config` starts ingestion when nothing is running, the install is no longer on its first run, and demo mode is off"
+      - "the saved receiver location is applied to the live store on the same save, so distance and bearing compute immediately"
+      - "a failed hot-start logs `config_apply_failed` and never fails a save that already wrote, matching the slice-055 entry beside it"
+      - "docs and Settings-copy rationale updated: the first-run restart is gone, endpoint changes on a running adapter still need one"
+    out_of_scope:
+      - "hot-*restart*: changing the endpoint of an already-running adapter stays restart-required, and the Settings badges stay"
+      - "the receiver-metrics `StatsJsonPoller`, which is also never built on a first run and has no setter (follow-up issue)"
+      - "ingestion teardown, adapter reconfiguration, or a general settings-application registry"
+    acceptance_criteria:
+      - "finishing the setup wizard on a fresh install starts ingestion and aircraft flow into the live set with no backend restart"
+      - "a second config save constructs no second ingestion service"
+      - "a hot-start that raises leaves the save successful and ingestion retryable on a later save"
+      - "`/api/v1/ready` never regresses when the ingestion subsystem registers after `mark_startup_complete()`"
+    required_tests:
+      - first-run save starts ingestion and aircraft reach the live store
+      - second-save idempotence test asserting no new service is constructed
+      - failing-hot-start isolation test asserting the save still succeeds
+      - readiness test across a mid-life subsystem registration
+      - receiver-location-applied-to-live-store test
+    expected_artifacts:
+      - backend/src/flightsite/api/ingestion.py
+      - backend/src/flightsite/api/internal.py
+      - backend/src/flightsite/app.py
+      - docs/INSTALL.md
+    preferred_agent: opus
+    risk_level: medium
+    notes: "Unplanned fix slice for GitHub issue #122, the first-run wart docs/INSTALL.md §6 documented as a known limitation. Added by Fable outside the phase plan."
+
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,
 # 027, 031, 033, 035, 037, 038, 052) are ADDITIONALLY serialized against each other


### PR DESCRIPTION
## Slice 056 — First-run ingestion hot-start

Fixes #122: on a fresh install, ingestion only started at boot with a saved config, so the wizard's save required a manual backend restart before aircraft appeared.

- New `api/ingestion.py` shared by boot and config-apply (takes the app like `api/context.py`; no import cycle): `decoder_endpoint` (relocated), `ingestion_startable` (nothing running ∧ not demo ∧ not first_run — the same fact the boot path tests), `start_decoder_ingestion`
- `_apply_live_settings` restructured into three independently-guarded entries (the 055 alerts entry's early-return would have silently skipped later entries): templates, receiver-location fill-blank-only (a running store's anchor never moves — that's why the settings badge stays), ingestion start — ordered location-then-ingestion so no aircraft lands in an unanchored store
- Hot-START only: endpoint changes on a running adapter remain restart-required (badges stay; docs reworded)
- **Race found & fixed**: concurrent saves could each build an adapter — `app.state.ingestion` is now claimed before `await start()` (check-and-claim atomic on the loop; failed start releases the slot). The regression test injects a real suspension point and was verified to fail against the old ordering.
- Readiness-order verified sound: register→mark_ready has no await between them and /ready is async on the same loop — the not-ready window is unobservable; documented + pinned by test
- Docs: README, INSTALL.md §6 (retitled), CONFIGURATION.md updated — the restart limitation is gone

Deferred (reported): StatsJsonPoller still never builds on first-run (no setter; separate work); CHANGELOG's known-limitation line waits for the release branch per the hard rule.

Tests: 10 new in tests/ingest/test_hot_start.py, all red-first. Verification: backend ruff/format/mypy clean, 4140 passed / 98.92% coverage; frontend lint/typecheck/1570 tests/format:check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)