### PR TITLE
docs(performance): record the provisional Raspberry Pi 4 baseline (slice 060)

### DIFF
--- a/backend/tests/perf/test_docs.py
+++ b/backend/tests/perf/test_docs.py
@@ -27,11 +27,25 @@ HARD_HEADING = "### 2.1 Hard gates"
 REFERENCE_HEADING = "### 2.2 Reference budgets"
 END_HEADING = "### 2.3"
 
+BASELINE_HEADING = "### 5.4 Recorded baselines"
+BASELINE_END_HEADING = "### 5.5"
+
 
 @pytest.fixture(scope="module")
 def document() -> str:
     assert DOC.exists(), f"{DOC} is missing; slice 049 publishes it"
     return DOC.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def baseline(document: str) -> str:
+    """§5.4 alone.
+
+    Scoped deliberately: §5.5's development-machine table and §7.6's storage
+    section carry their own figures and their own disclaimer, and a check on
+    the whole document would be satisfied — or defeated — by either of them.
+    """
+    return section(document, BASELINE_HEADING, BASELINE_END_HEADING)
 
 
 def section(document: str, start: str, end: str) -> str:
@@ -91,16 +105,42 @@ def test_the_envelope_the_document_states_is_the_one_the_harness_runs() -> None:
     assert "Raspberry Pi 4" in document
 
 
-def test_the_document_records_whether_a_pi_baseline_exists(document: str) -> None:
+def test_the_document_records_a_pi_baseline(baseline: str) -> None:
     """The second acceptance criterion of slice 049 is a recorded Pi 4 run.
 
-    Until one exists the document must say so plainly rather than leaving an
-    empty table a reader could mistake for a passing result. When a baseline is
-    added, this test is what reminds whoever adds it to remove the disclaimer.
+    Slice 060 recorded one, so this test has changed sides. It used to hold the
+    "no baseline yet" disclaimer in place until a real result replaced it; it
+    now holds the result in place, so that §5.4 cannot quietly revert to an
+    empty table a reader could mistake for a passing one.
     """
-    has_disclaimer = "No Raspberry Pi 4 baseline has been recorded yet" in document
-    has_result = "not yet run" not in document
-    assert has_disclaimer != has_result, (
-        "docs/PERFORMANCE.md §5.4 must either carry the 'no baseline yet' "
-        "disclaimer or a recorded result, not both and not neither"
+    assert "No Raspberry Pi 4 baseline has been recorded yet" not in baseline, (
+        "docs/PERFORMANCE.md §5.4 carries a recorded baseline; the 'no baseline "
+        "yet' disclaimer must not come back alongside it"
+    )
+    assert "not yet run" not in baseline, "docs/PERFORMANCE.md §5.4 must not be an empty table"
+
+
+@pytest.mark.parametrize("budget", BUDGETS, ids=lambda budget: budget.metric)
+def test_the_recorded_baseline_reports_every_budget(budget: Budget, baseline: str) -> None:
+    """§5.3 step 1: a baseline records *every* measured figure, not a selection.
+
+    A run that reports the comfortable rows and omits the rest is not a
+    baseline, and the omission is invisible unless something checks for it.
+    """
+    assert budget.metric in baseline, (
+        f"{budget.metric} is measured by the harness but absent from §5.4's recorded baseline"
+    )
+
+
+def test_a_recorded_overrun_cites_a_tracked_finding(baseline: str) -> None:
+    """§5.3 rule 3: a figure over budget is filed, never accommodated.
+
+    The recorded run's ``ingest_duty_cycle`` exceeds its budget. The rule says
+    that is a finding rather than grounds for widening anything, and a finding
+    nobody can follow up is indistinguishable from one nobody filed — so §5.4
+    has to name the issue tracking it.
+    """
+    assert "#132" in baseline, (
+        "docs/PERFORMANCE.md §5.4 records a figure over its budget but names no "
+        "tracked issue for it; §5.3 rule 3 requires the finding to be filed"
     )

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -18,9 +18,10 @@ comfortably below 1 GB.
 SPEC §85 does not ask for every metric to block a merge, and there is a good
 reason for that. Some limits are correctness-critical: cross one and the live
 picture becomes a backlog, or the process heads for the OOM killer. Others are
-questions of comfort whose real answer depends on hardware nobody has measured
-yet — and a budget calibrated on a developer laptop tells you nothing about an
-SD card on a Pi.
+questions of comfort whose real answer depends on the reference hardware — and
+a budget calibrated on a developer laptop tells you nothing about an SD card on
+a Pi. §5.4 now carries a first Pi 4 reading, taken on a contended machine; it
+informs the second kind of budget without yet being firm enough to fix one.
 
 So budgets come in two kinds, and every row of the table below is labelled.
 
@@ -33,7 +34,9 @@ So budgets come in two kinds, and every row of the table below is labelled.
 
 A reference budget is not a weaker budget. It is a budget that has not yet been
 calibrated against the hardware it is stated for, and reporting it as a hard
-gate on a developer machine would be dressing up a guess.
+gate on a developer machine would be dressing up a guess. A *contended* Pi 4 —
+which is what §5.4 records — does not lift that objection either; §5.4's
+closing note says why promotion waits for a clean re-run.
 
 ### CI headroom
 
@@ -80,6 +83,12 @@ responsive.*
 
 SPEC §85: *trend-track less critical metrics initially; convert to hard gates
 once real Pi 4 baselines exist.*
+
+A first Pi 4 baseline now exists (§5.4), so the per-row rationales below are no
+longer arguing from no data at all. None of these rows is promoted on it: that
+run was contended and its figures are upper bounds, so §5.3's promotion step is
+deferred to the clean re-run rather than applied to numbers that would set
+every threshold in the wrong place. §5.4 gives the argument in full.
 
 | Metric | SPEC §85 item | Budget (Pi 4) | Statistic | Why not yet a hard gate |
 |---|---|---|---|---|
@@ -297,16 +306,101 @@ table and the JSON off the Pi.
 
 ### 5.4 Recorded baselines
 
-> **No Raspberry Pi 4 baseline has been recorded yet.** The procedure above is
-> documented and the harness runs standalone, but the hardware was not
-> available to the slice that built it. Until a row appears here, every
-> reference budget in §2.2 remains a stated target rather than a calibrated
-> one, and none of them can be promoted to a hard gate. This is the outstanding
-> item for slice 049's second acceptance criterion.
+**2026-09-01** · FlightSite **v0.2.0** · Raspberry Pi 4 Model B Rev 1.5, 4 GB
+RAM (3794 MB), SD-card root (`/dev/root`, 59 GB), Raspberry Pi OS (armhf
+userland on an aarch64 kernel), Docker Compose · 500 aircraft, 600 ticks,
+4 WebSocket clients, ~10 min wall ·
+`flightsite-perf --realtime --ticks 600`
 
-| Date | Release | Hardware | Storage | Result |
-|---|---|---|---|---|
-| — | — | — | — | not yet run |
+> **This run was contended, contrary to §5.1 step 3.** It was taken on the
+> project owner's live production Pi with the production FlightSite backend
+> ingesting at 1 Hz, and with dump1090-fa, tar1090 and the FlightRadar24 and
+> ADS-B Exchange feeders all running on the same machine and the same SD card.
+> §5.1 allows a decoder feeding the Pi and nothing else; this had the decoder,
+> its web UI, two upload feeders, a second full copy of the product ingesting
+> live, and the harness — all competing for one SD card.
+>
+> The figures below are therefore recorded as the **provisional** Pi 4
+> baseline. They are a real Pi 4 under a real (in fact pessimistic) load, which
+> is worth far more than the empty table they replace, but they are not the
+> quiet-machine measurement §5.2 describes. **A clean re-run is pending**;
+> until it lands, read every figure here as an upper bound rather than as the
+> hardware's number.
+
+Budgets below are the Pi 4 budgets from §2 at face value. `CI_HEADROOM` does
+not apply: it exists so that a shared CI runner cannot fail a gate, and this
+*is* the reference hardware the budgets are stated for.
+
+| Metric | Gate | median | p95 | max | Gated statistic | Pi 4 budget | Result |
+|---|---|---|---|---|---|---|---|
+| `live_population` | hard | — | — | — | min 526 | ≥ 500 | pass |
+| `ingest_apply_ms` | hard | 55.8 | 81.2 | 664 | p95 81.2 | ≤ 100 | pass |
+| `ingest_duty_cycle` | hard | 0.213 | 0.99 | 5.29 | p95 0.99 | ≤ 0.5 | **over budget — issue #132** |
+| `live_sweep_ms` | hard | — | — | 9.59 | max 9.59 | ≤ 100 | pass |
+| `api_live_ms` | hard | 82.2 | 135 | 597 | p95 135 | ≤ 250 | pass |
+| `memory_rss_mib` | hard | 145 | — | 175 | max 175 | ≤ 1024 | pass |
+| `ws_fanout_ms` | reference | 54.3 | 68.1 | 764 | p95 68.1 | ≤ 100 | pass |
+| `db_write_cycle_ms` | reference | 80.1 | 678 | 5180 | p95 678 | ≤ 250 | over budget |
+| `db_read_ms` | reference | 15.5 | 26.2 | 365 | p95 26.2 | ≤ 500 | pass |
+| `analytics_query_ms` | reference | 31.8 | 48.2 | 78.7 | p95 48.2 | ≤ 500 | pass |
+| `startup_s` | reference | — | — | — | max 0.547 | ≤ 30 | pass |
+| `recovery_s` | reference | — | — | — | max 9.3 | ≤ 30 | pass |
+
+The WebSocket run distributed 3,560 frames with **0 resync reconnects**, which
+is slice 057's batching fix (§5.5's closing note) confirmed on real hardware
+rather than on the machine that wrote it. Recovery adopted **539 open
+sightings** in 9.3 s, the same open-sighting count as §5.5's development run
+and about four times its cost — the clearest single expression of what SD-card
+I/O does to this product. The JSON report is on that Pi at
+`/opt/flightsite/data/perf-baseline/report.json`; §5.2 asks for it to be copied
+off, and the clean re-run should archive it alongside this table.
+
+**Ten of the twelve figures pass, and the two that do not are the same
+finding.** `ingest_duty_cycle` is a hard gate and its p95 of 0.99 is twice its
+budget: at that figure the per-tick hot path is consuming a whole 1 Hz poll,
+with no margin left. Its driver is visible one row down — `db_write_cycle_ms`
+p95 678 ms against a 250 ms budget, with a maximum of 5.18 s. The duty cycle
+sums the harness's stages serially (§5.5 explains why, and why the product does
+not), so an SD card that occasionally takes five seconds to commit a flush
+carries the duty cycle straight up with it.
+
+Only the first of the two fails anything. `db_write_cycle_ms` is a reference
+budget, so by §1 it is reported rather than enforced, and it sits inside the
+in-suite bound of 1250 ms in any case; it is recorded here because it is the
+explanation for the row above it, not because a run went red.
+
+Per §5.3 rule 3 this is **a finding, not a reason to widen anything**: it is
+filed as **issue #132**, no budget in `backend/src/flightsite/perf/budgets.py`
+was touched, and `ingest_duty_cycle` remains a hard gate at 0.5. The issue
+records the three things that bear on it — the SQLite write spikes seen here,
+issue #114's track-row storage, and the owner's planned migration to a Pi 5
+with an SSD, which changes the storage substrate this measurement is dominated
+by. Whether the overrun survives an uncontended run on that hardware is exactly
+what the clean re-run answers.
+
+#### Promotion is deferred to the clean re-run
+
+§5.3 step 2 asks, for each reference budget now backed by a Pi 4 baseline,
+whether to promote it to a hard gate. The answer for all six is **not yet**,
+and the reason is the caveat at the top of this section rather than any
+reluctance about the figures themselves.
+
+A promotion sets a number that fails builds. Calibrating one on a contended run
+gets it wrong in one of two directions, and there is no third. Take the
+measurements at face value and every threshold inherits the contention:
+`db_write_cycle_ms` would be promoted at something near a second, which is not
+this product's write latency but its neighbours' share of an SD card, and the
+gate would then sit far too loose to catch the regression it exists for.
+Discount the contention instead and the discount is a guess — nothing here
+separates the harness's own cost from its neighbours'. Either way the result is
+§1's dressed-up guess, arrived at with more ceremony.
+
+So the reference budgets in §2.2 stay reference budgets. What this run does
+establish is that promotion is now a *near-term* decision with real evidence
+behind it rather than an open question: five of the six sit comfortably inside
+their budgets even under this load, and the sixth is the write-cycle row that
+#132 exists to explain. The clean re-run is the point at which §5.3 step 2 gets
+applied for real.
 
 ### 5.5 Development-machine baseline
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -140,6 +140,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 057 | Activity WebSocket batching | 012, 035, 049 | opus | medium | Batch a detector pass's activity events into one WebSocket frame so a fresh install's backlog stops evicting every client (issue #99) |
 | 058 | Quick wins bundle | 031, 042, 043, 050 | opus | low | Six small tracked fixes on one branch: max-range sort index, FAA User-Agent, VACUUM refusal surfaced, backup gzip 6, pagination noun, demo-mode "today" (issues #107, #112, #115, #116, #117, #121) |
 | 059 | OpenSky metadata source | 021, 022, 023, 042 | opus | medium | Opt-in, default-off OpenSky aircraft database as a fill-gaps-only source under an ambiguous license (ADR-0013) |
+| 060 | Raspberry Pi 4 performance baseline | 049, 050 | opus | low | Record the first Pi 4 baseline in docs/PERFORMANCE.md §5.4 and defer §5.3 promotion to the pending clean re-run (issues #101, #132) |
 
 ## Parallelization Guide
 

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1502,6 +1502,37 @@ slices:
     risk_level: medium
     notes: "Owner-approved opt-in source. Licensing is ambiguous rather than clean, so the posture matches the Mictronics row (fetch-on-demand only) and adds default-off on top; contact@opensky-network.org is recorded in ADR-0013 as the route to firmer ground. Added by Fable outside the phase plan."
 
+  - id: "060"
+    title: "Raspberry Pi 4 performance baseline"
+    phase: 8
+    branch: "060-pi-baseline"
+    status: merged
+    depends_on: ["049", "050"]
+    objective: "Record the first Raspberry Pi 4 baseline for the slice-049 budget table in docs/PERFORMANCE.md, and apply §5.3's promotion rule to what that run actually measured (GitHub issues #101, #132)."
+    scope:
+      - "docs/PERFORMANCE.md §5.4 records the 2026-09-01 Pi 4 Model B Rev 1.5 / 4 GB / SD-card run of `flightsite-perf --realtime --ticks 600` against release v0.2.0: date, hardware, storage, and every measured figure with its gated statistic and verdict"
+      - "the run's contention caveat is recorded in substance — the production backend and the dump1090-fa/tar1090/FR24/ADSBx feeders shared the machine and the SD card, contrary to §5.1 step 3 — so the row stands as the provisional baseline with a clean re-run pending"
+      - "§5.3 promotion is deferred with its reasoning stated: reference budgets are not promoted to hard gates on contended numbers, because a gate calibrated on them would be either too loose or simply wrong"
+      - "the ingest_duty_cycle p95 overrun is recorded as a finding (issue #132) per §5.3 rule 3, not as a widened budget"
+      - "the slice-049 test that held the §5.4 no-baseline disclaimer in place is flipped to pin that §5.4 now carries a recorded baseline"
+    out_of_scope:
+      - "any change to the budget values or gate kinds in backend/src/flightsite/perf/budgets.py (that is the clean re-run's decision)"
+      - "the §7.6 Pi 4 storage baseline, which has its own procedure (§7.8) and its own disclaimer"
+      - "fixing the duty-cycle overrun itself (issue #132, which interacts with #114 and the owner's planned Pi 5 + SSD migration)"
+      - "re-running the measurement on an idle Pi (the pending clean re-run)"
+    acceptance_criteria:
+      - "docs/PERFORMANCE.md §5.4 carries the recorded Pi 4 baseline with every figure, the contention caveat, and the clean-re-run note referencing #132"
+      - "the document states that §5.3 promotion is deferred to the clean re-run, and why"
+      - "tests/perf/test_docs.py fails if §5.4 loses its recorded baseline, rather than requiring the disclaimer"
+      - "no budget value or gate kind in perf/budgets.py changed"
+    required_tests: [the flipped §5.4 baseline-presence guard in tests/perf/test_docs.py]
+    expected_artifacts:
+      - docs/PERFORMANCE.md
+      - backend/tests/perf/test_docs.py
+    preferred_agent: opus
+    risk_level: low
+    notes: "Closes slice 049's second acceptance criterion (issue #101) with a provisional, honestly-caveated figure. Measurement was run by Fable on the owner's production Pi over SSH; the JSON report is at /opt/flightsite/data/perf-baseline/report.json on that machine. Added by Fable outside the phase plan."
+
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,
 # 027, 031, 033, 035, 037, 038, 052) are ADDITIONALLY serialized against each other


### PR DESCRIPTION
Slice 060 — closes the #101 qualification gap with the measured (contended-run) Pi 4 baseline.

- PERFORMANCE.md §5.4: disclaimer replaced with the measured 12-metric table from the owner's Pi 4 (run 2026-09-01), with the contention caveat (FlightSite live stack + feeders running; SD-card write spikes) and a footnote pointing at #132 for the failing ingest_duty_cycle metric. §5.3 budget promotion deferred until a clean run.
- backend/tests/perf/test_docs.py: the test pinning the §5.4 disclaimer now pins the baseline table instead.

Roadmap: slice 060 entry added, status merged (flipped in-slice per convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)