### PR TITLE
feat(map): backfill the selected aircraft's track from its open sighting (slice 061)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -140,6 +140,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 057 | Activity WebSocket batching | 012, 035, 049 | opus | medium | Batch a detector pass's activity events into one WebSocket frame so a fresh install's backlog stops evicting every client (issue #99) |
 | 058 | Quick wins bundle | 031, 042, 043, 050 | opus | low | Six small tracked fixes on one branch: max-range sort index, FAA User-Agent, VACUUM refusal surfaced, backup gzip 6, pagination noun, demo-mode "today" (issues #107, #112, #115, #116, #117, #121) |
 | 059 | OpenSky metadata source | 021, 022, 023, 042 | opus | medium | Opt-in, default-off OpenSky aircraft database as a fill-gaps-only source under an ambiguous license (ADR-0013) |
+| 061 | Selected aircraft track backfill | 014, 052 | opus | low | Backfill the selected aircraft's track from its open sighting so a click draws the whole current sighting, not just what arrives after it (issue #133) |
 
 ## Parallelization Guide
 

--- a/frontend/src/features/aircraft-detail/AircraftDetailPanel.tsx
+++ b/frontend/src/features/aircraft-detail/AircraftDetailPanel.tsx
@@ -68,7 +68,9 @@ export function AircraftDetailPanel() {
     state.selectedIcao ? state.departing[state.selectedIcao] : undefined,
   );
   const receiver = useLiveAircraftStore((state) => state.receiver);
-  const track = useLiveAircraftStore((state) => state.track);
+  // `trackLive`, not `track`: the mini stats report what has been watched
+  // arriving since selection, which the backfilled drawn track no longer is.
+  const trackLive = useLiveAircraftStore((state) => state.trackLive);
   const selectAircraft = useLiveAircraftStore((state) => state.selectAircraft);
 
   const isOpen = selectedIcao !== null;
@@ -304,7 +306,7 @@ export function AircraftDetailPanel() {
               </DetailSection>
 
               <div className="px-4 py-3">
-                <TrackStats track={track} />
+                <TrackStats points={trackLive} />
               </div>
             </>
           )}

--- a/frontend/src/features/aircraft-detail/components/TrackStats.test.tsx
+++ b/frontend/src/features/aircraft-detail/components/TrackStats.test.tsx
@@ -2,29 +2,23 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { TrackStats } from "@/features/aircraft-detail/components/TrackStats";
+import { useLiveAircraftStore } from "@/features/map/aircraft/store/useLiveAircraftStore";
+import { makeAircraft } from "@/test/liveAircraftFixtures";
 
 describe("TrackStats", () => {
   it("shows a quiet message when nothing has accumulated yet", () => {
-    render(<TrackStats track={null} />);
-    expect(screen.getByText(/No track accumulated yet/i)).toBeInTheDocument();
-  });
-
-  it("shows a quiet message for a track with zero points", () => {
-    render(<TrackStats track={{ icao: "aaaaaa", points: [] }} />);
+    render(<TrackStats points={[]} />);
     expect(screen.getByText(/No track accumulated yet/i)).toBeInTheDocument();
   });
 
   it("shows point count and duration for an accumulated track", () => {
     render(
       <TrackStats
-        track={{
-          icao: "aaaaaa",
-          points: [
-            { lat: 47, lon: -122, at: 0 },
-            { lat: 47.1, lon: -122, at: 3000 },
-            { lat: 47.2, lon: -122, at: 12000 },
-          ],
-        }}
+        points={[
+          { lat: 47, lon: -122, at: 0 },
+          { lat: 47.1, lon: -122, at: 3000 },
+          { lat: 47.2, lon: -122, at: 12000 },
+        ]}
       />,
     );
     expect(screen.getByText(/3 points/)).toBeInTheDocument();
@@ -32,11 +26,53 @@ describe("TrackStats", () => {
   });
 
   it("uses singular wording for exactly one point", () => {
-    render(
-      <TrackStats
-        track={{ icao: "aaaaaa", points: [{ lat: 47, lon: -122, at: 0 }] }}
-      />,
-    );
+    render(<TrackStats points={[{ lat: 47, lon: -122, at: 0 }]} />);
     expect(screen.getByText(/1 point\b/)).toBeInTheDocument();
+  });
+
+  it("times a backfilled track from the selection, not from the sighting", () => {
+    // The regression this pins: reading the duration off the *drawn* track
+    // made a click on a 20-minute-old flight report "20m since selection"
+    // immediately, and — because re-selecting no longer restarts the track —
+    // permanently. The store's `trackLive` is the only list the selection
+    // actually dates.
+    const T0 = 1_800_000_000_000;
+    const store = useLiveAircraftStore.getState();
+    store.reset();
+    store.applySnapshot(
+      {
+        aircraft: [
+          makeAircraft({ icao: "aaaaaa", position: { lat: 47.5, lon: -122 } }),
+        ],
+        receiver: null,
+      },
+      T0,
+    );
+    store.selectAircraft("aaaaaa", T0);
+    store.backfillTrack("aaaaaa", 91_001, [
+      { lat: 47.1, lon: -122, at: T0 - 1_200_000 },
+      { lat: 47.3, lon: -122, at: T0 - 600_000 },
+    ]);
+    store.applyDelta(
+      {
+        updated: [
+          makeAircraft({ icao: "aaaaaa", position: { lat: 47.6, lon: -122 } }),
+        ],
+        stale: [],
+        removed: [],
+      },
+      T0 + 5000,
+    );
+
+    // Twenty minutes of track is drawn, two positions of it were watched.
+    expect(useLiveAircraftStore.getState().track?.points).toHaveLength(4);
+    render(<TrackStats points={useLiveAircraftStore.getState().trackLive} />);
+
+    expect(
+      screen.getByText(/2 points · 5s since selection/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/20m/)).not.toBeInTheDocument();
+
+    useLiveAircraftStore.getState().reset();
   });
 });

--- a/frontend/src/features/aircraft-detail/components/TrackStats.tsx
+++ b/frontend/src/features/aircraft-detail/components/TrackStats.tsx
@@ -1,21 +1,30 @@
 /**
- * Current-track mini stats (scope item 7): point count and duration of the
- * track accumulated since selection, from `useLiveAircraftStore`'s
- * `track` (`features/map/aircraft/track.ts`). Deliberately subtle — this
- * is a by-product of the map's own accumulation, not a stored history
- * record (the real per-sighting track arrives with the 052 backfill seam
- * `track.ts` documents), so it reads as a small aside, not a headline stat.
+ * Current-track mini stats (scope item 7): how much track the client has
+ * watched arrive since the aircraft was selected. Deliberately subtle — a
+ * by-product of the map's own accumulation, not a stored history record, so it
+ * reads as a small aside rather than a headline stat.
+ *
+ * Fed from the store's `trackLive`, **not** from the drawn track's `points`.
+ * Since slice 061 those are different things: the drawn track is backfilled
+ * from the open sighting's checkpointed path, so its first point is where the
+ * sighting began — timestamped by the *receiver's* clock — and reading a
+ * duration off it made this line claim a 20-minute-old flight had been
+ * selected for 20 minutes, from the instant it was clicked. `trackLive` is the
+ * one list actually dated by the selection, so both numbers here come from it
+ * and the "since selection" clause governs the whole sentence. The drawn
+ * track's own extent is on the map, where it can be seen rather than counted.
  */
 
 import { formatDurationShort } from "@/features/aircraft-detail/lib/format";
-import type { SelectedTrack } from "@/features/map/aircraft/track";
+import type { TrackPoint } from "@/features/map/aircraft/track";
 
 export interface TrackStatsProps {
-  track: SelectedTrack | null;
+  /** Positions watched arriving since selection — `useLiveAircraftStore`'s
+   * `trackLive`. */
+  points: readonly TrackPoint[];
 }
 
-export function TrackStats({ track }: TrackStatsProps) {
-  const points = track?.points ?? [];
+export function TrackStats({ points }: TrackStatsProps) {
   if (points.length === 0) {
     return (
       <p className="text-xs text-muted-foreground">No track accumulated yet.</p>

--- a/frontend/src/features/map/aircraft/AircraftLayer.test.tsx
+++ b/frontend/src/features/map/aircraft/AircraftLayer.test.tsx
@@ -1,5 +1,6 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, render } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AircraftLayer } from "@/features/map/aircraft/AircraftLayer";
 import { AIRCRAFT_SOURCE_ID } from "@/features/map/aircraft/aircraftLayers";
@@ -19,6 +20,7 @@ import {
   MapLibreMockMap,
   resetMapLibreMock,
 } from "@/test/maplibreGlMock";
+import { installOverlaysApiMock } from "@/test/overlaysApiMock";
 
 /**
  * End-to-end through the real map wiring: `MapLibreMap` (which the mocked
@@ -34,16 +36,30 @@ import {
 beforeEach(() => {
   resetMapLibreMock();
   useLiveAircraftStore.getState().reset();
+  // `AircraftLayer` reads the selected aircraft's open sighting to backfill
+  // its track (slice 061); selecting one here must resolve against a stub
+  // rather than the network. The default answer is "no open sighting", so
+  // these label tests see exactly the track they build themselves.
+  installOverlaysApiMock();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 async function renderLoadedLayer(): Promise<MapLibreMockMap> {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   render(
-    <MapLibreMap
-      config={DEV_PLACEHOLDER_MAP_CONFIG}
-      basemap={getDefaultBasemap()}
-    >
-      <AircraftLayer />
-    </MapLibreMap>,
+    <QueryClientProvider client={queryClient}>
+      <MapLibreMap
+        config={DEV_PLACEHOLDER_MAP_CONFIG}
+        basemap={getDefaultBasemap()}
+      >
+        <AircraftLayer />
+      </MapLibreMap>
+    </QueryClientProvider>,
   );
   const map = getLastMockMap();
   await act(async () => {

--- a/frontend/src/features/map/aircraft/AircraftLayer.tsx
+++ b/frontend/src/features/map/aircraft/AircraftLayer.tsx
@@ -5,14 +5,21 @@
  * context and what positions the status chip over the canvas. It renders almost
  * nothing itself: the aircraft are drawn by MapLibre from sources these hooks
  * keep fed, and the only DOM is the connection chip.
+ *
+ * `useTrackBackfill` is the one hook here that reads the *history* API rather
+ * than the live socket, so it needs a `QueryClientProvider` above this
+ * component (every route already has one). It fetches only while an aircraft is
+ * selected, and only the selected aircraft's open sighting.
  */
 
 import { ConnectionStatusChip } from "@/features/map/aircraft/ConnectionStatusChip";
 import { useAircraftLayer } from "@/features/map/aircraft/useAircraftLayer";
 import { useLiveConnection } from "@/features/map/aircraft/useLiveConnection";
+import { useTrackBackfill } from "@/features/map/aircraft/useTrackBackfill";
 
 export function AircraftLayer() {
   useLiveConnection();
   useAircraftLayer();
+  useTrackBackfill();
   return <ConnectionStatusChip />;
 }

--- a/frontend/src/features/map/aircraft/store/useLiveAircraftStore.test.ts
+++ b/frontend/src/features/map/aircraft/store/useLiveAircraftStore.test.ts
@@ -262,6 +262,54 @@ describe("selection and track accumulation", () => {
     expect(store().track).toBeNull();
   });
 
+  it("preserves the track when the already-selected aircraft is selected again", () => {
+    // A second click on the same aircraft — or a panel row, jump link, or
+    // notification naming the one already selected — must not restart
+    // accumulation: it would throw away the backfilled history with nothing
+    // to rebuild it (issue #133).
+    store().selectAircraft("aaaaaa", T0);
+    store().applyDelta(
+      {
+        updated: [
+          makeAircraft({ icao: "aaaaaa", position: { lat: 47.1, lon: -122 } }),
+        ],
+        stale: [],
+        removed: [],
+      },
+      T0 + 1000,
+    );
+    const before = store().track;
+
+    store().selectAircraft("aaaaaa", T0 + 2000);
+
+    expect(store().selectedIcao).toBe("aaaaaa");
+    expect(store().track).toBe(before);
+    expect(store().track?.points).toHaveLength(2);
+  });
+
+  it("does not notify subscribers when the selection does not change", () => {
+    store().selectAircraft("aaaaaa", T0);
+    let notifications = 0;
+    const unsubscribe = useLiveAircraftStore.subscribe(() => {
+      notifications += 1;
+    });
+    store().selectAircraft("aaaaaa", T0 + 10);
+    unsubscribe();
+
+    expect(notifications).toBe(0);
+  });
+
+  it("does not notify subscribers when nothing was selected and null is passed", () => {
+    let notifications = 0;
+    const unsubscribe = useLiveAircraftStore.subscribe(() => {
+      notifications += 1;
+    });
+    store().selectAircraft(null, T0);
+    unsubscribe();
+
+    expect(notifications).toBe(0);
+  });
+
   it("keeps the track when the selected aircraft reports no position", () => {
     store().selectAircraft("aaaaaa", T0);
     store().applyDelta(
@@ -315,6 +363,9 @@ describe("backfillTrack", () => {
     );
   });
 
+  const SIGHTING = 91_001;
+  const NEXT_SIGHTING = 91_002;
+
   const history = [
     { lat: 47.1, lon: -122, at: T0 - 300_000 },
     { lat: 47.3, lon: -122, at: T0 - 150_000 },
@@ -322,17 +373,18 @@ describe("backfillTrack", () => {
 
   it("merges the sighting's history under the points seen since selection", () => {
     store().selectAircraft("aaaaaa", T0);
-    store().backfillTrack("aaaaaa", history);
+    store().backfillTrack("aaaaaa", SIGHTING, history);
 
     expect(store().track?.points).toEqual([
       ...history,
       { lat: 47.5, lon: -122, at: T0 },
     ]);
+    expect(store().trackBackfilledFrom).toBe(SIGHTING);
   });
 
   it("keeps extending the track live after a backfill", () => {
     store().selectAircraft("aaaaaa", T0);
-    store().backfillTrack("aaaaaa", history);
+    store().backfillTrack("aaaaaa", SIGHTING, history);
     store().applyDelta(
       {
         updated: [
@@ -352,12 +404,25 @@ describe("backfillTrack", () => {
     });
   });
 
+  it("keeps the backfilled history when the aircraft is clicked again", () => {
+    // The regression this pairs with: a re-click used to restart accumulation
+    // while the backfill's inputs stayed unchanged, so nothing re-fetched and
+    // the trail collapsed to a dot for the rest of the selection.
+    store().selectAircraft("aaaaaa", T0);
+    store().backfillTrack("aaaaaa", SIGHTING, history);
+    store().selectAircraft("aaaaaa", T0 + 5000);
+
+    expect(store().track?.points).toHaveLength(3);
+  });
+
   it("discards a response that arrives after the aircraft was deselected", () => {
     store().selectAircraft("aaaaaa", T0);
     store().selectAircraft(null, T0 + 10);
-    store().backfillTrack("aaaaaa", history);
+    store().backfillTrack("aaaaaa", SIGHTING, history);
 
     expect(store().track).toBeNull();
+    expect(store().trackLive).toEqual([]);
+    expect(store().trackBackfilledFrom).toBeNull();
   });
 
   it("discards a response for an aircraft the selection has moved on from", () => {
@@ -371,18 +436,16 @@ describe("backfillTrack", () => {
       T0,
     );
     store().selectAircraft("bbbbbb", T0);
-    store().backfillTrack("aaaaaa", history);
+    store().backfillTrack("aaaaaa", SIGHTING, history);
 
-    expect(store().track).toEqual({
-      icao: "bbbbbb",
-      points: [{ lat: 10, lon: 10, at: T0 }],
-    });
+    expect(store().track?.icao).toBe("bbbbbb");
+    expect(store().track?.points).toEqual([{ lat: 10, lon: 10, at: T0 }]);
   });
 
   it("leaves the track alone when the aircraft has no open sighting", () => {
     store().selectAircraft("aaaaaa", T0);
     const before = store().track;
-    store().backfillTrack("aaaaaa", []);
+    store().backfillTrack("aaaaaa", SIGHTING, []);
 
     expect(store().track).toBe(before);
   });
@@ -395,9 +458,11 @@ describe("backfillTrack", () => {
     const unsubscribe = useLiveAircraftStore.subscribe(() => {
       notifications += 1;
     });
-    store().backfillTrack("aaaaaa", [{ lat: 47.5, lon: -122, at: T0 }]);
-    store().backfillTrack("aaaaaa", []);
-    store().backfillTrack("bbbbbb", history);
+    store().backfillTrack("aaaaaa", SIGHTING, [
+      { lat: 47.5, lon: -122, at: T0 },
+    ]);
+    store().backfillTrack("aaaaaa", SIGHTING, []);
+    store().backfillTrack("bbbbbb", SIGHTING, history);
     unsubscribe();
 
     expect(notifications).toBe(0);
@@ -405,13 +470,88 @@ describe("backfillTrack", () => {
 
   it("re-backfills after a deselect and reselect", () => {
     store().selectAircraft("aaaaaa", T0);
-    store().backfillTrack("aaaaaa", history);
+    store().backfillTrack("aaaaaa", SIGHTING, history);
     store().selectAircraft(null, T0 + 10);
     store().selectAircraft("aaaaaa", T0 + 20);
     expect(store().track?.points).toHaveLength(1);
+    expect(store().trackBackfilledFrom).toBeNull();
 
-    store().backfillTrack("aaaaaa", history);
+    store().backfillTrack("aaaaaa", SIGHTING, history);
     expect(store().track?.points).toHaveLength(3);
+  });
+
+  it("stays idempotent when the same sighting is backfilled again", () => {
+    // The refetch `staleTime: 0` provokes returns the same open sighting with
+    // its path grown at the newest end — ground the live points already cover,
+    // so the drawn track must simply not move.
+    store().selectAircraft("aaaaaa", T0);
+    store().backfillTrack("aaaaaa", SIGHTING, history);
+    const afterFirst = store().track;
+
+    store().backfillTrack("aaaaaa", SIGHTING, [
+      ...history,
+      { lat: 47.45, lon: -122, at: T0 - 1000 },
+    ]);
+
+    expect(store().track).toBe(afterFirst);
+    expect(store().track?.points).toHaveLength(3);
+  });
+
+  it("replaces a closed sighting's path when the next sighting backfills", () => {
+    // Issue #136: sighting N closes and N+1 opens for the same aircraft while
+    // N's row is still in the query cache, so N's path is merged first. The
+    // correction has to *remove* N's points, which no additive merge can do —
+    // the rebuild runs against the live record instead.
+    store().selectAircraft("aaaaaa", T0);
+    store().backfillTrack("aaaaaa", SIGHTING, history);
+    store().applyDelta(
+      {
+        updated: [
+          makeAircraft({ icao: "aaaaaa", position: { lat: 47.6, lon: -122 } }),
+        ],
+        stale: [],
+        removed: [],
+      },
+      T0 + 1000,
+    );
+    expect(store().track?.points).toHaveLength(4);
+
+    const reopened = [{ lat: 48.9, lon: -122, at: T0 - 20_000 }];
+    store().backfillTrack("aaaaaa", NEXT_SIGHTING, reopened);
+
+    // The closed sighting's two points are gone, the new sighting's one point
+    // is drawn, and both live positions survived untouched.
+    expect(store().track?.points).toEqual([
+      { lat: 48.9, lon: -122, at: T0 - 20_000 },
+      { lat: 47.5, lon: -122, at: T0 },
+      { lat: 47.6, lon: -122, at: T0 + 1000 },
+    ]);
+    expect(store().trackBackfilledFrom).toBe(NEXT_SIGHTING);
+  });
+
+  it("keeps accumulating live positions after a sighting replacement", () => {
+    store().selectAircraft("aaaaaa", T0);
+    store().backfillTrack("aaaaaa", SIGHTING, history);
+    store().backfillTrack("aaaaaa", NEXT_SIGHTING, [
+      { lat: 48.9, lon: -122, at: T0 - 20_000 },
+    ]);
+    store().applyDelta(
+      {
+        updated: [
+          makeAircraft({ icao: "aaaaaa", position: { lat: 47.7, lon: -122 } }),
+        ],
+        stale: [],
+        removed: [],
+      },
+      T0 + 2000,
+    );
+
+    expect(store().track?.points).toHaveLength(3);
+    expect(store().track?.points.at(-1)).toEqual({
+      lat: 47.7,
+      lon: -122,
+      at: T0 + 2000,
+    });
   });
 
   it("caps the merged track at the retention limit", () => {
@@ -424,7 +564,7 @@ describe("backfillTrack", () => {
         at: T0 - (TRACK_MAX_POINTS + 100 - index) * 1000,
       }),
     );
-    store().backfillTrack("aaaaaa", long);
+    store().backfillTrack("aaaaaa", SIGHTING, long);
 
     expect(store().track?.points).toHaveLength(TRACK_MAX_POINTS);
     // The newest end is kept: the live-accumulated point is still last.
@@ -458,6 +598,8 @@ describe("reset", () => {
     expect(store().departing).toEqual({});
     expect(store().selectedIcao).toBeNull();
     expect(store().track).toBeNull();
+    expect(store().trackLive).toEqual([]);
+    expect(store().trackBackfilledFrom).toBeNull();
     expect(store().receiver).toBeNull();
     expect(store().connection).toBe("connecting");
   });

--- a/frontend/src/features/map/aircraft/store/useLiveAircraftStore.test.ts
+++ b/frontend/src/features/map/aircraft/store/useLiveAircraftStore.test.ts
@@ -302,6 +302,140 @@ describe("selection and track accumulation", () => {
   });
 });
 
+describe("backfillTrack", () => {
+  beforeEach(() => {
+    store().applySnapshot(
+      {
+        aircraft: [
+          makeAircraft({ icao: "aaaaaa", position: { lat: 47.5, lon: -122 } }),
+        ],
+        receiver: null,
+      },
+      T0,
+    );
+  });
+
+  const history = [
+    { lat: 47.1, lon: -122, at: T0 - 300_000 },
+    { lat: 47.3, lon: -122, at: T0 - 150_000 },
+  ];
+
+  it("merges the sighting's history under the points seen since selection", () => {
+    store().selectAircraft("aaaaaa", T0);
+    store().backfillTrack("aaaaaa", history);
+
+    expect(store().track?.points).toEqual([
+      ...history,
+      { lat: 47.5, lon: -122, at: T0 },
+    ]);
+  });
+
+  it("keeps extending the track live after a backfill", () => {
+    store().selectAircraft("aaaaaa", T0);
+    store().backfillTrack("aaaaaa", history);
+    store().applyDelta(
+      {
+        updated: [
+          makeAircraft({ icao: "aaaaaa", position: { lat: 47.6, lon: -122 } }),
+        ],
+        stale: [],
+        removed: [],
+      },
+      T0 + 1000,
+    );
+
+    expect(store().track?.points).toHaveLength(4);
+    expect(store().track?.points.at(-1)).toEqual({
+      lat: 47.6,
+      lon: -122,
+      at: T0 + 1000,
+    });
+  });
+
+  it("discards a response that arrives after the aircraft was deselected", () => {
+    store().selectAircraft("aaaaaa", T0);
+    store().selectAircraft(null, T0 + 10);
+    store().backfillTrack("aaaaaa", history);
+
+    expect(store().track).toBeNull();
+  });
+
+  it("discards a response for an aircraft the selection has moved on from", () => {
+    store().applySnapshot(
+      {
+        aircraft: [
+          makeAircraft({ icao: "bbbbbb", position: { lat: 10, lon: 10 } }),
+        ],
+        receiver: null,
+      },
+      T0,
+    );
+    store().selectAircraft("bbbbbb", T0);
+    store().backfillTrack("aaaaaa", history);
+
+    expect(store().track).toEqual({
+      icao: "bbbbbb",
+      points: [{ lat: 10, lon: 10, at: T0 }],
+    });
+  });
+
+  it("leaves the track alone when the aircraft has no open sighting", () => {
+    store().selectAircraft("aaaaaa", T0);
+    const before = store().track;
+    store().backfillTrack("aaaaaa", []);
+
+    expect(store().track).toBe(before);
+  });
+
+  it("does not notify subscribers when the backfill adds nothing", () => {
+    // The layer redraws on every store notification; a redundant backfill must
+    // not cost one.
+    store().selectAircraft("aaaaaa", T0);
+    let notifications = 0;
+    const unsubscribe = useLiveAircraftStore.subscribe(() => {
+      notifications += 1;
+    });
+    store().backfillTrack("aaaaaa", [{ lat: 47.5, lon: -122, at: T0 }]);
+    store().backfillTrack("aaaaaa", []);
+    store().backfillTrack("bbbbbb", history);
+    unsubscribe();
+
+    expect(notifications).toBe(0);
+  });
+
+  it("re-backfills after a deselect and reselect", () => {
+    store().selectAircraft("aaaaaa", T0);
+    store().backfillTrack("aaaaaa", history);
+    store().selectAircraft(null, T0 + 10);
+    store().selectAircraft("aaaaaa", T0 + 20);
+    expect(store().track?.points).toHaveLength(1);
+
+    store().backfillTrack("aaaaaa", history);
+    expect(store().track?.points).toHaveLength(3);
+  });
+
+  it("caps the merged track at the retention limit", () => {
+    store().selectAircraft("aaaaaa", T0);
+    const long = Array.from(
+      { length: TRACK_MAX_POINTS + 100 },
+      (_u, index) => ({
+        lat: 47 + index / 100_000,
+        lon: -122,
+        at: T0 - (TRACK_MAX_POINTS + 100 - index) * 1000,
+      }),
+    );
+    store().backfillTrack("aaaaaa", long);
+
+    expect(store().track?.points).toHaveLength(TRACK_MAX_POINTS);
+    // The newest end is kept: the live-accumulated point is still last.
+    expect(store().track?.points.at(-1)).toEqual({
+      lat: 47.5,
+      lon: -122,
+      at: T0,
+    });
+  });
+});
+
 describe("connection status", () => {
   it("starts connecting and follows the socket", () => {
     expect(store().connection).toBe("connecting");

--- a/frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
+++ b/frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
@@ -35,7 +35,10 @@
 import { create } from "zustand";
 
 import type { SelectedTrack, TrackPoint } from "@/features/map/aircraft/track";
-import { appendTrackPoint } from "@/features/map/aircraft/track";
+import {
+  appendTrackPoint,
+  mergeTrackPoints,
+} from "@/features/map/aircraft/track";
 import type { LiveAircraft, ReceiverInfo } from "@/lib/api/live";
 import type { ConnectionStatus } from "@/lib/ws/liveSocket";
 import type { DeltaData, SnapshotData } from "@/lib/ws/protocol";
@@ -71,7 +74,9 @@ export interface LiveAircraftState {
   departing: Record<string, DepartingRecord>;
   receiver: ReceiverInfo | null;
   selectedIcao: string | null;
-  /** Positions observed for the selected aircraft since it was selected. */
+  /** The selected aircraft's track: positions observed since it was selected,
+   * under the current sighting's history once `backfillTrack` has merged it
+   * in. */
   track: SelectedTrack | null;
   connection: ConnectionStatus;
 
@@ -81,6 +86,11 @@ export interface LiveAircraftState {
   /** Selects an aircraft (or clears the selection with `null`), restarting
    * track accumulation from the aircraft's current position. */
   selectAircraft: (icao: string | null, now?: number) => void;
+  /** Merges the selected aircraft's fetched history under the points watched
+   * since selection (issue #133). A no-op unless `icao` is still the aircraft
+   * the current track belongs to, which is what discards a response that
+   * arrives after the selection moved on. */
+  backfillTrack: (icao: string, points: readonly TrackPoint[]) => void;
   /** Returns the store to its initial state — used when the socket is torn
    * down so a remount never renders a picture from a dead connection. */
   reset: () => void;
@@ -88,7 +98,12 @@ export interface LiveAircraftState {
 
 function initialState(): Omit<
   LiveAircraftState,
-  "applySnapshot" | "applyDelta" | "setConnection" | "selectAircraft" | "reset"
+  | "applySnapshot"
+  | "applyDelta"
+  | "setConnection"
+  | "selectAircraft"
+  | "backfillTrack"
+  | "reset"
 > {
   return {
     aircraft: {},
@@ -252,6 +267,26 @@ export const useLiveAircraftStore = create<LiveAircraftState>((set) => ({
         selectedIcao: icao,
         track: extendTrack(null, icao, state.aircraft, now),
       };
+    });
+  },
+
+  backfillTrack: (icao, points) => {
+    set((state) => {
+      const track = state.track;
+      // The track is keyed by ICAO, so a response for an aircraft the
+      // selection has since moved away from finds nothing to merge into and is
+      // dropped. Reselecting the *same* aircraft restarts accumulation and
+      // does take the backfill again, which is what makes a reselect redraw
+      // the whole sighting rather than a single point.
+      if (points.length === 0 || !track || track.icao !== icao) {
+        return state;
+      }
+      const merged = mergeTrackPoints(points, track.points);
+      // Returning `state` itself, not an empty patch: an unchanged track must
+      // not notify the layer's subscription into a pointless redraw.
+      return merged === track.points
+        ? state
+        : { track: { icao, points: merged } };
     });
   },
 

--- a/frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
+++ b/frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
@@ -74,23 +74,47 @@ export interface LiveAircraftState {
   departing: Record<string, DepartingRecord>;
   receiver: ReceiverInfo | null;
   selectedIcao: string | null;
-  /** The selected aircraft's track: positions observed since it was selected,
-   * under the current sighting's history once `backfillTrack` has merged it
-   * in. */
+  /** The selected aircraft's track, as the renderer draws it: positions
+   * observed since it was selected, under the current sighting's history once
+   * `backfillTrack` has merged it in. */
   track: SelectedTrack | null;
+  /**
+   * The positions of {@link track} the client watched arrive, without any
+   * backfilled history — bookkeeping for the backfill, never drawn.
+   *
+   * It is the one part of the track the client knows first-hand, and so the
+   * only safe base to rebuild from. When a backfill names a different sighting
+   * than the one already merged (issue #136: sighting N closes and N+1 opens
+   * for the same aircraft inside the query cache's stale window), the history
+   * is rebuilt against this rather than piled on top of points that turned out
+   * to belong to a sighting that has since closed — no additive merge could
+   * ever un-draw those.
+   */
+  trackLive: TrackPoint[];
+  /** The sighting id `track.points` was backfilled from, `null` before any
+   * backfill has landed. Bookkeeping for the backfill, never drawn. */
+  trackBackfilledFrom: number | null;
   connection: ConnectionStatus;
 
   applySnapshot: (data: SnapshotData, now?: number) => void;
   applyDelta: (data: DeltaData, now?: number) => void;
   setConnection: (status: ConnectionStatus) => void;
   /** Selects an aircraft (or clears the selection with `null`), restarting
-   * track accumulation from the aircraft's current position. */
+   * track accumulation from the aircraft's current position. Selecting the
+   * aircraft that is *already* selected changes nothing at all — see the
+   * implementation for why that matters. */
   selectAircraft: (icao: string | null, now?: number) => void;
   /** Merges the selected aircraft's fetched history under the points watched
    * since selection (issue #133). A no-op unless `icao` is still the aircraft
    * the current track belongs to, which is what discards a response that
-   * arrives after the selection moved on. */
-  backfillTrack: (icao: string, points: readonly TrackPoint[]) => void;
+   * arrives after the selection moved on. `sightingId` says which sighting the
+   * path came from, so a backfill can *replace* the history of a sighting that
+   * has since closed rather than pile new points on top of it (issue #136). */
+  backfillTrack: (
+    icao: string,
+    sightingId: number,
+    points: readonly TrackPoint[],
+  ) => void;
   /** Returns the store to its initial state — used when the socket is torn
    * down so a remount never renders a picture from a dead connection. */
   reset: () => void;
@@ -111,7 +135,49 @@ function initialState(): Omit<
     receiver: null,
     selectedIcao: null,
     track: null,
+    trackLive: [],
+    trackBackfilledFrom: null,
     connection: "connecting",
+  };
+}
+
+/** The three fields that move together as the selected aircraft's track: what
+ * is drawn, what was watched arriving, and which sighting was merged in. */
+interface TrackState {
+  track: SelectedTrack | null;
+  trackLive: TrackPoint[];
+  trackBackfilledFrom: number | null;
+}
+
+const NO_TRACK: TrackState = {
+  track: null,
+  trackLive: [],
+  trackBackfilledFrom: null,
+};
+
+/** Just the three track fields of a wider state.
+ *
+ * {@link extendTrack} is spread into a patch alongside freshly rebuilt
+ * `aircraft` and `departing` maps, so it must never hand back an object
+ * carrying anything else: spreading the whole previous state would put the
+ * *old* picture back over the new one. */
+function trackStateOf(state: TrackState): TrackState {
+  return {
+    track: state.track,
+    trackLive: state.trackLive,
+    trackBackfilledFrom: state.trackBackfilledFrom,
+  };
+}
+
+/** A track just starting for `icao`, with the drawn points and the live record
+ * sharing one empty array — see {@link extendTrack} on why that identity is
+ * load-bearing. */
+function freshTrack(icao: string): TrackState {
+  const points: TrackPoint[] = [];
+  return {
+    track: { icao, points },
+    trackLive: points,
+    trackBackfilledFrom: null,
   };
 }
 
@@ -168,28 +234,54 @@ function pruneDeparting(
   return next;
 }
 
-/** The track after this frame: seeded on selection, extended while the selected
- * aircraft keeps reporting a position, and left alone when it does not. */
+/**
+ * The track after this frame: seeded on selection, extended while the selected
+ * aircraft keeps reporting a position, and left alone when it does not.
+ *
+ * A new position is appended to both lists under the same rules, so `points`
+ * always ends with everything `live` holds — the backfill only ever prepends
+ * history, and the retention cap drops the oldest, which is history first.
+ */
 function extendTrack(
-  track: SelectedTrack | null,
+  state: TrackState,
   selectedIcao: string | null,
   aircraft: Record<string, LiveAircraftRecord>,
   now: number,
-): SelectedTrack | null {
+): TrackState {
   if (selectedIcao === null) {
-    return null;
+    return NO_TRACK;
   }
-  const base: SelectedTrack =
-    track && track.icao === selectedIcao
-      ? track
-      : { icao: selectedIcao, points: [] };
+  const base: TrackState =
+    state.track && state.track.icao === selectedIcao
+      ? trackStateOf(state)
+      : freshTrack(selectedIcao);
   const position = aircraft[selectedIcao]?.aircraft.position;
   if (!position) {
     return base;
   }
   const point: TrackPoint = { lat: position.lat, lon: position.lon, at: now };
-  const points = appendTrackPoint(base.points, point);
-  return points === base.points ? base : { icao: selectedIcao, points };
+  const trackLive = appendTrackPoint(base.trackLive, point);
+  if (trackLive === base.trackLive) {
+    return base;
+  }
+  // Until a backfill has actually put history in front of them, the drawn
+  // points *are* the live record — the same array, not a copy of it. That
+  // identity is what lets `backfillTrack` recognise a backfill that changed
+  // nothing and stay silent. Once the two diverge they are maintained
+  // separately, and `points` still always ends with everything `trackLive`
+  // holds: a backfill only prepends, and the retention cap drops the oldest.
+  const drawn = base.track?.points;
+  return {
+    track: {
+      icao: selectedIcao,
+      points:
+        drawn === undefined || drawn === base.trackLive
+          ? trackLive
+          : appendTrackPoint(drawn, point),
+    },
+    trackLive,
+    trackBackfilledFrom: base.trackBackfilledFrom,
+  };
 }
 
 export const useLiveAircraftStore = create<LiveAircraftState>((set) => ({
@@ -209,7 +301,7 @@ export const useLiveAircraftStore = create<LiveAircraftState>((set) => ({
         aircraft,
         departing: pruneDeparting(state.departing, now),
         receiver: data.receiver ?? state.receiver,
-        track: extendTrack(state.track, state.selectedIcao, aircraft, now),
+        ...extendTrack(state, state.selectedIcao, aircraft, now),
       };
     });
   },
@@ -249,7 +341,7 @@ export const useLiveAircraftStore = create<LiveAircraftState>((set) => ({
       return {
         aircraft,
         departing,
-        track: extendTrack(state.track, state.selectedIcao, aircraft, now),
+        ...extendTrack(state, state.selectedIcao, aircraft, now),
       };
     });
   },
@@ -260,17 +352,27 @@ export const useLiveAircraftStore = create<LiveAircraftState>((set) => ({
 
   selectAircraft: (icao, now = Date.now()) => {
     set((state) => {
+      // Re-selecting what is already selected is not a selection: it is a
+      // second click on the same aircraft, a click arriving from a panel row
+      // for the aircraft the map already has selected, or a notification
+      // jumping to it. Restarting accumulation there would throw away the
+      // backfilled history (issue #133) and collapse the trail to a single
+      // point, with nothing to rebuild it — the backfill keys off a *change*
+      // of selection, and this is not one.
+      if (icao === state.selectedIcao) {
+        return state;
+      }
       if (icao === null) {
-        return { selectedIcao: null, track: null };
+        return { selectedIcao: null, ...NO_TRACK };
       }
       return {
         selectedIcao: icao,
-        track: extendTrack(null, icao, state.aircraft, now),
+        ...extendTrack(NO_TRACK, icao, state.aircraft, now),
       };
     });
   },
 
-  backfillTrack: (icao, points) => {
+  backfillTrack: (icao, sightingId, points) => {
     set((state) => {
       const track = state.track;
       // The track is keyed by ICAO, so a response for an aircraft the
@@ -281,12 +383,29 @@ export const useLiveAircraftStore = create<LiveAircraftState>((set) => ({
       if (points.length === 0 || !track || track.icao !== icao) {
         return state;
       }
-      const merged = mergeTrackPoints(points, track.points);
+      // Which base to merge onto is the whole of issue #136. For the sighting
+      // already merged, `points` is the same path grown at its newest end —
+      // ground `trackLive` already covers — so merging onto the drawn track is
+      // additive and settles to a no-op. For a *different* sighting the drawn
+      // track holds a path that has turned out to belong to a sighting that
+      // closed, and no additive merge can remove it: rebuild from `trackLive`,
+      // the only part the client watched first-hand, and the stale points are
+      // simply not carried over.
+      const sameSighting = state.trackBackfilledFrom === sightingId;
+      const base = sameSighting ? track.points : state.trackLive;
+      const merged = mergeTrackPoints(points, base);
       // Returning `state` itself, not an empty patch: an unchanged track must
-      // not notify the layer's subscription into a pointless redraw.
-      return merged === track.points
-        ? state
-        : { track: { icao, points: merged } };
+      // not notify the layer's subscription into a pointless redraw. The
+      // sighting id is deliberately not recorded in that case — nothing from
+      // this sighting is drawn, so there is nothing for a later response to
+      // treat as already merged.
+      if (merged === track.points) {
+        return state;
+      }
+      return {
+        track: { icao, points: merged },
+        trackBackfilledFrom: sightingId,
+      };
     });
   },
 

--- a/frontend/src/features/map/aircraft/track.test.ts
+++ b/frontend/src/features/map/aircraft/track.test.ts
@@ -99,28 +99,112 @@ describe("mergeTrackPoints", () => {
     expect(merged).toEqual([{ lat: 47.25, lon: -122, at: 9 }]);
   });
 
-  it("interleaves points that alternate between the two lists", () => {
+  it("never interleaves history into the region the live list covers", () => {
+    // The live list is authoritative from its first point onwards; a history
+    // point landing inside that window is a clock artefact, not a fix the
+    // aircraft reported between two watched ones.
     const merged = mergeTrackPoints(
       [point(47.0, -122, 1), point(47.2, -122, 3)],
       [point(47.1, -122, 2), point(47.3, -122, 4)],
     );
-    expect(at(merged)).toEqual([1, 2, 3, 4]);
+    expect(at(merged)).toEqual([1, 2, 4]);
   });
 
-  it("drops a history point that does not advance the clock", () => {
-    // Neither list is trusted to be perfectly sorted: a merge that honoured an
-    // out-of-order point would draw a polyline that doubles back on itself.
+  it("backfills nothing when the receiver clock runs ahead of the browser", () => {
+    // The fold: the receiver's clock is 5 minutes ahead, and the aircraft was
+    // airborne for only 2 minutes before the click, so every history point is
+    // stamped *after* the live ones. Merged naively the polyline would draw
+    // the current position, jump back to where the aircraft was two minutes
+    // ago, and re-trace forward. Clamping degrades to the pre-backfill
+    // picture instead of drawing a line no aircraft flew.
+    const skew = 300_000;
+    const selectedAt = 1_800_000_000_000;
+    const history = [
+      point(47.0, -122, selectedAt - 120_000 + skew),
+      point(47.2, -122, selectedAt - 60_000 + skew),
+      point(47.4, -122, selectedAt + skew),
+    ];
+    const live = [
+      point(47.5, -122, selectedAt),
+      point(47.51, -122, selectedAt + 1000),
+    ];
+
+    expect(mergeTrackPoints(history, live)).toBe(live);
+  });
+
+  it("keeps the history a modest skew leaves genuinely older", () => {
+    // The same skew against a sighting that has been open long enough to
+    // outrun it: the part of the history still older than the first live point
+    // is real and is drawn.
+    const skew = 60_000;
+    const selectedAt = 1_800_000_000_000;
+    const history = [
+      point(47.0, -122, selectedAt - 600_000 + skew),
+      point(47.2, -122, selectedAt - 300_000 + skew),
+      point(47.4, -122, selectedAt + skew),
+    ];
+    const live = [point(47.5, -122, selectedAt)];
+
+    expect(at(mergeTrackPoints(history, live))).toEqual([
+      selectedAt - 540_000,
+      selectedAt - 240_000,
+      selectedAt,
+    ]);
+  });
+
+  it("sorts an out-of-order history point into place", () => {
+    // Neither list is trusted to be perfectly sorted: honouring the given
+    // order would draw a polyline that doubles back on itself.
     const merged = mergeTrackPoints(
       [point(47.0, -122, 1), point(47.2, -122, 7), point(47.1, -122, 4)],
       [point(47.3, -122, 10)],
     );
-    expect(at(merged)).toEqual([1, 7, 10]);
+    expect(at(merged)).toEqual([1, 4, 7, 10]);
   });
 
-  it("drops an accumulated point that does not advance the clock", () => {
+  it("sorts an out-of-order accumulated point into place", () => {
     const merged = mergeTrackPoints(
       [point(47.0, -122, 1)],
       [point(47.3, -122, 10), point(47.2, -122, 6)],
+    );
+    expect(at(merged)).toEqual([1, 6, 10]);
+  });
+
+  it("loses no later points to a single out-of-order history point", () => {
+    // Issue #137: the strictly-increasing rule was an amplifier, not a reorder
+    // guard — one spike at t=100 discarded every point after it, turning one
+    // bad point into four lost ones.
+    const merged = mergeTrackPoints(
+      [
+        point(47.0, -122, 1),
+        point(48.0, -122, 100),
+        point(47.1, -122, 2),
+        point(47.2, -122, 3),
+        point(47.3, -122, 4),
+        point(47.4, -122, 5),
+      ],
+      [],
+    );
+    expect(at(merged)).toEqual([1, 2, 3, 4, 5, 100]);
+  });
+
+  it("keeps the out-of-order point itself, in its sorted position", () => {
+    const merged = mergeTrackPoints(
+      [point(47.0, -122, 1), point(47.9, -122, 9), point(47.1, -122, 3)],
+      [point(48.0, -122, 20)],
+    );
+    expect(merged).toEqual([
+      { lat: 47.0, lon: -122, at: 1 },
+      { lat: 47.1, lon: -122, at: 3 },
+      { lat: 47.9, lon: -122, at: 9 },
+      { lat: 48.0, lon: -122, at: 20 },
+    ]);
+  });
+
+  it("de-duplicates repeated timestamps inside one list", () => {
+    const merged = mergeTrackPoints(
+      [point(47.0, -122, 1), point(47.05, -122, 1)],
+      [point(47.3, -122, 10)],
     );
     expect(at(merged)).toEqual([1, 10]);
   });

--- a/frontend/src/features/map/aircraft/track.test.ts
+++ b/frontend/src/features/map/aircraft/track.test.ts
@@ -91,7 +91,11 @@ describe("mergeTrackPoints", () => {
   });
 
   it("keeps the live point on a timestamp collision", () => {
-    // The client watched that fix arrive; the checkpoint is a summary of it.
+    // The clamp is what settles this, not the merge's tie-break: a history
+    // point sharing `newer[0]`'s timestamp is at the boundary of the region
+    // the live list owns, so it is dropped before the two lists ever meet.
+    // The outcome is the intended one either way — the client watched that fix
+    // arrive, where the checkpoint only summarises it.
     const merged = mergeTrackPoints(
       [point(47.2, -122, 9)],
       [point(47.25, -122, 9)],

--- a/frontend/src/features/map/aircraft/track.test.ts
+++ b/frontend/src/features/map/aircraft/track.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { TrackPoint } from "@/features/map/aircraft/track";
 import {
   appendTrackPoint,
+  mergeTrackPoints,
   TRACK_MAX_POINTS,
 } from "@/features/map/aircraft/track";
 
@@ -47,5 +48,99 @@ describe("appendTrackPoint", () => {
     expect(points).toHaveLength(TRACK_MAX_POINTS);
     expect(points[0]?.at).toBe(10);
     expect(points.at(-1)?.at).toBe(TRACK_MAX_POINTS + 9);
+  });
+});
+
+describe("mergeTrackPoints", () => {
+  const at = (points: readonly TrackPoint[]) => points.map((entry) => entry.at);
+
+  it("prepends history to points accumulated since selection", () => {
+    // The issue #133 case: the click happened at t=10, so everything the
+    // client watched starts there and the sighting's earlier path is fetched.
+    const merged = mergeTrackPoints(
+      [point(47.0, -122, 1), point(47.1, -122, 5)],
+      [point(47.3, -122, 10), point(47.4, -122, 11)],
+    );
+    expect(at(merged)).toEqual([1, 5, 10, 11]);
+  });
+
+  it("returns the fetched history alone when nothing has accumulated yet", () => {
+    const merged = mergeTrackPoints([point(47, -122, 1)], []);
+    expect(at(merged)).toEqual([1]);
+  });
+
+  it("returns the accumulated points unchanged when there is no history", () => {
+    // Identity, not a copy: an empty backfill must not churn `setData`.
+    const points = [point(47, -122, 1)];
+    expect(mergeTrackPoints([], points)).toBe(points);
+  });
+
+  it("returns the accumulated points unchanged when history adds nothing", () => {
+    const points = [point(47, -122, 1), point(47.1, -122, 2)];
+    expect(mergeTrackPoints([point(47, -122, 1)], points)).toBe(points);
+  });
+
+  it("collapses the overlap the checkpoint lag produces", () => {
+    // The checkpointed path runs past the moment of selection, so its tail and
+    // the live-accumulated head describe the same stretch of flight.
+    const merged = mergeTrackPoints(
+      [point(47.0, -122, 1), point(47.1, -122, 5), point(47.2, -122, 9)],
+      [point(47.25, -122, 9), point(47.3, -122, 12)],
+    );
+    expect(at(merged)).toEqual([1, 5, 9, 12]);
+  });
+
+  it("keeps the live point on a timestamp collision", () => {
+    // The client watched that fix arrive; the checkpoint is a summary of it.
+    const merged = mergeTrackPoints(
+      [point(47.2, -122, 9)],
+      [point(47.25, -122, 9)],
+    );
+    expect(merged).toEqual([{ lat: 47.25, lon: -122, at: 9 }]);
+  });
+
+  it("interleaves points that alternate between the two lists", () => {
+    const merged = mergeTrackPoints(
+      [point(47.0, -122, 1), point(47.2, -122, 3)],
+      [point(47.1, -122, 2), point(47.3, -122, 4)],
+    );
+    expect(at(merged)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("drops a history point that does not advance the clock", () => {
+    // Neither list is trusted to be perfectly sorted: a merge that honoured an
+    // out-of-order point would draw a polyline that doubles back on itself.
+    const merged = mergeTrackPoints(
+      [point(47.0, -122, 1), point(47.2, -122, 7), point(47.1, -122, 4)],
+      [point(47.3, -122, 10)],
+    );
+    expect(at(merged)).toEqual([1, 7, 10]);
+  });
+
+  it("drops an accumulated point that does not advance the clock", () => {
+    const merged = mergeTrackPoints(
+      [point(47.0, -122, 1)],
+      [point(47.3, -122, 10), point(47.2, -122, 6)],
+    );
+    expect(at(merged)).toEqual([1, 10]);
+  });
+
+  it("caps the merged track, keeping the newest points", () => {
+    const history = Array.from({ length: TRACK_MAX_POINTS }, (_unused, i) =>
+      point(47 + i / 10000, -122, i + 1),
+    );
+    const live = Array.from({ length: 50 }, (_unused, i) =>
+      point(48 + i / 10000, -122, TRACK_MAX_POINTS + i + 1),
+    );
+
+    const merged = mergeTrackPoints(history, live);
+
+    expect(merged).toHaveLength(TRACK_MAX_POINTS);
+    expect(merged[0]?.at).toBe(51);
+    expect(merged.at(-1)?.at).toBe(TRACK_MAX_POINTS + 50);
+  });
+
+  it("returns an empty track when both lists are empty", () => {
+    expect(mergeTrackPoints([], [])).toEqual([]);
   });
 });

--- a/frontend/src/features/map/aircraft/track.ts
+++ b/frontend/src/features/map/aircraft/track.ts
@@ -7,14 +7,17 @@
  * the ones it has watched arrive. Accumulation therefore starts at the moment
  * of selection.
  *
- * **The backfill seam.** A history read API lands in slice 052; when it does,
- * the track for the open sighting can be fetched and *prepended* to whatever
- * has accumulated here. Everything this module needs for that is already true:
- * points are plain `{lat, lon, at}` with a UTC-millisecond timestamp, they are
- * kept in ascending `at` order, and `points` is a value the store swaps whole
- * rather than a structure the renderer mutates. A backfill is then a merge of
- * two sorted point lists into a new array, with no change to the renderer, the
- * layer, or the store's shape.
+ * **The backfill seam, now filled (slice 061, issue #133).** The history read
+ * API landed in slice 052, and {@link mergeTrackPoints} is the merge the seam
+ * was left open for: `features/map/aircraft/useTrackBackfill` resolves the
+ * selected aircraft's open sighting, maps its checkpointed `path` to
+ * {@link TrackPoint}s, and hands them to the store's `backfillTrack`, which
+ * merges them under the live-accumulated points. Every assumption the seam
+ * relied on held: points are still plain `{lat, lon, at}` with a
+ * UTC-millisecond timestamp, still kept in ascending `at` order, and `points`
+ * is still a value the store swaps whole rather than a structure the renderer
+ * mutates — so the backfill is a merge of two sorted lists into a new array,
+ * and the renderer, the layer, and the store's state shape are untouched.
  */
 
 /** One observed position of the selected aircraft. */
@@ -72,4 +75,78 @@ export function appendTrackPoint(
   return next.length > TRACK_MAX_POINTS
     ? next.slice(next.length - TRACK_MAX_POINTS)
     : next;
+}
+
+/**
+ * Merges a backfilled history track with the live-accumulated one.
+ *
+ * A straight two-pointer merge of two ascending-`at` lists, emitting only
+ * strictly increasing timestamps. That single rule covers all three things the
+ * backfill has to survive:
+ *
+ * * **Overlap.** The server's checkpoint lags the live picture, so the tail of
+ *   `older` and the head of `newer` describe the same stretch of flight. Equal
+ *   timestamps collapse to one point, and `newer` wins the tie — the client
+ *   watched that fix arrive, where the checkpoint is a periodic summary of it.
+ * * **Out-of-order input.** Neither list is trusted to be perfectly sorted (a
+ *   response is server data, not an invariant this module established), and a
+ *   naive merge of an unsorted list would draw a polyline that doubles back.
+ *   A point that does not advance the clock is dropped instead.
+ * * **Retention.** The merged result is capped at {@link TRACK_MAX_POINTS},
+ *   keeping the newest — the same rule {@link appendTrackPoint} applies, so a
+ *   long sighting's history yields to the part of the flight on screen now.
+ *
+ * The two lists date their points from *different clocks*: `older` carries the
+ * receiver's timestamps and `newer` the browser's (see the store's docstring on
+ * why the live picture is dated locally). A skew between them can only shift
+ * where the two lists interleave inside the short overlap window, and both
+ * describe the same trajectory there, so the drawn line is unaffected.
+ *
+ * Returns `newer` unchanged when the merge would add nothing, so a backfill
+ * that turns out to be redundant costs no allocation and no `setData` churn.
+ */
+export function mergeTrackPoints(
+  older: readonly TrackPoint[],
+  newer: readonly TrackPoint[],
+): TrackPoint[] {
+  const merged: TrackPoint[] = [];
+  let oldIndex = 0;
+  let newIndex = 0;
+  let keptFromOlder = 0;
+  let keptFromNewer = 0;
+
+  const push = (point: TrackPoint, fromNewer: boolean): void => {
+    const last = merged[merged.length - 1];
+    if (last !== undefined && point.at <= last.at) {
+      return;
+    }
+    merged.push(point);
+    if (fromNewer) {
+      keptFromNewer += 1;
+    } else {
+      keptFromOlder += 1;
+    }
+  };
+
+  while (oldIndex < older.length || newIndex < newer.length) {
+    const left = older[oldIndex];
+    const right = newer[newIndex];
+    // `<=`, not `<`: on a tie the live-accumulated point is the one kept.
+    if (right !== undefined && (left === undefined || right.at <= left.at)) {
+      push(right, true);
+      newIndex += 1;
+    } else if (left !== undefined) {
+      push(left, false);
+      oldIndex += 1;
+    } else {
+      break;
+    }
+  }
+
+  if (keptFromOlder === 0 && keptFromNewer === newer.length) {
+    return newer as TrackPoint[];
+  }
+  return merged.length > TRACK_MAX_POINTS
+    ? merged.slice(merged.length - TRACK_MAX_POINTS)
+    : merged;
 }

--- a/frontend/src/features/map/aircraft/track.ts
+++ b/frontend/src/features/map/aircraft/track.ts
@@ -108,12 +108,18 @@ function ascendingByAt(points: readonly TrackPoint[]): readonly TrackPoint[] {
  *
  * 1. **Sort both inputs defensively** (stable, by `at`).
  * 2. **Clamp `older`** to before `newer[0].at`, when `newer` has any points.
- * 3. **Merge** the two sorted lists, de-duplicating on `at` — a live point
- *    wins a tie, since the client watched that fix arrive where the checkpoint
- *    is only a summary of it.
+ * 3. **Merge** the two sorted lists, de-duplicating on `at`.
  * 4. **Cap** at {@link TRACK_MAX_POINTS}, keeping the newest — the same rule
  *    {@link appendTrackPoint} applies, so a long sighting's history yields to
  *    the part of the flight on screen now.
+ *
+ * The two halves of that de-duplication belong to different steps. *Across*
+ * the lists it is the clamp's job and already done by the time the merge runs:
+ * every surviving `older` point precedes `newer[0]`, so no cross-list
+ * collision reaches step 3 and its tie-break branch is unreachable — kept as a
+ * defensive expression of "the live point wins", not as live logic. What step
+ * 3 does de-duplicate is *within* a list: two points sharing an `at`, which
+ * neither input is trusted to be free of.
  *
  * Steps 1 and 2 each exist for a specific failure:
  *
@@ -155,8 +161,10 @@ export function mergeTrackPoints(
   let keptFromOlder = 0;
   let keptFromNewer = 0;
 
-  // The live list owns everything from its first point onwards. With no live
-  // points there is nothing to defer to, and the whole history is drawable.
+  // `newer` owns everything from its first point onwards, whatever it is: the
+  // live-accumulated list on a first backfill, the already-drawn track on the
+  // idempotent same-sighting path. With no points there to defer to, the whole
+  // history is drawable.
   const liveFrom = live[0]?.at ?? Number.POSITIVE_INFINITY;
 
   const push = (point: TrackPoint, fromNewer: boolean): void => {
@@ -175,12 +183,16 @@ export function mergeTrackPoints(
   while (oldIndex < history.length || newIndex < live.length) {
     const left = history[oldIndex];
     if (left !== undefined && left.at >= liveFrom) {
-      // Inside the region the live list owns — including, under a large enough
-      // skew, the entire history.
+      // Inside the region `newer` owns — including, under a large enough skew,
+      // the entire history.
       oldIndex += 1;
       continue;
     }
     const right = live[newIndex];
+    // The `<=` half of this test is unreachable: the clamp above has already
+    // dropped every `left` that could tie with a `right`. It stays as the
+    // defensive statement of which point would win — the live one, watched
+    // arriving, over a checkpoint that only summarises it.
     if (right !== undefined && (left === undefined || right.at <= left.at)) {
       push(right, true);
       newIndex += 1;

--- a/frontend/src/features/map/aircraft/track.ts
+++ b/frontend/src/features/map/aircraft/track.ts
@@ -17,7 +17,7 @@
  * UTC-millisecond timestamp, still kept in ascending `at` order, and `points`
  * is still a value the store swaps whole rather than a structure the renderer
  * mutates — so the backfill is a merge of two sorted lists into a new array,
- * and the renderer, the layer, and the store's state shape are untouched.
+ * and the renderer and the layer are untouched.
  */
 
 /** One observed position of the selected aircraft. */
@@ -29,7 +29,9 @@ export interface TrackPoint {
 }
 
 /** The accumulating track, tied to the ICAO it was accumulated for so a stale
- * track can never be drawn against a newly selected aircraft. */
+ * track can never be drawn against a newly selected aircraft. This is the
+ * whole of what the renderer needs; the bookkeeping a backfill requires lives
+ * beside it in the store, not in here. */
 export interface SelectedTrack {
   icao: string;
   points: TrackPoint[];
@@ -78,42 +80,84 @@ export function appendTrackPoint(
 }
 
 /**
+ * `points` in ascending `at` order, by identity when it already is.
+ *
+ * The scan is the point: an already-ordered list — which is every list either
+ * caller actually produces — is returned as-is, so the defensive sort costs one
+ * pass and no allocation, and the identity result is what lets
+ * {@link mergeTrackPoints} recognise an unchanged track.
+ *
+ * `Array.prototype.sort` is stable, so points sharing an `at` keep the order
+ * they were given in.
+ */
+function ascendingByAt(points: readonly TrackPoint[]): readonly TrackPoint[] {
+  for (let index = 1; index < points.length; index += 1) {
+    if (
+      (points[index] as TrackPoint).at < (points[index - 1] as TrackPoint).at
+    ) {
+      return [...points].sort((left, right) => left.at - right.at);
+    }
+  }
+  return points;
+}
+
+/**
  * Merges a backfilled history track with the live-accumulated one.
  *
- * A straight two-pointer merge of two ascending-`at` lists, emitting only
- * strictly increasing timestamps. That single rule covers all three things the
- * backfill has to survive:
+ * The pipeline, in order:
  *
- * * **Overlap.** The server's checkpoint lags the live picture, so the tail of
- *   `older` and the head of `newer` describe the same stretch of flight. Equal
- *   timestamps collapse to one point, and `newer` wins the tie — the client
- *   watched that fix arrive, where the checkpoint is a periodic summary of it.
- * * **Out-of-order input.** Neither list is trusted to be perfectly sorted (a
- *   response is server data, not an invariant this module established), and a
- *   naive merge of an unsorted list would draw a polyline that doubles back.
- *   A point that does not advance the clock is dropped instead.
- * * **Retention.** The merged result is capped at {@link TRACK_MAX_POINTS},
- *   keeping the newest — the same rule {@link appendTrackPoint} applies, so a
- *   long sighting's history yields to the part of the flight on screen now.
+ * 1. **Sort both inputs defensively** (stable, by `at`).
+ * 2. **Clamp `older`** to before `newer[0].at`, when `newer` has any points.
+ * 3. **Merge** the two sorted lists, de-duplicating on `at` — a live point
+ *    wins a tie, since the client watched that fix arrive where the checkpoint
+ *    is only a summary of it.
+ * 4. **Cap** at {@link TRACK_MAX_POINTS}, keeping the newest — the same rule
+ *    {@link appendTrackPoint} applies, so a long sighting's history yields to
+ *    the part of the flight on screen now.
  *
- * The two lists date their points from *different clocks*: `older` carries the
- * receiver's timestamps and `newer` the browser's (see the store's docstring on
- * why the live picture is dated locally). A skew between them can only shift
- * where the two lists interleave inside the short overlap window, and both
- * describe the same trajectory there, so the drawn line is unaffected.
+ * Steps 1 and 2 each exist for a specific failure:
  *
- * Returns `newer` unchanged when the merge would add nothing, so a backfill
- * that turns out to be redundant costs no allocation and no `setData` churn.
+ * * **Clock skew** (step 2), and not as a corner case. The two lists are dated
+ *   by *different clocks*: `older` carries the receiver's timestamps
+ *   (`path[].t`) and `newer` the browser's `Date.now()` (the store's docstring
+ *   explains why the live picture is dated locally). A receiver clock running
+ *   ahead of the browser by more than the sighting's pre-selection age lands
+ *   the *whole* history after the live points, and an unclamped merge then
+ *   draws the current position, folds back to where the aircraft was minutes
+ *   ago, and re-traces forward — tens of nautical miles of polyline that no
+ *   aircraft flew. Clamping degrades gracefully instead: a skew that large
+ *   backfills nothing, which is the pre-slice-061 picture rather than a wrong
+ *   one. The clamp also subsumes the checkpoint-lag overlap, where the tail of
+ *   `older` and the head of `newer` describe the same stretch of flight.
+ * * **Out-of-order input** (step 1). Neither list is trusted to be sorted: a
+ *   response is server data, not an invariant this module established. Sorting
+ *   keeps that distrust *local* to the offending point. Dropping any point
+ *   that failed to advance the clock — the previous rule, issue #137 — was not
+ *   a reorder guard at all but an amplifier: one spike at `t100` in
+ *   `[t1, t100, t2, t3, t4, t5]` silently swallowed the entire tail, turning a
+ *   single bad point into four lost ones. A sort lands the spike in its own
+ *   place and keeps everything else.
+ *
+ * Returns `newer` unchanged when the merge would add nothing to it and it was
+ * already ordered, so a backfill that turns out to be redundant costs no
+ * allocation and no `setData` churn.
  */
 export function mergeTrackPoints(
   older: readonly TrackPoint[],
   newer: readonly TrackPoint[],
 ): TrackPoint[] {
+  const history = ascendingByAt(older);
+  const live = ascendingByAt(newer);
+
   const merged: TrackPoint[] = [];
   let oldIndex = 0;
   let newIndex = 0;
   let keptFromOlder = 0;
   let keptFromNewer = 0;
+
+  // The live list owns everything from its first point onwards. With no live
+  // points there is nothing to defer to, and the whole history is drawable.
+  const liveFrom = live[0]?.at ?? Number.POSITIVE_INFINITY;
 
   const push = (point: TrackPoint, fromNewer: boolean): void => {
     const last = merged[merged.length - 1];
@@ -128,10 +172,15 @@ export function mergeTrackPoints(
     }
   };
 
-  while (oldIndex < older.length || newIndex < newer.length) {
-    const left = older[oldIndex];
-    const right = newer[newIndex];
-    // `<=`, not `<`: on a tie the live-accumulated point is the one kept.
+  while (oldIndex < history.length || newIndex < live.length) {
+    const left = history[oldIndex];
+    if (left !== undefined && left.at >= liveFrom) {
+      // Inside the region the live list owns — including, under a large enough
+      // skew, the entire history.
+      oldIndex += 1;
+      continue;
+    }
+    const right = live[newIndex];
     if (right !== undefined && (left === undefined || right.at <= left.at)) {
       push(right, true);
       newIndex += 1;
@@ -143,7 +192,9 @@ export function mergeTrackPoints(
     }
   }
 
-  if (keptFromOlder === 0 && keptFromNewer === newer.length) {
+  // `live === newer` matters: a `newer` that had to be sorted is not the array
+  // the caller passed in, so returning it would keep the disorder on screen.
+  if (live === newer && keptFromOlder === 0 && keptFromNewer === newer.length) {
     return newer as TrackPoint[];
   }
   return merged.length > TRACK_MAX_POINTS

--- a/frontend/src/features/map/aircraft/useTrackBackfill.test.tsx
+++ b/frontend/src/features/map/aircraft/useTrackBackfill.test.tsx
@@ -292,8 +292,9 @@ describe("useTrackBackfill", () => {
 
   it("does not retry a 404 from the sighting detail read", async () => {
     // The sighting closed and was reaped between the two reads: a real answer,
-    // and the same non-retryable one `useSightingDetailQuery` treats it as —
-    // which matters here because both share a cache key for this endpoint.
+    // and the same non-retryable one `useSightingDetailQuery` treats it as.
+    // The two hooks keep separate caches, but it is one endpoint, and two
+    // policies for retrying it would be two answers to the same question.
     const fetchMock = installApi({
       list: listOf([openRow()]),
       detail: () =>

--- a/frontend/src/features/map/aircraft/useTrackBackfill.test.tsx
+++ b/frontend/src/features/map/aircraft/useTrackBackfill.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -79,20 +80,43 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 interface ApiScript {
-  list?: SightingListResponse;
+  /** A fixed list body, or one that varies by how many times it has been
+   * asked — which is how the "sighting N closed, N+1 opened" case is scripted. */
+  list?: SightingListResponse | ((callCount: number) => SightingListResponse);
   /** Resolves to the detail body; a rejection stands in for a dead backend. */
   detail?: () => Promise<Response>;
+  /** `id -> SightingDetail`, when a test needs more than one sighting. */
+  detailById?: Record<number, SightingDetail>;
 }
 
 function installApi(script: ApiScript) {
+  let listCalls = 0;
   const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
     const raw = typeof input === "string" ? input : input.toString();
     const url = new URL(raw, "http://localhost");
     if (url.pathname === "/api/v1/sightings") {
-      return jsonResponse(script.list ?? listOf([]));
+      listCalls += 1;
+      const body =
+        typeof script.list === "function"
+          ? script.list(listCalls)
+          : (script.list ?? listOf([]));
+      return jsonResponse(body);
     }
-    if (/^\/api\/v1\/sightings\/\d+$/.test(url.pathname)) {
-      return script.detail ? await script.detail() : jsonResponse(openDetail());
+    const detailMatch = /^\/api\/v1\/sightings\/(\d+)$/.exec(url.pathname);
+    if (detailMatch) {
+      if (script.detail) {
+        return await script.detail();
+      }
+      if (script.detailById) {
+        const detail = script.detailById[Number(detailMatch[1])];
+        return detail
+          ? jsonResponse(detail)
+          : jsonResponse(
+              { error: { code: "not_found", message: "gone", detail: null } },
+              404,
+            );
+      }
+      return jsonResponse(openDetail());
     }
     throw new Error(`Unhandled fetch in test: ${raw}`);
   });
@@ -100,12 +124,21 @@ function installApi(script: ApiScript) {
   return fetchMock;
 }
 
-function mount() {
+/** Mounts the hook. `staleTime` defaults to the *app's* 30 seconds rather than
+ * the test wrapper's zero, so the freshness the backfill needs (issue #136)
+ * has to come from the hook's own options to show up here at all. */
+function mount(staleTime = 30_000) {
   return renderHook(
     () => {
       useTrackBackfill();
     },
-    { wrapper: createQueryWrapper() },
+    {
+      wrapper: createQueryWrapper(
+        new QueryClient({
+          defaultOptions: { queries: { retry: false, staleTime } },
+        }),
+      ),
+    },
   );
 }
 
@@ -257,6 +290,37 @@ describe("useTrackBackfill", () => {
     expect(points()).toHaveLength(1);
   });
 
+  it("does not retry a 404 from the sighting detail read", async () => {
+    // The sighting closed and was reaped between the two reads: a real answer,
+    // and the same non-retryable one `useSightingDetailQuery` treats it as —
+    // which matters here because both share a cache key for this endpoint.
+    const fetchMock = installApi({
+      list: listOf([openRow()]),
+      detail: () =>
+        Promise.resolve(
+          jsonResponse(
+            { error: { code: "not_found", message: "gone", detail: null } },
+            404,
+          ),
+        ),
+    });
+    mount();
+
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa", T0);
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+    // One list read plus exactly one detail attempt, and nothing backfilled.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(points()).toHaveLength(1);
+  });
+
   it("discards a response that lands after the aircraft was deselected", async () => {
     let release: (() => void) | undefined;
     const gate = new Promise<void>((resolve) => {
@@ -316,6 +380,87 @@ describe("useTrackBackfill", () => {
       icao: "bbbbbb",
       points: [{ lat: 10, lon: 10, at: T0 + 10 }],
     });
+  });
+
+  it("re-reads the open sighting rather than trusting the shared stale window", async () => {
+    // Issue #136: which sighting is *open* is exactly the fact a 30-second
+    // cache serves wrongly. The client here is configured with the app's own
+    // stale window, so a cached answer would show up as a missing refetch.
+    const fetchMock = installApi({ list: listOf([openRow()]) });
+    mount();
+
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa", T0);
+    });
+    await waitFor(() => {
+      expect(points()).toHaveLength(3);
+    });
+    const afterFirst = fetchMock.mock.calls.length;
+
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft(null, T0 + 10);
+    });
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa", T0 + 20);
+    });
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(afterFirst);
+    });
+  });
+
+  it("replaces a closed sighting's path when the reselect finds the next one", async () => {
+    // The full issue #136 sequence: sighting N is answered first, then N+1
+    // opens for the same aircraft. The refetch must both happen and *correct*
+    // what N drew, which no purely additive merge could.
+    const nextDetail = openDetail({
+      id: OPEN_SIGHTING_ID + 1,
+      path: [
+        {
+          t: new Date(T0 - 20_000).toISOString(),
+          lat: 48.9,
+          lon: -122,
+          altitude_ft: 30000,
+          source: "adsb",
+        },
+      ],
+    });
+    installApi({
+      list: (callCount) =>
+        listOf([
+          callCount === 1
+            ? openRow()
+            : openRow({ id: OPEN_SIGHTING_ID + 1, icao: "aaaaaa" }),
+        ]),
+      detailById: {
+        [OPEN_SIGHTING_ID]: openDetail(),
+        [OPEN_SIGHTING_ID + 1]: nextDetail,
+      },
+    });
+    mount();
+
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa", T0);
+    });
+    await waitFor(() => {
+      expect(points()).toHaveLength(3);
+    });
+
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft(null, T0 + 10);
+    });
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa", T0 + 20);
+    });
+
+    // Sighting N's two points are replaced by N+1's single one, over the live
+    // position the reselect seeded — not added to them.
+    await waitFor(() => {
+      expect(points()?.map((entry) => entry.lat)).toEqual([48.9, 47.5]);
+    });
+    expect(useLiveAircraftStore.getState().trackBackfilledFrom).toBe(
+      OPEN_SIGHTING_ID + 1,
+    );
   });
 
   it("re-backfills when the same aircraft is selected again", async () => {

--- a/frontend/src/features/map/aircraft/useTrackBackfill.test.tsx
+++ b/frontend/src/features/map/aircraft/useTrackBackfill.test.tsx
@@ -1,0 +1,343 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useLiveAircraftStore } from "@/features/map/aircraft/store/useLiveAircraftStore";
+import {
+  toTrackPoints,
+  useTrackBackfill,
+} from "@/features/map/aircraft/useTrackBackfill";
+import type {
+  SightingDetail,
+  SightingListResponse,
+  SightingRow,
+} from "@/lib/api/sightings";
+import { makeAircraft } from "@/test/liveAircraftFixtures";
+import { createQueryWrapper } from "@/test/queryWrapper";
+import { sightingDetail, sightingRow } from "@/test/sightingsApiMock";
+
+/**
+ * The backfill chain in isolation (issue #133): the two history reads, the
+ * ICAO guard that survives a selection race, and the failure modes that must
+ * leave the live picture exactly as it was.
+ *
+ * This file drives `fetch` directly rather than through
+ * `test/overlaysApiMock`, because one of the cases it has to pin — a response
+ * landing after the aircraft was deselected — only exists if the test controls
+ * *when* the response arrives.
+ */
+
+const T0 = 1_800_000_000_000;
+const OPEN_SIGHTING_ID = 91_001;
+
+function listOf(rows: SightingRow[]): SightingListResponse {
+  return { items: rows, total: null, limit: 1, offset: 0 };
+}
+
+function openRow(overrides: Partial<SightingRow> = {}): SightingRow {
+  return sightingRow({
+    id: OPEN_SIGHTING_ID,
+    icao: "aaaaaa",
+    ended_at: null,
+    duration_s: null,
+    closure_reason: null,
+    ...overrides,
+  });
+}
+
+function openDetail(overrides: Partial<SightingDetail> = {}): SightingDetail {
+  return sightingDetail({
+    id: OPEN_SIGHTING_ID,
+    icao: "aaaaaa",
+    ended_at: null,
+    duration_s: null,
+    closure_reason: null,
+    path: [
+      {
+        t: new Date(T0 - 300_000).toISOString(),
+        lat: 47.1,
+        lon: -122,
+        altitude_ft: 21000,
+        source: "adsb",
+      },
+      {
+        t: new Date(T0 - 150_000).toISOString(),
+        lat: 47.3,
+        lon: -122,
+        altitude_ft: 22000,
+        source: "adsb",
+      },
+    ],
+    ...overrides,
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+interface ApiScript {
+  list?: SightingListResponse;
+  /** Resolves to the detail body; a rejection stands in for a dead backend. */
+  detail?: () => Promise<Response>;
+}
+
+function installApi(script: ApiScript) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const raw = typeof input === "string" ? input : input.toString();
+    const url = new URL(raw, "http://localhost");
+    if (url.pathname === "/api/v1/sightings") {
+      return jsonResponse(script.list ?? listOf([]));
+    }
+    if (/^\/api\/v1\/sightings\/\d+$/.test(url.pathname)) {
+      return script.detail ? await script.detail() : jsonResponse(openDetail());
+    }
+    throw new Error(`Unhandled fetch in test: ${raw}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function mount() {
+  return renderHook(
+    () => {
+      useTrackBackfill();
+    },
+    { wrapper: createQueryWrapper() },
+  );
+}
+
+function points() {
+  return useLiveAircraftStore.getState().track?.points;
+}
+
+beforeEach(() => {
+  useLiveAircraftStore.getState().reset();
+  useLiveAircraftStore.getState().applySnapshot(
+    {
+      aircraft: [
+        makeAircraft({ icao: "aaaaaa", position: { lat: 47.5, lon: -122 } }),
+        makeAircraft({ icao: "bbbbbb", position: { lat: 10, lon: 10 } }),
+      ],
+      receiver: null,
+    },
+    T0,
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("toTrackPoints", () => {
+  it("maps ISO instants to UTC milliseconds", () => {
+    expect(
+      toTrackPoints([
+        {
+          t: "2026-08-30T22:02:10.000Z",
+          lat: 47.11,
+          lon: -121.8,
+          altitude_ft: 21000,
+          source: "adsb",
+        },
+      ]),
+    ).toEqual([{ lat: 47.11, lon: -121.8, at: 1_788_127_330_000 }]);
+  });
+
+  it("drops a point whose timestamp will not parse", () => {
+    // A NaN `at` compares false against every timestamp, so it would strand a
+    // point wherever the merge happened to place it.
+    expect(
+      toTrackPoints([
+        {
+          t: "not a date",
+          lat: 47,
+          lon: -122,
+          altitude_ft: null,
+          source: "adsb",
+        },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("useTrackBackfill", () => {
+  it("fetches nothing while no aircraft is selected", () => {
+    const fetchMock = installApi({});
+    mount();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("backfills the open sighting's path under the selected track", async () => {
+    installApi({ list: listOf([openRow()]) });
+    mount();
+
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa", T0);
+    });
+
+    await waitFor(() => {
+      expect(points()).toHaveLength(3);
+    });
+    expect(points()?.map((point) => point.lat)).toEqual([47.1, 47.3, 47.5]);
+  });
+
+  it("asks only for the selected aircraft's currently-open sighting", async () => {
+    const fetchMock = installApi({ list: listOf([openRow()]) });
+    mount();
+
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa", T0);
+    });
+    await waitFor(() => {
+      expect(points()).toHaveLength(3);
+    });
+
+    const listUrl = new URL(
+      String(fetchMock.mock.calls[0]?.[0]),
+      "http://localhost",
+    );
+    expect(listUrl.pathname).toBe("/api/v1/sightings");
+    expect(listUrl.searchParams.get("icao")).toBe("aaaaaa");
+    expect(listUrl.searchParams.get("open")).toBe("true");
+    expect(listUrl.searchParams.get("limit")).toBe("1");
+    expect(String(fetchMock.mock.calls[1]?.[0])).toBe(
+      `/api/v1/sightings/${OPEN_SIGHTING_ID}`,
+    );
+  });
+
+  it("leaves the track alone when the aircraft has no open sighting", async () => {
+    // An aircraft that has only just appeared has nothing checkpointed yet —
+    // the pre-slice behaviour, and not an error.
+    const fetchMock = installApi({ list: listOf([]) });
+    mount();
+
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa", T0);
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    expect(points()).toHaveLength(1);
+  });
+
+  it("ignores a closed sighting the lookup happens to return", async () => {
+    const fetchMock = installApi({
+      list: listOf([sightingRow({ id: OPEN_SIGHTING_ID, icao: "aaaaaa" })]),
+    });
+    mount();
+
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa", T0);
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    expect(points()).toHaveLength(1);
+  });
+
+  it("leaves the selection and the live track intact when the fetch fails", async () => {
+    installApi({
+      list: listOf([openRow()]),
+      detail: () => Promise.reject(new Error("network down")),
+    });
+    mount();
+
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa", T0);
+    });
+
+    await waitFor(() => {
+      expect(useLiveAircraftStore.getState().selectedIcao).toBe("aaaaaa");
+    });
+    expect(points()).toHaveLength(1);
+  });
+
+  it("discards a response that lands after the aircraft was deselected", async () => {
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    installApi({
+      list: listOf([openRow()]),
+      detail: async () => {
+        await gate;
+        return jsonResponse(openDetail());
+      },
+    });
+    mount();
+
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa", T0);
+    });
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft(null, T0 + 10);
+    });
+
+    await act(async () => {
+      release?.();
+      await gate;
+    });
+
+    expect(useLiveAircraftStore.getState().track).toBeNull();
+  });
+
+  it("discards a response for an aircraft the selection has moved on from", async () => {
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    installApi({
+      list: listOf([openRow()]),
+      detail: async () => {
+        await gate;
+        return jsonResponse(openDetail());
+      },
+    });
+    mount();
+
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa", T0);
+    });
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("bbbbbb", T0 + 10);
+    });
+
+    await act(async () => {
+      release?.();
+      await gate;
+    });
+
+    expect(useLiveAircraftStore.getState().track).toEqual({
+      icao: "bbbbbb",
+      points: [{ lat: 10, lon: 10, at: T0 + 10 }],
+    });
+  });
+
+  it("re-backfills when the same aircraft is selected again", async () => {
+    installApi({ list: listOf([openRow()]) });
+    mount();
+
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa", T0);
+    });
+    await waitFor(() => {
+      expect(points()).toHaveLength(3);
+    });
+
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft(null, T0 + 10);
+    });
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa", T0 + 20);
+    });
+
+    await waitFor(() => {
+      expect(points()).toHaveLength(3);
+    });
+  });
+});

--- a/frontend/src/features/map/aircraft/useTrackBackfill.ts
+++ b/frontend/src/features/map/aircraft/useTrackBackfill.ts
@@ -1,0 +1,125 @@
+/**
+ * Backfills the selected aircraft's track from its open sighting (issue #133).
+ *
+ * Slice 014 could only draw positions the client had watched arrive, so
+ * clicking an airborne aircraft showed nothing and then grew a trail from the
+ * click onwards — the aircraft's earlier path in the same sighting was never
+ * shown. Slice 052's history API supplies it, in two reads chained here:
+ *
+ * 1. `GET /api/v1/sightings?icao=<hex>&open=true&limit=1` — the aircraft's
+ *    currently-open sighting, if it has one.
+ * 2. `GET /api/v1/sightings/{id}` — that sighting's `path`, the timestamp-
+ *    ordered checkpointed track-so-far (`docs/API.md` §3.7).
+ *
+ * The result is merged *under* the live-accumulated points by the store's
+ * `backfillTrack`, never assigned over them: the checkpoint lags the live
+ * picture by design, so the two overlap and `mergeTrackPoints` is what
+ * reconciles them.
+ *
+ * Three things it must not do, and how each is handled:
+ *
+ * * **Break selection.** Every failure mode — no open sighting (the aircraft
+ *   just appeared and has no checkpoint yet), a 404, a dead backend — leaves
+ *   the query in an error or empty state and simply backfills nothing. The
+ *   selection, the panel and the live trail are unaffected; this is an
+ *   enhancement layered on a picture that already works without it.
+ * * **Draw one aircraft's history against another.** The response is applied
+ *   only for the ICAO it was requested for, and `backfillTrack` re-checks that
+ *   against the track it would merge into, so a response that lands after the
+ *   selection moved on is discarded at both ends.
+ * * **Re-render the map.** Only `selectedIcao` is subscribed to — a field that
+ *   changes on a click, not at the frame rate — so the ~1 Hz live picture still
+ *   never renders React through this hook.
+ *
+ * Deselecting clears the track, so a reselect backfills again; TanStack Query
+ * answers the repeat from cache rather than re-reading the backend.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+
+import { useLiveAircraftStore } from "@/features/map/aircraft/store/useLiveAircraftStore";
+import type { TrackPoint } from "@/features/map/aircraft/track";
+import type {
+  SightingListParams,
+  SightingPathPoint,
+} from "@/lib/api/sightings";
+import {
+  getSightingDetail,
+  getSightingList,
+  sightingsQueryKeys,
+} from "@/lib/api/sightings";
+
+/** The open-sighting lookup, as `GET /api/v1/sightings` wants it: the single
+ * newest currently-open sighting for one aircraft. */
+function openSightingParams(icao: string): SightingListParams {
+  return {
+    limit: 1,
+    offset: 0,
+    sort: "started_at",
+    order: "desc",
+    icao,
+    open: true,
+  };
+}
+
+/**
+ * The sighting path as track points.
+ *
+ * `t` is an ISO-8601 UTC instant from the receiver's clock; `TrackPoint.at` is
+ * UTC milliseconds. Anything that will not parse is dropped rather than
+ * poisoning the merge with `NaN`, which compares false against every timestamp
+ * and would leave a point stranded wherever the merge happened to place it.
+ */
+export function toTrackPoints(
+  path: readonly SightingPathPoint[],
+): TrackPoint[] {
+  const points: TrackPoint[] = [];
+  for (const point of path) {
+    const at = Date.parse(point.t);
+    if (!Number.isNaN(at)) {
+      points.push({ lat: point.lat, lon: point.lon, at });
+    }
+  }
+  return points;
+}
+
+export function useTrackBackfill(): void {
+  const selectedIcao = useLiveAircraftStore((state) => state.selectedIcao);
+
+  // Deliberately `useQuery` rather than `useSightingListQuery`: that hook keeps
+  // the previous page's rows on screen while the next loads, which for a
+  // per-selection lookup would mean briefly holding *another aircraft's*
+  // sighting. Here a pending lookup must read as pending.
+  const listQuery = useQuery({
+    queryKey: sightingsQueryKeys.list(openSightingParams(selectedIcao ?? "")),
+    queryFn: () => getSightingList(openSightingParams(selectedIcao as string)),
+    enabled: selectedIcao !== null,
+  });
+
+  // An open sighting reports `ended_at: null`; the ICAO is re-checked because
+  // the row is what the rest of this chain is keyed on.
+  const row = listQuery.data?.items[0];
+  const sightingId =
+    row && row.ended_at === null && row.icao === selectedIcao ? row.id : null;
+
+  const detailQuery = useQuery({
+    queryKey: sightingsQueryKeys.detail(sightingId ?? -1),
+    queryFn: () => getSightingDetail(sightingId as number),
+    enabled: sightingId !== null,
+  });
+
+  const detail = detailQuery.data;
+
+  useEffect(() => {
+    if (selectedIcao === null || detail === undefined) {
+      return;
+    }
+    if (detail.icao !== selectedIcao) {
+      return;
+    }
+    useLiveAircraftStore
+      .getState()
+      .backfillTrack(selectedIcao, toTrackPoints(detail.path));
+  }, [selectedIcao, detail]);
+}

--- a/frontend/src/features/map/aircraft/useTrackBackfill.ts
+++ b/frontend/src/features/map/aircraft/useTrackBackfill.ts
@@ -31,8 +31,16 @@
  *   changes on a click, not at the frame rate — so the ~1 Hz live picture still
  *   never renders React through this hook.
  *
- * Deselecting clears the track, so a reselect backfills again; TanStack Query
- * answers the repeat from cache rather than re-reading the backend.
+ * Deselecting clears the track, so a reselect backfills again.
+ *
+ * **Freshness (issue #136).** Both reads run at `staleTime: 0` under query keys
+ * of their own, rather than sharing the Sightings pages' 30-second cache. Which
+ * sighting is *open* is exactly the fact that cache would serve stale: sighting
+ * N closes, N+1 opens for the same aircraft, and a reselect inside the stale
+ * window would otherwise draw N's path. A cached answer is still rendered
+ * immediately while the refetch runs — and when the refetch names a different
+ * sighting, `backfillTrack` rebuilds rather than accumulates, so the stale path
+ * is removed rather than merely added to.
  */
 
 import { useQuery } from "@tanstack/react-query";
@@ -47,8 +55,23 @@ import type {
 import {
   getSightingDetail,
   getSightingList,
-  sightingsQueryKeys,
+  SightingsApiError,
 } from "@/lib/api/sightings";
+
+/**
+ * Cache keys of this hook's own.
+ *
+ * Deliberately *not* `sightingsQueryKeys`: these reads want no stale window,
+ * where the Sightings pages want the shared 30-second one. Two observers of one
+ * key with contradictory `staleTime`/`retry` is a race over whose options win,
+ * so the divergence is settled by keeping the caches separate.
+ */
+const trackBackfillQueryKeys = {
+  openSighting: (icao: string) =>
+    ["map", "track-backfill", "open-sighting", icao] as const,
+  path: (sightingId: number) =>
+    ["map", "track-backfill", "path", sightingId] as const,
+};
 
 /** The open-sighting lookup, as `GET /api/v1/sightings` wants it: the single
  * newest currently-open sighting for one aircraft. */
@@ -92,9 +115,10 @@ export function useTrackBackfill(): void {
   // per-selection lookup would mean briefly holding *another aircraft's*
   // sighting. Here a pending lookup must read as pending.
   const listQuery = useQuery({
-    queryKey: sightingsQueryKeys.list(openSightingParams(selectedIcao ?? "")),
+    queryKey: trackBackfillQueryKeys.openSighting(selectedIcao ?? ""),
     queryFn: () => getSightingList(openSightingParams(selectedIcao as string)),
     enabled: selectedIcao !== null,
+    staleTime: 0,
   });
 
   // An open sighting reports `ended_at: null`; the ICAO is re-checked because
@@ -104,9 +128,17 @@ export function useTrackBackfill(): void {
     row && row.ended_at === null && row.icao === selectedIcao ? row.id : null;
 
   const detailQuery = useQuery({
-    queryKey: sightingsQueryKeys.detail(sightingId ?? -1),
+    queryKey: trackBackfillQueryKeys.path(sightingId ?? -1),
     queryFn: () => getSightingDetail(sightingId as number),
     enabled: sightingId !== null,
+    staleTime: 0,
+    // The retry policy `useSightingDetailQuery` established for this endpoint:
+    // a 404 is a real answer ("that sighting closed and was reaped between the
+    // two reads"), not a transient failure worth hammering.
+    retry: (failureCount, error) =>
+      !(error instanceof SightingsApiError && error.status === 404) &&
+      failureCount < 2,
+    retryDelay: 100,
   });
 
   const detail = detailQuery.data;
@@ -115,11 +147,14 @@ export function useTrackBackfill(): void {
     if (selectedIcao === null || detail === undefined) {
       return;
     }
-    if (detail.icao !== selectedIcao) {
+    // Both identities are re-checked: the ICAO because a response must never
+    // reach another aircraft's track, and the id because `detail` is what says
+    // which sighting these points belong to.
+    if (detail.icao !== selectedIcao || detail.id !== sightingId) {
       return;
     }
     useLiveAircraftStore
       .getState()
-      .backfillTrack(selectedIcao, toTrackPoints(detail.path));
-  }, [selectedIcao, detail]);
+      .backfillTrack(selectedIcao, detail.id, toTrackPoints(detail.path));
+  }, [selectedIcao, sightingId, detail]);
 }

--- a/frontend/src/pages/LiveMapPage.test.tsx
+++ b/frontend/src/pages/LiveMapPage.test.tsx
@@ -263,9 +263,9 @@ describe("LiveMapPage", () => {
     expect(track.features[0]?.geometry.coordinates).toHaveLength(2);
   });
 
-  it("backfills the clicked aircraft's track from its open sighting", async () => {
-    // Issue #133: before slice 061 the trail started at the click, so an
-    // aircraft that had been airborne for an hour drew a single point.
+  /** Serves `aaaaaa` an open sighting whose checkpointed path runs from 46.5 to
+   * 46.8 — well before any live position this file feeds in. */
+  function installOpenSightingMock() {
     installOverlaysApiMock({
       sightings: {
         items: [
@@ -307,6 +307,12 @@ describe("LiveMapPage", () => {
         }),
       },
     });
+  }
+
+  it("backfills the clicked aircraft's track from its open sighting", async () => {
+    // Issue #133: before slice 061 the trail started at the click, so an
+    // aircraft that had been airborne for an hour drew a single point.
+    installOpenSightingMock();
 
     const map = await renderLoadedMap();
     await act(async () => {
@@ -330,6 +336,48 @@ describe("LiveMapPage", () => {
       features: { geometry: { coordinates: number[][] } }[];
     };
     // Oldest first, ending at the position the click selected.
+    expect(track.features[0]?.geometry.coordinates).toEqual([
+      [-122, 46.5],
+      [-122, 46.8],
+      [-122, 47],
+    ]);
+  });
+
+  it("keeps the backfilled trail when the same aircraft is clicked again", async () => {
+    // A second click (or the second half of a double-click) used to restart
+    // accumulation while leaving the backfill's inputs unchanged, so nothing
+    // re-fetched and the trail collapsed to a dot for the rest of the
+    // selection.
+    installOpenSightingMock();
+
+    const map = await renderLoadedMap();
+    await act(async () => {
+      getLastWebSocket().emitFrame(
+        snapshotFrame(1, [
+          makeAircraft({ icao: "aaaaaa", position: { lat: 47, lon: -122 } }),
+        ]),
+      );
+    });
+
+    map.renderedFeatures = [{ properties: { icao: "aaaaaa" } }];
+    await act(async () => {
+      map.emit("click", { point: { x: 10, y: 10 } });
+    });
+    await waitFor(() => {
+      expect(useLiveAircraftStore.getState().track?.points).toHaveLength(3);
+    });
+
+    await act(async () => {
+      map.emit("click", { point: { x: 11, y: 11 } });
+    });
+    await act(async () => {
+      map.emit("click", { point: { x: 12, y: 12 } });
+    });
+
+    expect(useLiveAircraftStore.getState().selectedIcao).toBe("aaaaaa");
+    const track = map.getSource(AIRCRAFT_TRACK_SOURCE_ID)?.data as {
+      features: { geometry: { coordinates: number[][] } }[];
+    };
     expect(track.features[0]?.geometry.coordinates).toEqual([
       [-122, 46.5],
       [-122, 46.8],

--- a/frontend/src/pages/LiveMapPage.test.tsx
+++ b/frontend/src/pages/LiveMapPage.test.tsx
@@ -41,6 +41,7 @@ import {
   EMPTY_FEATURE_COLLECTION,
   installOverlaysApiMock,
 } from "@/test/overlaysApiMock";
+import { sightingDetail, sightingRow } from "@/test/sightingsApiMock";
 import { getLastWebSocket, resetWebSocketMock } from "@/test/webSocketMock";
 
 // The `maplibre-gl` and `WebSocket` mocks are registered globally in
@@ -260,6 +261,80 @@ describe("LiveMapPage", () => {
       features: { geometry: { coordinates: number[][] } }[];
     };
     expect(track.features[0]?.geometry.coordinates).toHaveLength(2);
+  });
+
+  it("backfills the clicked aircraft's track from its open sighting", async () => {
+    // Issue #133: before slice 061 the trail started at the click, so an
+    // aircraft that had been airborne for an hour drew a single point.
+    installOverlaysApiMock({
+      sightings: {
+        items: [
+          sightingRow({
+            id: 91_001,
+            icao: "aaaaaa",
+            ended_at: null,
+            duration_s: null,
+            closure_reason: null,
+          }),
+        ],
+        total: null,
+        limit: 1,
+        offset: 0,
+      },
+      sightingDetail: {
+        91_001: sightingDetail({
+          id: 91_001,
+          icao: "aaaaaa",
+          ended_at: null,
+          duration_s: null,
+          closure_reason: null,
+          path: [
+            {
+              t: "2020-01-01T00:00:00.000Z",
+              lat: 46.5,
+              lon: -122,
+              altitude_ft: 20000,
+              source: "adsb",
+            },
+            {
+              t: "2020-01-01T00:05:00.000Z",
+              lat: 46.8,
+              lon: -122,
+              altitude_ft: 21000,
+              source: "adsb",
+            },
+          ],
+        }),
+      },
+    });
+
+    const map = await renderLoadedMap();
+    await act(async () => {
+      getLastWebSocket().emitFrame(
+        snapshotFrame(1, [
+          makeAircraft({ icao: "aaaaaa", position: { lat: 47, lon: -122 } }),
+        ]),
+      );
+    });
+
+    map.renderedFeatures = [{ properties: { icao: "aaaaaa" } }];
+    await act(async () => {
+      map.emit("click", { point: { x: 10, y: 10 } });
+    });
+
+    await waitFor(() => {
+      expect(useLiveAircraftStore.getState().track?.points).toHaveLength(3);
+    });
+
+    const track = map.getSource(AIRCRAFT_TRACK_SOURCE_ID)?.data as {
+      features: { geometry: { coordinates: number[][] } }[];
+    };
+    // Oldest first, ending at the position the click selected.
+    expect(track.features[0]?.geometry.coordinates).toEqual([
+      [-122, 46.5],
+      [-122, 46.8],
+      [-122, 47],
+    ]);
   });
 
   it("clears the selection when the click lands on empty map", async () => {

--- a/frontend/src/test/overlaysApiMock.ts
+++ b/frontend/src/test/overlaysApiMock.ts
@@ -1,6 +1,8 @@
 import type { FeatureCollection } from "geojson";
 import { vi } from "vitest";
 
+import type { SightingDetail, SightingListResponse } from "@/lib/api/sightings";
+
 /** An empty `FeatureCollection` — the default response for both endpoints,
  * matching what a stock backend answers (an empty `airports` table, or no
  * `airspace.geojson` supplied). */
@@ -23,13 +25,31 @@ export interface MockOverlaysApiOptions {
   airports?: FeatureCollection | ((url: URL) => FeatureCollection);
   /** Response `GET /api/v1/airspace` returns. */
   airspace?: FeatureCollection;
+  /** Response `GET /api/v1/sightings` returns — the selected aircraft's open
+   * sighting lookup (roadmap slice 061). Defaults to no sightings, which is
+   * the "aircraft just appeared, nothing checkpointed yet" case and the one
+   * every test that never selects an aircraft is in anyway. */
+  sightings?: SightingListResponse | ((url: URL) => SightingListResponse);
+  /** `id -> SightingDetail` for `GET /api/v1/sightings/{id}`; an id with no
+   * entry 404s. */
+  sightingDetail?: Record<number, SightingDetail>;
 }
 
+/** The `GET /api/v1/sightings` default: no open sighting for anything. */
+const EMPTY_SIGHTING_LIST: SightingListResponse = {
+  items: [],
+  total: null,
+  limit: 1,
+  offset: 0,
+};
+
 /** Installs a `global.fetch` stub serving `GET /api/v1/airports` and
- * `GET /api/v1/airspace` (roadmap slice 028) so map-overlay tests can
- * exercise the real `lib/api/overlays` client and TanStack Query hooks
- * without a running backend. Any other URL throws, surfacing an un-mocked
- * request as a test failure instead of a silent network error. */
+ * `GET /api/v1/airspace` (roadmap slice 028), plus the two sightings reads the
+ * Live Map itself makes when an aircraft is selected — `GET /api/v1/sightings`
+ * and `GET /api/v1/sightings/{id}`, which back the track backfill (roadmap
+ * slice 061) — so map tests can exercise the real API clients and TanStack
+ * Query hooks without a running backend. Any other URL throws, surfacing an
+ * un-mocked request as a test failure instead of a silent network error. */
 export function installOverlaysApiMock(options: MockOverlaysApiOptions = {}) {
   const fetchMock = vi.fn(
     async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -47,6 +67,34 @@ export function installOverlaysApiMock(options: MockOverlaysApiOptions = {}) {
 
       if (url.pathname === "/api/v1/airspace" && method === "GET") {
         return jsonResponse(options.airspace ?? EMPTY_FEATURE_COLLECTION);
+      }
+
+      if (url.pathname === "/api/v1/sightings" && method === "GET") {
+        const body =
+          typeof options.sightings === "function"
+            ? options.sightings(url)
+            : (options.sightings ?? EMPTY_SIGHTING_LIST);
+        return jsonResponse(body);
+      }
+
+      const sightingDetailMatch = /^\/api\/v1\/sightings\/(\d+)$/.exec(
+        url.pathname,
+      );
+      if (sightingDetailMatch && method === "GET") {
+        const detail = options.sightingDetail?.[Number(sightingDetailMatch[1])];
+        if (detail === undefined) {
+          return jsonResponse(
+            {
+              error: {
+                code: "not_found",
+                message: `No sighting with id ${sightingDetailMatch[1]}`,
+                detail: null,
+              },
+            },
+            404,
+          );
+        }
+        return jsonResponse(detail);
       }
 
       throw new Error(`Unhandled fetch in test: ${method} ${raw}`);

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1501,6 +1501,43 @@ slices:
     preferred_agent: opus
     risk_level: medium
     notes: "Owner-approved opt-in source. Licensing is ambiguous rather than clean, so the posture matches the Mictronics row (fetch-on-demand only) and adds default-off on top; contact@opensky-network.org is recorded in ADR-0013 as the route to firmer ground. Added by Fable outside the phase plan."
+  - id: "061"
+    title: "Selected aircraft track backfill"
+    phase: 8
+    branch: "061-track-backfill"
+    status: merged
+    depends_on: ["014", "052"]
+    objective: "Fill the backfill seam slice 014 left open: draw the selected aircraft's track back to the start of its current sighting on selection, instead of accumulating a trail only from the moment of the click."
+    scope:
+      - "`useTrackBackfill` chains the two slice-052 history reads on selection — `GET /api/v1/sightings?icao=<hex>&open=true&limit=1` for the open sighting, then `GET /api/v1/sightings/{id}` for its checkpointed `path` — through TanStack Query, mounted beside the other aircraft-layer hooks"
+      - "`mergeTrackPoints` merges the fetched history under the live-accumulated points: two ascending-`at` lists, strictly increasing timestamps only, live wins a tie, capped at `TRACK_MAX_POINTS` keeping the newest"
+      - "`backfillTrack` store action applies the merge only while the track still belongs to the ICAO the response was requested for, discarding a response that lands after the selection moved on, and returns the store unchanged when nothing was added so the layer does not redraw"
+      - "no open sighting, a closed row, a 404, or a dead backend backfills nothing and leaves selection, the detail panel and the live trail exactly as they were"
+      - "the `track.ts` seam docstring records what now fills it"
+    out_of_scope:
+      - "the renderer, the track layer, `SelectedTrack`'s shape, or the `TRACK_MAX_POINTS` retention rule (the slice-014 contract exists so this slice needs none of them)"
+      - "the slice-054 interpolation and position-anchor behaviour"
+      - "backend changes: slice 052's endpoints already serve everything this needs"
+      - "historical playback of closed sightings on the live map (a v1 non-goal; the sighting detail page owns closed-sighting paths)"
+    acceptance_criteria:
+      - "clicking an airborne aircraft immediately draws its track back to the start of the current sighting as checkpointed"
+      - "the trail keeps extending live after the backfill, and a deselect/reselect backfills again"
+      - "a response for an aircraft that is no longer selected never reaches the drawn track"
+      - "an aircraft with no open sighting, and a failing history read, both leave the pre-slice behaviour intact"
+    required_tests:
+      - merge unit tests (empty accumulation, checkpoint overlap, tie-breaking, out-of-order guards, retention cap, identity return)
+      - store tests for backfill application, the ICAO guard on deselect and reselect, and the no-notification path
+      - hook tests for the two chained reads, the no-open-sighting and closed-row paths, fetch failure, and a late response landing after deselect
+      - a Live Map page test asserting a click draws the backfilled track oldest-first
+    expected_artifacts:
+      - frontend/src/features/map/aircraft/useTrackBackfill.ts
+      - frontend/src/features/map/aircraft/track.ts
+      - frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
+      - frontend/src/features/map/aircraft/AircraftLayer.tsx
+      - frontend/src/test/overlaysApiMock.ts
+    preferred_agent: opus
+    risk_level: low
+    notes: "Unplanned fix slice for GitHub issue #133, the seam `frontend/src/features/map/aircraft/track.ts` has documented since slice 014. Frontend-only. Added by Fable outside the phase plan."
 
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,


### PR DESCRIPTION
Slice 061 — closes #133, closes #136, closes #137.

Clicking an aircraft now immediately draws its trail back to the start of the current sighting, filling the backfill seam track.ts documented since slice 014 with the history API slice 052 delivered.

- `mergeTrackPoints`: defensively sort both inputs → clamp history to before the live list's first point (kills the clock-skew fold; fixes the #137 tail-swallowing amplification) → merge/dedupe → cap keeping newest.
- `useTrackBackfill` hook: open-sighting lookup + detail read on selection, own query keys at `staleTime: 0` (#136), 404s not retried (matching the established sightings policy), late/cross-aircraft responses discarded.
- Store: `selectAircraft` is a no-op on re-select (review finding: a second click previously collapsed the trail to a dot permanently); backfills track their source sighting id, so a backfill from a different sighting rebuilds against live accumulation instead of union-ing onto stale points (#136).
- `TrackStats` reads the since-selection accumulation, not the drawn track, so "since selection" stays true after a backfill.

Reviewed by a dedicated adversarial pass (two rounds + verification): all findings fixed in-branch; deferred items were filed and then folded back in at the owner's direction.

31+ new frontend tests (1650 total green); lint/typecheck/format:check clean. Re-synced with dev after the slice 060 merge (roadmap union in numeric order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTAJUucu2ZPAD235B3GQeZ