### PR TITLE
fix(live): age aircraft by the decoder's seen report so ghosts expire on schedule (slice 062)

### DIFF
--- a/backend/src/flightsite/live/__init__.py
+++ b/backend/src/flightsite/live/__init__.py
@@ -30,6 +30,7 @@ from flightsite.live.aircraft import (
     appear,
     mark_stale,
     merge,
+    reported_silence_s,
 )
 from flightsite.live.events import (
     DEFAULT_QUEUE_SIZE,
@@ -83,4 +84,5 @@ __all__ = [
     "distance_nm",
     "mark_stale",
     "merge",
+    "reported_silence_s",
 ]

--- a/backend/src/flightsite/live/aircraft.py
+++ b/backend/src/flightsite/live/aircraft.py
@@ -35,6 +35,32 @@ fabricate, and it does not forget either). Three consequences worth naming:
   ``on_ground=True`` with no altitude). That update clears ``altitude_ft``
   rather than leaving a stale cruise level attached to a parked aircraft.
 
+Observation age
+---------------
+
+A poll is not an observation. Both supported decoders retain an aircraft in
+their output for minutes after they last heard it, re-listing the entry — with
+a growing reported age — on every poll, so "this entry was in the document we
+just fetched" says nothing about when the aircraft last transmitted. The
+decoder answers that itself: ``seen_s`` is how long ago it last heard anything
+from this aircraft, and ``seen_pos_s`` how long ago it last decoded a position.
+
+:func:`appear` and :func:`merge` therefore date every observation ``seen_s``
+seconds *before* the clock reading they are handed, rather than at it. Without
+that, a silent aircraft's clock restarted on every poll and it could never age
+past one polling interval while the decoder still listed it — the live set
+carried the decoder's whole retention window instead of what is actually
+audible, and the store's stale and removal sweeps fired minutes late (issue
+#134).
+
+This preserves the store's monotonic-only discipline (see
+:mod:`flightsite.live.store`): ``seen_s`` is a *relative* age reported by the
+decoder, not a wall-clock instant read from a machine whose clock may jump.
+Subtracting it from the injected monotonic reading yields a monotonic instant.
+
+The wall-clock companions agree by construction, because the ingest adapter
+already dates ``update.timestamp`` at ``reference minus seen_s``.
+
 Provenance
 ----------
 
@@ -48,7 +74,7 @@ a number came off the wire or out of a formula.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import StrEnum
 from types import MappingProxyType
 from typing import Final
@@ -266,6 +292,34 @@ def _range_to(
     return distance_and_bearing(receiver, position)
 
 
+def _observed_at(now: float, age_s: float | None) -> float:
+    """The monotonic instant an observation reported as ``age_s`` seconds old happened.
+
+    ``None`` means the source reports no age — a replayed fixture that never
+    captured one, or a future adapter for a decoder that does not offer it —
+    and the observation is then taken at face value. A negative age would date
+    it in the future, which no clock reading may be, so it clamps to ``now``.
+    """
+    if age_s is None or age_s <= 0.0:
+        return now
+    return now - age_s
+
+
+def _position_lag_s(update: AircraftStateUpdate) -> float:
+    """How much older this update's position is than the update itself.
+
+    Both decoders report ``seen_pos_s >= seen_s`` — a position cannot have been
+    decoded more recently than the last message carrying it — so this is the
+    non-negative gap between ``update.timestamp`` (already dated at
+    ``reference minus seen_s`` by the adapter) and the moment the position was
+    actually decoded. Zero whenever the decoder reports no separate position
+    age, which leaves the position dated with the update.
+    """
+    if update.seen_pos_s is None:
+        return 0.0
+    return max(update.seen_pos_s - (update.seen_s or 0.0), 0.0)
+
+
 def _track_point(update: AircraftStateUpdate, position: Position) -> TrackPoint:
     return TrackPoint(
         timestamp=update.timestamp,
@@ -285,7 +339,14 @@ def appear(
     receiver: Position | None = None,
     track_capacity: int = DEFAULT_TRACK_CAPACITY,
 ) -> LiveAircraft:
-    """Build the first live record for an aircraft from its first observation."""
+    """Build the first live record for an aircraft from its first observation.
+
+    The record starts :attr:`LiveState.LIVE` even when the decoder reports it
+    already long silent: an aircraft has to be in the live set before the sweep
+    can age it out, and the sweep — the sole authority on the stale and removal
+    thresholds — will do exactly that on its next pass, because the timing this
+    record carries is the decoder's, not the poll's.
+    """
     position = update.position
     ground_state, ground_provenance = _ground_state(
         on_ground=update.on_ground, altitude_ft=update.altitude_ft
@@ -296,17 +357,22 @@ def appear(
     if position is not None:
         track.append(_track_point(update, position))
 
+    observed_at = _observed_at(now, update.seen_s)
+    position_lag_s = _position_lag_s(update)
+
     return LiveAircraft(
         icao=update.icao,
         first_seen=update.timestamp,
         last_seen=update.timestamp,
-        first_seen_monotonic=now,
-        last_seen_monotonic=now,
+        first_seen_monotonic=observed_at,
+        last_seen_monotonic=observed_at,
         state=LiveState.LIVE,
         position=position,
         position_source=update.position_source,
-        position_seen=update.timestamp if position is not None else None,
-        position_seen_monotonic=now if position is not None else None,
+        position_seen=(
+            update.timestamp - timedelta(seconds=position_lag_s) if position is not None else None
+        ),
+        position_seen_monotonic=observed_at - position_lag_s if position is not None else None,
         callsign=update.callsign,
         callsign_seen=update.timestamp if update.callsign is not None else None,
         squawk=update.squawk,
@@ -335,12 +401,28 @@ def merge(
     update: AircraftStateUpdate,
     *,
     now: float,
+    stale_s: float,
     receiver: Position | None = None,
 ) -> tuple[LiveAircraft, frozenset[str]]:
     """Fold ``update`` into ``current``; return the new record and what changed.
 
     The returned record shares ``current``'s track object, to which this call
     has already appended the update's position if it carried a new one.
+
+    ``stale_s`` is the store's configured stale threshold, and merging is the
+    *only* place a record leaves :attr:`LiveState.STALE`: an aircraft heard
+    again is live again, and the transition rides out on the resulting
+    :class:`~flightsite.live.events.AircraftUpdated` as a changed ``state``.
+    The reverse transition stays with the sweep, which owns it along with the
+    :class:`~flightsite.live.events.AircraftStale` event that announces it, so
+    an update never silently re-states an aircraft's lifecycle.
+
+    What decides the revival is the *aged* observation, not the poll. A decoder
+    that re-lists an aircraft it has not heard for two minutes is not evidence
+    the aircraft is back, so such an update leaves the state alone; only an
+    observation younger than ``stale_s`` brings a stale record back to life.
+    The parameter is required rather than defaulted: a hard-coded 15 s would
+    quietly disagree with a store the owner configured differently.
     """
     has_position = update.position is not None
     position = update.position if has_position else current.position
@@ -360,15 +442,25 @@ def merge(
     if has_position and position is not None:
         current.track.append(_track_point(update, position))
 
+    observed_at = _observed_at(now, update.seen_s)
+    position_lag_s = _position_lag_s(update)
+    heard_recently = now - observed_at < stale_s
+
     merged = replace(
         current,
         last_seen=update.timestamp,
-        last_seen_monotonic=now,
-        state=LiveState.LIVE,
+        last_seen_monotonic=observed_at,
+        state=LiveState.LIVE if heard_recently else current.state,
         position=position,
         position_source=position_source,
-        position_seen=update.timestamp if has_position else current.position_seen,
-        position_seen_monotonic=now if has_position else current.position_seen_monotonic,
+        position_seen=(
+            update.timestamp - timedelta(seconds=position_lag_s)
+            if has_position
+            else current.position_seen
+        ),
+        position_seen_monotonic=(
+            observed_at - position_lag_s if has_position else current.position_seen_monotonic
+        ),
         callsign=update.callsign if update.callsign is not None else current.callsign,
         callsign_seen=update.timestamp if update.callsign is not None else current.callsign_seen,
         squawk=update.squawk if update.squawk is not None else current.squawk,

--- a/backend/src/flightsite/live/aircraft.py
+++ b/backend/src/flightsite/live/aircraft.py
@@ -58,8 +58,14 @@ This preserves the store's monotonic-only discipline (see
 decoder, not a wall-clock instant read from a machine whose clock may jump.
 Subtracting it from the injected monotonic reading yields a monotonic instant.
 
-The wall-clock companions agree by construction, because the ingest adapter
-already dates ``update.timestamp`` at ``reference minus seen_s``.
+The wall-clock companions are aged the same way and by the same amount: the
+ingest adapter already dates ``update.timestamp`` at ``reference minus
+seen_s``. The two are not derived from the same instant, though —
+``update.timestamp`` counts back from the fetch, ``observed_at`` from a clock
+read after parsing — so expect a small, consistent sub-second offset between a
+record's wall-clock and monotonic views of the same observation. Nothing in
+this codebase compares them across that boundary, and no threshold here is
+fine-grained enough to care.
 
 Provenance
 ----------
@@ -292,17 +298,23 @@ def _range_to(
     return distance_and_bearing(receiver, position)
 
 
-def _observed_at(now: float, age_s: float | None) -> float:
-    """The monotonic instant an observation reported as ``age_s`` seconds old happened.
+def reported_silence_s(update: AircraftStateUpdate) -> float:
+    """How long ago the decoder says it last heard this aircraft, sanitized.
+
+    The single sanitizing step every age-derived value in this module goes
+    through, so none of them can disagree about what one update means.
 
     ``None`` means the source reports no age — a replayed fixture that never
     captured one, or a future adapter for a decoder that does not offer it —
-    and the observation is then taken at face value. A negative age would date
-    it in the future, which no clock reading may be, so it clamps to ``now``.
+    and the observation is then taken at face value, age zero. A negative age
+    would date the observation in the future, which no clock reading may be,
+    so it too reads as zero. Public because the store needs the same number to
+    decide whether an observation is admissible at all.
     """
+    age_s = update.seen_s
     if age_s is None or age_s <= 0.0:
-        return now
-    return now - age_s
+        return 0.0
+    return age_s
 
 
 def _position_lag_s(update: AircraftStateUpdate) -> float:
@@ -314,10 +326,13 @@ def _position_lag_s(update: AircraftStateUpdate) -> float:
     ``reference minus seen_s`` by the adapter) and the moment the position was
     actually decoded. Zero whenever the decoder reports no separate position
     age, which leaves the position dated with the update.
+
+    It measures the gap against the *sanitized* silence, so a nonsensical
+    negative ``seen_s`` cannot inflate the position's age past its own report.
     """
     if update.seen_pos_s is None:
         return 0.0
-    return max(update.seen_pos_s - (update.seen_s or 0.0), 0.0)
+    return max(update.seen_pos_s - reported_silence_s(update), 0.0)
 
 
 def _track_point(update: AircraftStateUpdate, position: Position) -> TrackPoint:
@@ -357,7 +372,7 @@ def appear(
     if position is not None:
         track.append(_track_point(update, position))
 
-    observed_at = _observed_at(now, update.seen_s)
+    observed_at = now - reported_silence_s(update)
     position_lag_s = _position_lag_s(update)
 
     return LiveAircraft(
@@ -442,9 +457,10 @@ def merge(
     if has_position and position is not None:
         current.track.append(_track_point(update, position))
 
-    observed_at = _observed_at(now, update.seen_s)
+    silence_s = reported_silence_s(update)
+    observed_at = now - silence_s
     position_lag_s = _position_lag_s(update)
-    heard_recently = now - observed_at < stale_s
+    heard_recently = silence_s < stale_s
 
     merged = replace(
         current,
@@ -515,4 +531,5 @@ __all__ = [
     "appear",
     "mark_stale",
     "merge",
+    "reported_silence_s",
 ]

--- a/backend/src/flightsite/live/store.py
+++ b/backend/src/flightsite/live/store.py
@@ -22,27 +22,52 @@ default):
 * **removed** — silent for at least ``remove_s``. Dropped from the live set,
   announced with the last record and its track attached.
 
+"Silent" throughout means silent by the decoder's own account of when it last
+heard the aircraft, never "absent from the last poll" — see
+:mod:`flightsite.live.aircraft`. dump1090-fa keeps a dead aircraft in its JSON
+for about five minutes, so an entry being present in the document is not an
+observation, and treating it as one held the decoder's whole retention window
+in the live set (issue #134).
+
+That retention window forces a fourth outcome, ahead of the three above: an
+observation the decoder already reports as silent for at least ``remove_s`` is
+**not admitted**. No record is created, no event is published, and the aircraft
+simply is not live. Without the refusal a removal is undone a second later —
+the next poll re-delivers the same entry, it is admitted at an age already past
+the threshold, the following sweep removes it again, and that pair repeats at
+the poll rate until the decoder finally drops it. Thousands of spurious
+appear/remove events per cohort, and a live total that answers differently
+depending on whether it is read before or after the sweep.
+
+Refusal is drawn at ``remove_s`` and deliberately not at ``stale_s``. An
+aircraft last heard 40 s ago *was* genuinely heard, inside the window the live
+set is defined by, so it is admitted — as ``live``, because
+:func:`~flightsite.live.aircraft.appear` states what the record is rather than
+pre-judging it, and the sweep takes it stale on its next pass. Only an aircraft
+the decoder itself places outside the live window is turned away. Re-admission
+is likewise not blocked: a genuinely re-acquired aircraft reports a fresh age
+and appears again, exactly as a first contact would.
+
+Refusing is the store applying its own thresholds, which is why it belongs here
+and not in the ingest adapter. The adapter's job is to report faithfully what
+the decoder said; this module stays the single authority on what counts as
+live.
+
+Which side of the ``stale_s`` line an admitted record sits on is decided in two
+places, and deliberately only two. The sweep below owns the ``live → stale``
+direction and the :class:`~flightsite.live.events.AircraftStale` event that
+announces it. :func:`~flightsite.live.aircraft.merge` owns the reverse: an
+aircraft heard again — genuinely heard, within ``stale_s`` — is live again
+immediately, which is why it takes this store's threshold as an argument.
+
 The third threshold in the settings model, ``sighting.close_s`` (600 s), is
 deliberately **not** implemented here. Sighting closure is slice 009's
 lifecycle, over persisted sightings rather than live records; what this store
 owes it is :attr:`~flightsite.live.aircraft.LiveAircraft.last_seen` on every
 record and on every event, which is the instant that rule is measured from.
 
-"Silent" is measured from the decoder's own report of when it last heard the
-aircraft, not from when a poll last mentioned it — see
-:mod:`flightsite.live.aircraft`. dump1090-fa keeps a dead aircraft in its JSON
-for about five minutes, so an entry being present in the document is not an
-observation, and treating it as one held the whole retention window in the live
-set (issue #134).
-
-Which side of the ``stale_s`` line a record sits on is decided in two places,
-and deliberately only two. The sweep below owns the ``live → stale`` direction
-and the :class:`~flightsite.live.events.AircraftStale` event that announces it.
-:func:`~flightsite.live.aircraft.merge` owns the reverse: an aircraft heard
-again — genuinely heard, within ``stale_s`` — is live again immediately, which
-is why it takes this store's threshold as an argument.
-
-All three decisions read an injected monotonic clock, never the wall clock.
+Every one of these decisions reads an injected monotonic clock, never the wall
+clock.
 A Raspberry Pi with no RTC boots with a wildly wrong time and then jumps when
 NTP lands; a wall-clock timer would read that jump as every aircraft having
 been silent for hours and expire the entire live set at once. The clock is a
@@ -75,7 +100,14 @@ from typing import Final
 import structlog
 
 from flightsite.ingest import AircraftStateBatch, AircraftStateUpdate, Position
-from flightsite.live.aircraft import LiveAircraft, LiveState, appear, mark_stale, merge
+from flightsite.live.aircraft import (
+    LiveAircraft,
+    LiveState,
+    appear,
+    mark_stale,
+    merge,
+    reported_silence_s,
+)
 from flightsite.live.events import (
     DEFAULT_QUEUE_SIZE,
     AircraftAppeared,
@@ -277,7 +309,12 @@ class LiveStore:
         self.apply_updates(batch)
 
     def apply_updates(self, updates: Iterable[AircraftStateUpdate]) -> None:
-        """Apply a sequence of updates, publishing an event for each."""
+        """Apply a sequence of updates, publishing an event for each admitted one.
+
+        An update the decoder reports as already expired is silently dropped
+        rather than admitted — see the module docstring's fourth lifecycle
+        outcome — so this does not publish exactly one event per input.
+        """
         now = self._clock()
         for update in updates:
             self._apply_update(update, now)
@@ -285,6 +322,12 @@ class LiveStore:
     def _apply_update(self, update: AircraftStateUpdate, now: float) -> None:
         current = self._aircraft.get(update.icao)
         if current is None:
+            if reported_silence_s(update) >= self._remove_s:
+                # The decoder is still listing an aircraft it stopped hearing
+                # longer ago than the removal threshold. Admitting it would
+                # create a record the very next sweep must remove, once per
+                # poll for the rest of the decoder's retention window.
+                return
             aircraft = appear(
                 update,
                 now=now,

--- a/backend/src/flightsite/live/store.py
+++ b/backend/src/flightsite/live/store.py
@@ -28,6 +28,20 @@ lifecycle, over persisted sightings rather than live records; what this store
 owes it is :attr:`~flightsite.live.aircraft.LiveAircraft.last_seen` on every
 record and on every event, which is the instant that rule is measured from.
 
+"Silent" is measured from the decoder's own report of when it last heard the
+aircraft, not from when a poll last mentioned it — see
+:mod:`flightsite.live.aircraft`. dump1090-fa keeps a dead aircraft in its JSON
+for about five minutes, so an entry being present in the document is not an
+observation, and treating it as one held the whole retention window in the live
+set (issue #134).
+
+Which side of the ``stale_s`` line a record sits on is decided in two places,
+and deliberately only two. The sweep below owns the ``live → stale`` direction
+and the :class:`~flightsite.live.events.AircraftStale` event that announces it.
+:func:`~flightsite.live.aircraft.merge` owns the reverse: an aircraft heard
+again — genuinely heard, within ``stale_s`` — is live again immediately, which
+is why it takes this store's threshold as an argument.
+
 All three decisions read an injected monotonic clock, never the wall clock.
 A Raspberry Pi with no RTC boots with a wildly wrong time and then jumps when
 NTP lands; a wall-clock timer would read that jump as every aircraft having
@@ -281,7 +295,13 @@ class LiveStore:
             self._dispatcher.publish(AircraftAppeared(aircraft=aircraft, at=aircraft.last_seen))
             return
 
-        aircraft, changed = merge(current, update, now=now, receiver=self._receiver_location)
+        aircraft, changed = merge(
+            current,
+            update,
+            now=now,
+            stale_s=self._stale_s,
+            receiver=self._receiver_location,
+        )
         self._aircraft[update.icao] = aircraft
         self._dispatcher.publish(
             AircraftUpdated(aircraft=aircraft, at=aircraft.last_seen, changed=changed)

--- a/backend/tests/api/test_serializers.py
+++ b/backend/tests/api/test_serializers.py
@@ -18,7 +18,14 @@ from flightsite.api.schemas import AircraftView, ReceiverInfo
 from flightsite.api.serializers import aircraft_payload, iso_utc, receiver_payload
 from flightsite.config import ConfigStore, LocationSettings, Settings
 from flightsite.ingest import Position
-from flightsite.live import LiveAircraft, LiveState, appear, mark_stale, merge
+from flightsite.live import (
+    DEFAULT_STALE_S,
+    LiveAircraft,
+    LiveState,
+    appear,
+    mark_stale,
+    merge,
+)
 
 from ..live.conftest import SEATTLE, ManualClock, make_update
 
@@ -244,6 +251,7 @@ def test_a_merged_record_serializes_its_latest_values() -> None:
         first,
         make_update(offset_s=1.0, position=NEARBY, squawk="4521"),
         now=clock.advance(1.0),
+        stale_s=DEFAULT_STALE_S,
         receiver=SEATTLE,
     )
     payload = aircraft_payload(second)

--- a/backend/tests/live/test_lifecycle.py
+++ b/backend/tests/live/test_lifecycle.py
@@ -13,6 +13,7 @@ import pytest
 
 from flightsite.ingest import Position
 from flightsite.live import (
+    AircraftAppeared,
     AircraftRemoved,
     AircraftStale,
     AircraftUpdated,
@@ -21,7 +22,7 @@ from flightsite.live import (
     LiveStore,
 )
 
-from .conftest import ICAO, ManualClock, make_batch, make_update
+from .conftest import BASE_TIME, ICAO, ManualClock, make_batch, make_update
 
 
 @pytest.fixture
@@ -215,6 +216,115 @@ def test_only_silent_aircraft_expire(live_store: LiveStore, clock: ManualClock) 
 
     assert live_store.get("ae1463") is None
     assert live_store.get("4ca7b3") is not None
+
+
+# -------------------------------------------------- decoder retention windows
+
+
+def poll_ghost(live_store: LiveStore, *, seen_s: float) -> None:
+    """Re-deliver an entry the decoder is still listing but no longer hearing.
+
+    Its ``last_seen`` never moves — offset zero — while the age the decoder
+    reports grows with every poll. That is exactly what ``aircraft.json``
+    carries for the five minutes dump1090-fa retains a dead aircraft.
+    """
+    live_store.apply(make_batch(make_update(seen_s=seen_s)))
+
+
+def test_a_ghost_the_decoder_keeps_listing_ages_out_on_the_documented_thresholds(
+    live_store: LiveStore, clock: ManualClock, events: EventSubscription
+) -> None:
+    # Issue #134: the poller re-delivers every entry every second, so before
+    # the aircraft was aged by the decoder's own report its silence clock
+    # restarted on every poll and it survived the whole retention window.
+    poll_ghost(live_store, seen_s=0.0)
+
+    went_stale_at: int | None = None
+    removed_at: int | None = None
+    for second in range(1, 91):
+        clock.advance(1.0)
+        poll_ghost(live_store, seen_s=float(second))
+        live_store.sweep()
+        aircraft = live_store.get(ICAO)
+        if aircraft is None:
+            removed_at = second
+            break
+        if aircraft.state is LiveState.STALE and went_stale_at is None:
+            went_stale_at = second
+
+    assert went_stale_at == 15
+    assert removed_at == 60
+
+    removals = [event for event in events.drain() if isinstance(event, AircraftRemoved)]
+    assert len(removals) == 1
+    assert removals[0].aircraft.icao == ICAO
+    # The record is dated at the aircraft's last transmission, not at the last
+    # poll that mentioned it, so a consumer measuring from it gets the truth.
+    assert removals[0].aircraft.last_seen == BASE_TIME
+
+
+def test_a_ghost_that_is_still_listed_never_flickers_back_to_live(
+    live_store: LiveStore, clock: ManualClock, events: EventSubscription
+) -> None:
+    poll_ghost(live_store, seen_s=0.0)
+    for second in range(1, 50):
+        clock.advance(1.0)
+        poll_ghost(live_store, seen_s=float(second))
+        live_store.sweep()
+
+    stale_events = [event for event in events.drain() if isinstance(event, AircraftStale)]
+    assert len(stale_events) == 1
+
+
+def test_an_aircraft_the_decoder_is_still_hearing_never_expires(
+    live_store: LiveStore, clock: ManualClock
+) -> None:
+    # The other half of the contract: a real 1 Hz observation stream reports a
+    # sub-second age, which must keep the aircraft live indefinitely.
+    for second in range(120):
+        clock.advance(1.0)
+        live_store.apply(make_batch(make_update(offset_s=float(second), seen_s=0.4)))
+        live_store.sweep()
+
+    aircraft = live_store.get(ICAO)
+    assert aircraft is not None
+    assert aircraft.state is LiveState.LIVE
+
+
+def test_an_aircraft_heard_again_after_a_gap_comes_back_live(
+    live_store: LiveStore, clock: ManualClock
+) -> None:
+    poll_ghost(live_store, seen_s=0.0)
+    for second in range(1, 21):
+        clock.advance(1.0)
+        poll_ghost(live_store, seen_s=float(second))
+        live_store.sweep()
+    silent = live_store.get(ICAO)
+    assert silent is not None
+    assert silent.state is LiveState.STALE
+
+    clock.advance(1.0)
+    live_store.apply(make_batch(make_update(offset_s=21.0, seen_s=0.2)))
+
+    aircraft = live_store.get(ICAO)
+    assert aircraft is not None
+    assert aircraft.state is LiveState.LIVE
+
+
+def test_an_entry_the_decoder_first_reports_already_silent_is_swept_straight_out(
+    live_store: LiveStore, events: EventSubscription
+) -> None:
+    # Restarting FlightSite against a running decoder hands the store the whole
+    # retention window at once. Those entries enter the live set — the sweep is
+    # the only authority on the thresholds — and leave it on the next pass.
+    poll_ghost(live_store, seen_s=282.0)
+    assert ICAO in live_store
+
+    live_store.sweep()
+
+    assert ICAO not in live_store
+    kinds = [type(event) for event in events.drain()]
+    assert kinds == [AircraftAppeared, AircraftRemoved]
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/live/test_lifecycle.py
+++ b/backend/tests/live/test_lifecycle.py
@@ -311,20 +311,114 @@ def test_an_aircraft_heard_again_after_a_gap_comes_back_live(
     assert aircraft.state is LiveState.LIVE
 
 
-def test_an_entry_the_decoder_first_reports_already_silent_is_swept_straight_out(
+def test_an_entry_the_decoder_reports_as_already_expired_is_never_admitted(
     live_store: LiveStore, events: EventSubscription
 ) -> None:
     # Restarting FlightSite against a running decoder hands the store the whole
-    # retention window at once. Those entries enter the live set — the sweep is
-    # the only authority on the thresholds — and leave it on the next pass.
+    # retention window at once. An entry the decoder itself places outside the
+    # live window is turned away: no record, and nothing announced about an
+    # aircraft that was never live.
     poll_ghost(live_store, seen_s=282.0)
-    assert ICAO in live_store
 
+    assert ICAO not in live_store
+    assert len(live_store) == 0
+    assert events.drain() == ()
+
+
+def test_an_entry_first_heard_inside_the_removal_window_is_admitted(
+    live_store: LiveStore, clock: ManualClock, events: EventSubscription
+) -> None:
+    # The refusal is drawn at remove_s, not at stale_s: 40 s of silence is
+    # still inside the window the live set is defined by, so the aircraft is
+    # admitted and then ages out on the ordinary schedule.
+    poll_ghost(live_store, seen_s=40.0)
+
+    admitted = live_store.get(ICAO)
+    assert admitted is not None
+    assert admitted.state is LiveState.LIVE
+
+    live_store.sweep()
+    swept = live_store.get(ICAO)
+    assert swept is not None
+    assert swept.state is LiveState.STALE
+
+    clock.advance(21.0)
     live_store.sweep()
 
     assert ICAO not in live_store
     kinds = [type(event) for event in events.drain()]
-    assert kinds == [AircraftAppeared, AircraftRemoved]
+    assert kinds == [AircraftAppeared, AircraftStale, AircraftRemoved]
+
+
+def test_a_removed_ghost_is_not_re_admitted_by_the_polls_that_follow(
+    live_store: LiveStore, clock: ManualClock, events: EventSubscription
+) -> None:
+    # The regression this guards: the store removes the ghost at 60 s, the
+    # decoder keeps listing it for minutes more, and every following poll used
+    # to re-admit it for the next sweep to remove again — an appear/remove pair
+    # per second, per ghost, for the rest of the retention window.
+    poll_ghost(live_store, seen_s=0.0)
+    for second in range(1, 73):
+        clock.advance(1.0)
+        poll_ghost(live_store, seen_s=float(second))
+        live_store.sweep()
+
+    assert ICAO not in live_store
+    kinds = [type(event) for event in events.drain()]
+    assert kinds.count(AircraftAppeared) == 1
+    assert kinds.count(AircraftRemoved) == 1
+
+
+def test_a_removed_aircraft_the_decoder_genuinely_hears_again_is_re_admitted(
+    live_store: LiveStore, clock: ManualClock, events: EventSubscription
+) -> None:
+    # The refusal turns away re-listings, not re-acquisitions: once the decoder
+    # reports a fresh age the aircraft is live again, appearing for a second
+    # time exactly as a first-time contact would.
+    poll_ghost(live_store, seen_s=0.0)
+    for second in range(1, 73):
+        clock.advance(1.0)
+        poll_ghost(live_store, seen_s=float(second))
+        live_store.sweep()
+    assert ICAO not in live_store
+
+    clock.advance(1.0)
+    live_store.apply(make_batch(make_update(offset_s=73.0, seen_s=0.3)))
+
+    aircraft = live_store.get(ICAO)
+    assert aircraft is not None
+    assert aircraft.state is LiveState.LIVE
+    appearances = [event for event in events.drain() if isinstance(event, AircraftAppeared)]
+    assert len(appearances) == 2
+
+
+def test_the_live_count_is_the_audible_count_at_every_sampling_phase(
+    live_store: LiveStore, clock: ManualClock
+) -> None:
+    # What the owner actually sees. One aircraft the decoder keeps hearing, one
+    # it stopped hearing at second zero but keeps listing. The total must not
+    # depend on whether the count is read just after a poll or just after a
+    # sweep — the oscillation that reading gave while removals were undone.
+    audible, ghost = "4ca7b3", ICAO
+    after_poll: list[int] = []
+    after_sweep: list[int] = []
+    for second in range(1, 121):
+        clock.advance(1.0)
+        live_store.apply_updates(
+            [
+                make_update(audible, offset_s=float(second), seen_s=0.4),
+                make_update(ghost, seen_s=float(second)),
+            ]
+        )
+        after_poll.append(live_store.counts().total)
+        live_store.sweep()
+        after_sweep.append(live_store.counts().total)
+
+    # Both aircraft count while the ghost's silence is under remove_s; the
+    # sweep drops it at second 60 and no later poll brings it back. The one
+    # second of overlap is the documented sweep-interval lag, not a bug.
+    assert after_poll == [2] * 60 + [1] * 60
+    assert after_sweep == [2] * 59 + [1] * 61
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/live/test_merge.py
+++ b/backend/tests/live/test_merge.py
@@ -257,6 +257,35 @@ def test_a_position_with_no_age_of_its_own_is_dated_with_the_update() -> None:
     assert aircraft.position_seen == aircraft.last_seen
 
 
+def test_a_position_is_aged_against_the_sanitized_silence() -> None:
+    # A negative seen_s reads as zero everywhere, so it cannot widen the gap
+    # to the position and over-age it. Measured against the raw value this
+    # position would date 15 s back rather than the 10 s the decoder reported.
+    aircraft = appear(
+        make_update(position=AIRBORNE_POSITION, seen_s=-5.0, seen_pos_s=10.0),
+        now=1_000.0,
+        receiver=SEATTLE,
+    )
+
+    assert aircraft.last_seen_monotonic == 1_000.0
+    assert aircraft.position_seen_monotonic == 990.0
+
+
+def test_a_position_reported_fresher_than_the_update_is_dated_with_the_update() -> None:
+    # seen_pos_s below seen_s is incoherent — a position cannot be heard more
+    # recently than the message carrying it — so the gap floors at zero rather
+    # than dating the position ahead of the observation that reported it.
+    aircraft = appear(
+        make_update(position=AIRBORNE_POSITION, seen_s=30.0, seen_pos_s=10.0),
+        now=1_000.0,
+        receiver=SEATTLE,
+    )
+
+    assert aircraft.last_seen_monotonic == 970.0
+    assert aircraft.position_seen_monotonic == 970.0
+    assert aircraft.position_seen == aircraft.last_seen
+
+
 # --------------------------------------------------------------- reviving
 
 

--- a/backend/tests/live/test_merge.py
+++ b/backend/tests/live/test_merge.py
@@ -13,12 +13,15 @@ from typing import Any
 import pytest
 
 from flightsite.ingest import Position
+from flightsite.live import DEFAULT_STALE_S
 from flightsite.live.aircraft import (
     AIRBORNE_INFERENCE_ALTITUDE_FT,
     GroundState,
     LiveAircraft,
+    LiveState,
     Provenance,
     appear,
+    mark_stale,
     merge,
 )
 
@@ -40,7 +43,13 @@ def test_a_partial_update_does_not_erase_known_fields() -> None:
     clock = ManualClock()
     current = first(callsign="RCH492", squawk="4521", altitude_ft=25_000.0, on_ground=False)
 
-    merged, _ = merge(current, make_update(offset_s=1.0, rssi_db=-12.1), now=clock(), receiver=None)
+    merged, _ = merge(
+        current,
+        make_update(offset_s=1.0, rssi_db=-12.1),
+        now=clock(),
+        stale_s=DEFAULT_STALE_S,
+        receiver=None,
+    )
 
     assert merged.callsign == "RCH492"
     assert merged.squawk == "4521"
@@ -53,7 +62,9 @@ def test_a_position_survives_an_update_that_carries_none() -> None:
     # that position's source; position_seen records how old it now is.
     current = first(position=AIRBORNE_POSITION, position_source="mlat")
 
-    merged, _ = merge(current, make_update(offset_s=5.0), now=5.0, receiver=SEATTLE)
+    merged, _ = merge(
+        current, make_update(offset_s=5.0), now=5.0, stale_s=DEFAULT_STALE_S, receiver=SEATTLE
+    )
 
     assert merged.position == AIRBORNE_POSITION
     assert merged.position_source == "mlat"
@@ -66,7 +77,11 @@ def test_a_callsign_change_is_reported_as_a_changed_field() -> None:
     current = first(callsign="RCH492")
 
     merged, changed = merge(
-        current, make_update(offset_s=1.0, callsign="RCH493"), now=1.0, receiver=None
+        current,
+        make_update(offset_s=1.0, callsign="RCH493"),
+        now=1.0,
+        stale_s=DEFAULT_STALE_S,
+        receiver=None,
     )
 
     assert merged.callsign == "RCH493"
@@ -79,7 +94,11 @@ def test_per_poll_bookkeeping_is_not_reported_as_a_change() -> None:
     current = first(callsign="RCH492", seen_s=0.1)
 
     _, changed = merge(
-        current, make_update(offset_s=1.0, callsign="RCH492", seen_s=0.4), now=1.0, receiver=None
+        current,
+        make_update(offset_s=1.0, callsign="RCH492", seen_s=0.4),
+        now=1.0,
+        stale_s=DEFAULT_STALE_S,
+        receiver=None,
     )
 
     assert changed == frozenset()
@@ -88,7 +107,13 @@ def test_per_poll_bookkeeping_is_not_reported_as_a_change() -> None:
 def test_identity_fields_carry_their_own_timestamps() -> None:
     current = first(callsign="RCH492")
 
-    merged, _ = merge(current, make_update(offset_s=30.0, squawk="4521"), now=30.0, receiver=None)
+    merged, _ = merge(
+        current,
+        make_update(offset_s=30.0, squawk="4521"),
+        now=30.0,
+        stale_s=DEFAULT_STALE_S,
+        receiver=None,
+    )
 
     assert merged.callsign_seen == BASE_TIME
     assert merged.squawk_seen == BASE_TIME + timedelta(seconds=30)
@@ -98,7 +123,9 @@ def test_identity_fields_carry_their_own_timestamps() -> None:
 def test_observations_are_counted() -> None:
     current = first()
 
-    merged, _ = merge(current, make_update(offset_s=1.0), now=1.0, receiver=None)
+    merged, _ = merge(
+        current, make_update(offset_s=1.0), now=1.0, stale_s=DEFAULT_STALE_S, receiver=None
+    )
 
     assert current.observations == 1
     assert merged.observations == 2
@@ -108,9 +135,191 @@ def test_merging_leaves_the_previous_record_untouched() -> None:
     # Records are immutable, which is what makes a snapshot safe to hold.
     current = first(callsign="RCH492")
 
-    merge(current, make_update(offset_s=1.0, callsign="RCH493"), now=1.0, receiver=None)
+    merge(
+        current,
+        make_update(offset_s=1.0, callsign="RCH493"),
+        now=1.0,
+        stale_s=DEFAULT_STALE_S,
+        receiver=None,
+    )
 
     assert current.callsign == "RCH492"
+
+
+# ------------------------------------------------------------ observation age
+
+
+def test_a_first_observation_is_dated_by_the_decoders_reported_age() -> None:
+    aircraft = appear(make_update(seen_s=20.0), now=1_000.0, receiver=SEATTLE)
+
+    assert aircraft.last_seen_monotonic == 980.0
+    assert aircraft.first_seen_monotonic == 980.0
+    assert aircraft.age_s(1_000.0) == 20.0
+
+
+@pytest.mark.parametrize(
+    "seen_s",
+    [
+        pytest.param(0.2, id="fresh"),
+        pytest.param(20.0, id="past-stale"),
+        pytest.param(282.0, id="ghost"),
+    ],
+)
+def test_an_update_is_dated_by_the_decoders_reported_age(seen_s: float) -> None:
+    current = first(seen_s=0.0)
+
+    merged, _ = merge(
+        current,
+        make_update(offset_s=1.0, seen_s=seen_s),
+        now=1_000.0,
+        stale_s=DEFAULT_STALE_S,
+        receiver=None,
+    )
+
+    assert merged.last_seen_monotonic == pytest.approx(1_000.0 - seen_s)
+    assert merged.age_s(1_000.0) == pytest.approx(seen_s)
+
+
+def test_a_ghost_re_delivered_every_second_stops_ageing_at_its_last_transmission() -> None:
+    # The failure in issue #134: the decoder keeps listing an aircraft it has
+    # not heard for minutes, so the monotonic instant must stay put while the
+    # clock and the reported age advance together.
+    aircraft = first(seen_s=0.0)
+
+    instants = []
+    for tick in range(1, 6):
+        aircraft, _ = merge(
+            aircraft,
+            make_update(seen_s=float(tick)),
+            now=1_000.0 + tick,
+            stale_s=DEFAULT_STALE_S,
+            receiver=None,
+        )
+        instants.append(aircraft.last_seen_monotonic)
+
+    assert instants == [1_000.0] * 5
+
+
+@pytest.mark.parametrize(
+    "seen_s", [pytest.param(None, id="not-reported"), pytest.param(-0.5, id="negative")]
+)
+def test_an_unusable_reported_age_dates_the_observation_at_the_clock(seen_s: float | None) -> None:
+    # A source that reports no age at all is taken at face value, and no
+    # observation may be dated in the future.
+    current = first()
+
+    merged, _ = merge(
+        current,
+        make_update(offset_s=1.0, seen_s=seen_s),
+        now=1_000.0,
+        stale_s=DEFAULT_STALE_S,
+        receiver=None,
+    )
+
+    assert merged.last_seen_monotonic == 1_000.0
+
+
+def test_a_position_is_dated_by_its_own_reported_age() -> None:
+    aircraft = appear(
+        make_update(position=AIRBORNE_POSITION, seen_s=4.0, seen_pos_s=30.0),
+        now=1_000.0,
+        receiver=SEATTLE,
+    )
+
+    assert aircraft.position_seen_monotonic == 970.0
+    assert aircraft.position_age_s(1_000.0) == 30.0
+    # The wall-clock companion agrees: the update is already dated at
+    # reference minus seen_s, and the position is another 26 s behind that.
+    assert aircraft.position_seen == aircraft.last_seen - timedelta(seconds=26.0)
+
+
+def test_a_merged_position_is_dated_by_its_own_reported_age() -> None:
+    current = first()
+
+    merged, _ = merge(
+        current,
+        make_update(offset_s=1.0, position=AIRBORNE_POSITION, seen_s=4.0, seen_pos_s=30.0),
+        now=1_000.0,
+        stale_s=DEFAULT_STALE_S,
+        receiver=SEATTLE,
+    )
+
+    assert merged.last_seen_monotonic == 996.0
+    assert merged.position_seen_monotonic == 970.0
+
+
+def test_a_position_with_no_age_of_its_own_is_dated_with_the_update() -> None:
+    aircraft = appear(
+        make_update(position=AIRBORNE_POSITION, seen_s=4.0), now=1_000.0, receiver=SEATTLE
+    )
+
+    assert aircraft.position_seen_monotonic == 996.0
+    assert aircraft.position_seen == aircraft.last_seen
+
+
+# --------------------------------------------------------------- reviving
+
+
+def test_a_fresh_observation_revives_a_stale_record() -> None:
+    stale = mark_stale(first(seen_s=0.0))
+
+    merged, changed = merge(
+        stale,
+        make_update(offset_s=20.0, seen_s=0.5),
+        now=1_000.0,
+        stale_s=DEFAULT_STALE_S,
+        receiver=None,
+    )
+
+    assert merged.state is LiveState.LIVE
+    assert "state" in changed
+
+
+def test_a_re_polled_ghost_does_not_revive_a_stale_record() -> None:
+    # The decoder still listing the entry is not evidence the aircraft is back.
+    stale = mark_stale(first(seen_s=0.0))
+
+    merged, changed = merge(
+        stale,
+        make_update(offset_s=20.0, seen_s=40.0),
+        now=1_000.0,
+        stale_s=DEFAULT_STALE_S,
+        receiver=None,
+    )
+
+    assert merged.state is LiveState.STALE
+    assert "state" not in changed
+
+
+def test_an_observation_exactly_on_the_stale_threshold_does_not_revive() -> None:
+    stale = mark_stale(first(seen_s=0.0))
+
+    merged, _ = merge(
+        stale,
+        make_update(offset_s=20.0, seen_s=DEFAULT_STALE_S),
+        now=1_000.0,
+        stale_s=DEFAULT_STALE_S,
+        receiver=None,
+    )
+
+    assert merged.state is LiveState.STALE
+
+
+def test_merging_never_takes_a_live_record_stale_itself() -> None:
+    # Marking stale is the sweep's job, along with the event that announces it;
+    # merge only ever reports what the record's timing now says.
+    live = first(seen_s=0.0)
+
+    merged, _ = merge(
+        live,
+        make_update(offset_s=20.0, seen_s=40.0),
+        now=1_000.0,
+        stale_s=DEFAULT_STALE_S,
+        receiver=None,
+    )
+
+    assert merged.state is LiveState.LIVE
+    assert merged.age_s(1_000.0) == 40.0
 
 
 # ------------------------------------------------------------ non-positioned
@@ -164,7 +373,11 @@ def test_range_is_recomputed_once_a_receiver_location_arrives() -> None:
     aircraft = appear(make_update(position=AIRBORNE_POSITION), now=0.0, receiver=None)
 
     merged, changed = merge(
-        aircraft, make_update(offset_s=1.0, position=AIRBORNE_POSITION), now=1.0, receiver=SEATTLE
+        aircraft,
+        make_update(offset_s=1.0, position=AIRBORNE_POSITION),
+        now=1.0,
+        stale_s=DEFAULT_STALE_S,
+        receiver=SEATTLE,
     )
 
     assert merged.distance_nm is not None
@@ -194,7 +407,11 @@ def test_a_ground_report_clears_a_stale_cruise_altitude() -> None:
     current = first(altitude_ft=25_000.0)
 
     merged, changed = merge(
-        current, make_update(offset_s=1.0, on_ground=True), now=1.0, receiver=None
+        current,
+        make_update(offset_s=1.0, on_ground=True),
+        now=1.0,
+        stale_s=DEFAULT_STALE_S,
+        receiver=None,
     )
 
     assert merged.altitude_ft is None
@@ -233,7 +450,9 @@ def test_ground_state_stays_unknown_without_confident_evidence(fields: dict[str,
 def test_a_ground_determination_persists_until_the_decoder_revises_it() -> None:
     current = first(on_ground=True)
 
-    merged, _ = merge(current, make_update(offset_s=1.0), now=1.0, receiver=None)
+    merged, _ = merge(
+        current, make_update(offset_s=1.0), now=1.0, stale_s=DEFAULT_STALE_S, receiver=None
+    )
 
     assert merged.on_ground is True
     assert merged.ground_state is GroundState.ON_GROUND
@@ -252,6 +471,7 @@ def test_positions_accumulate_into_the_track_in_order() -> None:
                 position=Position(latitude=47.0 + index * 0.1, longitude=-122.0),
             ),
             now=float(index),
+            stale_s=DEFAULT_STALE_S,
             receiver=SEATTLE,
         )
 
@@ -261,7 +481,9 @@ def test_positions_accumulate_into_the_track_in_order() -> None:
 def test_a_non_positioned_update_adds_no_track_point() -> None:
     aircraft = first(position=Position(latitude=47.0, longitude=-122.0))
 
-    aircraft, _ = merge(aircraft, make_update(offset_s=1.0), now=1.0, receiver=SEATTLE)
+    aircraft, _ = merge(
+        aircraft, make_update(offset_s=1.0), now=1.0, stale_s=DEFAULT_STALE_S, receiver=SEATTLE
+    )
 
     assert len(aircraft.track) == 1
 
@@ -279,6 +501,7 @@ def test_the_track_is_shared_across_successive_records() -> None:
         aircraft,
         make_update(offset_s=1.0, position=Position(latitude=47.1, longitude=-122.0)),
         now=1.0,
+        stale_s=DEFAULT_STALE_S,
         receiver=SEATTLE,
     )
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,7 +152,11 @@ Asyncio tasks in one process:
   applies the batch to the live store. Budget: apply-500-aircraft-batch well under one
   polling interval.
 - **Lifecycle timer** — drives stale (15 s), live-removal (60 s), and sighting-close
-  (10 min) transitions from a monotonic clock (configurable values).
+  (10 min) transitions from a monotonic clock (configurable values). The silence those
+  thresholds measure runs from the decoder's own report of when it last heard the
+  aircraft, not from the last poll that listed it: both supported decoders keep a dead
+  aircraft in their output for minutes, so an entry appearing in a poll is not an
+  observation.
 - **Persistence worker** — drains bounded queues of domain events into batched
   transactions. Backpressure policy: queues are bounded; on overflow, coalescible
   items (track points) are thinned first and a counter + diagnostic records the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -140,6 +140,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 057 | Activity WebSocket batching | 012, 035, 049 | opus | medium | Batch a detector pass's activity events into one WebSocket frame so a fresh install's backlog stops evicting every client (issue #99) |
 | 058 | Quick wins bundle | 031, 042, 043, 050 | opus | low | Six small tracked fixes on one branch: max-range sort index, FAA User-Agent, VACUUM refusal surfaced, backup gzip 6, pagination noun, demo-mode "today" (issues #107, #112, #115, #116, #117, #121) |
 | 059 | OpenSky metadata source | 021, 022, 023, 042 | opus | medium | Opt-in, default-off OpenSky aircraft database as a fill-gaps-only source under an ambiguous license (ADR-0013) |
+| 062 | Live-set ghost expiry | 007, 008, 009 | opus | medium | Age live records by the decoder's own "last heard" report so dump1090's ~5-minute retention window stops inflating the live count and the 15 s / 60 s thresholds fire on time (issue #134) |
 
 ## Parallelization Guide
 

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1502,6 +1502,43 @@ slices:
     risk_level: medium
     notes: "Owner-approved opt-in source. Licensing is ambiguous rather than clean, so the posture matches the Mictronics row (fetch-on-demand only) and adds default-off on top; contact@opensky-network.org is recorded in ADR-0013 as the route to firmer ground. Added by Fable outside the phase plan."
 
+  - id: "062"
+    title: "Live-set ghost expiry"
+    phase: 8
+    branch: "062-live-count-ghosts"
+    status: merged
+    depends_on: ["007", "008", "009"]
+    objective: "Age each live record by the decoder's own report of when it last heard the aircraft, so dump1090-fa's ~5-minute retention window stops inflating the live set and the documented 15 s / 60 s lifecycle thresholds fire on time (issue #134)."
+    scope:
+      - "`live/aircraft.py` `appear()`/`merge()` date every observation at `now - seen_s` (and the position at `now - seen_pos_s`) instead of at the poll, clamping an absent or negative reported age to `now`"
+      - "the wall-clock `position_seen` is dated by the same offset as its monotonic companion, so the two never disagree"
+      - "`merge()` takes the store's `stale_s` and revives a STALE record only on an observation younger than it; a re-polled entry the decoder has not actually heard leaves the state alone, and marking stale stays the sweep's job along with its event"
+      - "`live/store.py` passes its configured threshold and documents the two-place ownership of the live/stale boundary"
+    out_of_scope:
+      - "the thresholds themselves, the sweep, and the sighting-close rule, all unchanged"
+      - "filtering high-age entries in the ingest adapter — the store's thresholds stay the single lifecycle authority"
+      - "the consumer-efficiency follow-ups the higher event cadence exposes (forced sighting flush per removal, alert dedupe state dropped on removal, airport trail discarded after 60 s), each tracked separately"
+      - "frontend changes"
+    acceptance_criteria:
+      - "an entry the decoder re-delivers every second with a growing reported age goes STALE at 15 s and is removed at 60 s of real silence, not when the decoder finally drops it"
+      - "a STALE record is revived only by an observation younger than `stale_s`; a re-polled ghost never flips it back to LIVE"
+      - "an aircraft the decoder is still hearing at 1 Hz stays LIVE indefinitely"
+      - "the removal event carries the last record, dated at the aircraft's last transmission rather than the last poll"
+      - "no regression in the sighting lifecycle suite or the slice-049 perf harness scenarios"
+    required_tests:
+      - appear/merge ageing tests over fresh, past-stale and 282 s reported ages, including the absent and negative cases
+      - position ageing tests for `seen_pos_s`, present and absent
+      - revival tests: fresh observation revives STALE, re-polled ghost does not, threshold boundary does not
+      - store-level integration test re-delivering one ghost per second and asserting the STALE and removal seconds plus the removal event's record
+      - regression test that an aircraft reporting a sub-second age never expires
+    expected_artifacts:
+      - backend/src/flightsite/live/aircraft.py
+      - backend/src/flightsite/live/store.py
+      - backend/tests/live/test_merge.py
+      - backend/tests/live/test_lifecycle.py
+    preferred_agent: opus
+    risk_level: medium
+    notes: "Owner measured 80 shown against 59 audible on the Pi at v0.2.0. Fixes GitHub issue #134. Added by Fable outside the phase plan."
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,
 # 027, 031, 033, 035, 037, 038, 052) are ADDITIONALLY serialized against each other

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1545,6 +1545,7 @@ slices:
       - "the wall-clock `position_seen` is dated by the same offset as its monotonic companion, so the two never disagree"
       - "`merge()` takes the store's `stale_s` and revives a STALE record only on an observation younger than it; a re-polled entry the decoder has not actually heard leaves the state alone, and marking stale stays the sweep's job along with its event"
       - "`live/store.py` passes its configured threshold and documents the two-place ownership of the live/stale boundary"
+      - "`live/store.py` refuses to admit an observation the decoder already reports as silent for at least `remove_s`: no record, no event. Without it a removal is undone by the next poll and the appear/remove pair repeats at the poll rate for the rest of the decoder's retention window"
     out_of_scope:
       - "the thresholds themselves, the sweep, and the sighting-close rule, all unchanged"
       - "filtering high-age entries in the ingest adapter — the store's thresholds stay the single lifecycle authority"
@@ -1554,6 +1555,9 @@ slices:
       - "an entry the decoder re-delivers every second with a growing reported age goes STALE at 15 s and is removed at 60 s of real silence, not when the decoder finally drops it"
       - "a STALE record is revived only by an observation younger than `stale_s`; a re-polled ghost never flips it back to LIVE"
       - "an aircraft the decoder is still hearing at 1 Hz stays LIVE indefinitely"
+      - "a removed ghost the decoder keeps listing is not re-admitted by the polls that follow: exactly one appear and one removal across the retention window"
+      - "an aircraft first reported as already expired is never admitted, while one first reported between `stale_s` and `remove_s` is admitted live and then ages out normally"
+      - "the live total is the audible total whether it is sampled just after a poll or just after a sweep"
       - "the removal event carries the last record, dated at the aircraft's last transmission rather than the last poll"
       - "no regression in the sighting lifecycle suite or the slice-049 perf harness scenarios"
     required_tests:
@@ -1561,6 +1565,8 @@ slices:
       - position ageing tests for `seen_pos_s`, present and absent
       - revival tests: fresh observation revives STALE, re-polled ghost does not, threshold boundary does not
       - store-level integration test re-delivering one ghost per second and asserting the STALE and removal seconds plus the removal event's record
+      - admission tests: an already-expired first report is refused, a report inside the removal window is admitted, a removed ghost is not re-admitted over 12 further poll+sweep cycles, and a genuinely re-heard aircraft appears again
+      - live-count test asserting the total at both sampling phases across 120 poll+sweep cycles
       - regression test that an aircraft reporting a sub-second age never expires
     expected_artifacts:
       - backend/src/flightsite/live/aircraft.py


### PR DESCRIPTION
Slice 062 — closes #134.

The live count read ~80 while tar1090/SkyAware read 59: dump1090-fa retains dead aircraft in aircraft.json for ~5 minutes, the poller re-delivers every entry each second, and merge() stamped "heard just now" on every applied update — so ghosts never aged past one polling interval and the 15 s / 60 s lifecycle thresholds effectively never fired.

- Observations are now dated at the decoder's own reported age (`now − seen_s`, sanitized in one place by `reported_silence_s`); positions carry their own `seen_pos` lag.
- Lifecycle ownership split: merge() owns only stale→live revival (`aged age < stale_s`); the sweep keeps live→stale and removal. A re-polled ghost can never flip a STALE record back to LIVE.
- Admission gate (review-driven): the store refuses a first observation already reported as expired (`≥ remove_s`) — no record, no event — killing the 1 Hz appear/remove oscillation the review reproduced. Re-acquisition with a genuinely fresh age re-appears normally; first contact inside the stale window admits LIVE and sweeps on schedule.
- Consumer audit of all six event subscribers at the new (correct) cadence: no correctness breakage; efficiency follow-ups tracked in #138. The slice-054 interpolation contract is untouched — and the 15 s stale fade now actually occurs, as designed.

Reviewed by a dedicated adversarial pass (initial review caught the oscillation blocker; verification re-ran the reproduction and boundary probes — verdict MERGE).

+24 tests including a 72-cycle ghost-re-delivery simulation and an every-sampling-phase count assertion; full suite 4306 passed, coverage 98.9%; ruff/format/mypy clean. Re-synced with dev after the 060 and 061 merges (roadmap numeric-order union).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTAJUucu2ZPAD235B3GQeZ