### PR TITLE
fix(map): date position fixes by the decoder's seen_pos age (slice 064)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -143,6 +143,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 060 | Raspberry Pi 4 performance baseline | 049, 050 | opus | low | Record the first Pi 4 baseline in docs/PERFORMANCE.md §5.4 and defer §5.3 promotion to the pending clean re-run (issues #101, #132) |
 | 061 | Selected aircraft track backfill | 014, 052 | opus | low | Backfill the selected aircraft's track from its open sighting so a click draws the whole current sighting, not just what arrives after it (issue #133) |
 | 062 | Live-set ghost expiry | 007, 008, 009 | opus | medium | Age live records by the decoder's own "last heard" report so dump1090's ~5-minute retention window stops inflating the live count and the 15 s / 60 s thresholds fire on time (issue #134) |
+| 064 | Honest position-fix anchor | 054 | opus | low | Date each position fix by the decode age the frame reports rather than by its arrival, so dead reckoning hands over between fixes without the periodic backwards step (issue #144) |
 
 ## Parallelization Guide
 

--- a/frontend/src/features/map/aircraft/interpolation.ts
+++ b/frontend/src/features/map/aircraft/interpolation.ts
@@ -17,6 +17,28 @@
  * crept forward again. Elapsed time has to be measured from the moment the
  * position was *fixed*, which is what the store now records.
  *
+ * **And the fix was already old when it arrived** — issue #144. The store dates
+ * a new fix at `receivedAt - seen_pos_s`, the decoder's own age for the CPR
+ * solution, rather than at the instant the frame landed; see
+ * `useLiveAircraftStore` for the dating rules and why a *repeated* fix is never
+ * re-dated. That is what makes this projection continuous across fixes. With
+ * both anchors honest, the projection running from fix N at the moment fix N+1
+ * lands and the projection starting from fix N+1 are the same point for an
+ * aircraft flying straight: N+1's coordinates sit behind N's projection by
+ * exactly the travel N+1's own age immediately adds back. Whatever poll and
+ * socket latency the frames share cancels in the subtraction, so it need not be
+ * known — only the part of the delay the decoder measures differs between
+ * fixes, and that is the part `seen_pos_s` reports. Dating both fixes at
+ * arrival instead dropped the age term from one side only, which is why the
+ * marker stepped back by (fix age × ground speed) on every decode.
+ *
+ * A back-dated fix is therefore projected forward the moment it arrives, with
+ * `elapsed` already positive. That is the intent, not an edge case: `elapsed`
+ * asks how long the aircraft has been flying since it was placed, and the
+ * answer at arrival is `seen_pos_s`, not zero. The `elapsed === 0` shortcut
+ * below still covers what it always covered — no time to project, so nothing
+ * to compute.
+ *
  * **Why dead reckoning rather than tweening between the last two positions.**
  * Tweening is smooth but wrong twice over: it renders the aircraft a full
  * update *behind* where it was last reported, and it needs two positions, which
@@ -45,13 +67,20 @@
  * has stopped hearing them, so their last known position is the honest thing to
  * draw.
  *
- * **No correction blend on a new fix**, considered and declined in slice 054. A
- * new fix still moves the marker by however far the projection had drifted, and
- * easing into it instead of snapping was the obvious next refinement. It is not
- * worth it: with the anchor correct that step is the dead-reckoning error over
- * one fix interval — metres for an aircraft flying straight, against the ~0.8 nm
- * the mis-anchored version jumped — so the blend would smooth something already
- * near the noise floor. The cost is real, though. This function is pure and
+ * **No correction blend on a new fix**, considered and declined in slice 054
+ * and re-examined in 064. A new fix still moves the marker by however far the
+ * projection had drifted, and easing into it instead of snapping is the obvious
+ * next refinement. Slice 054 declined it on the grounds that the step is only
+ * the dead-reckoning error over one fix interval — metres for an aircraft
+ * flying straight, against the ~0.8 nm the #119 anchor jumped. That was the
+ * right conclusion from a premise that was not yet true: the anchor was still
+ * late by the fix's own age, leaving a systematic step of (fix age × ground
+ * speed), ~0.1-0.3 nm at jet speeds and reliably backwards, which is the
+ * oscillation issue #144 reported. Back-dating removes that term rather than
+ * masking it, and what remains is the error the paragraph always claimed —
+ * genuine manoeuvring between fixes, near the noise floor for straight flight,
+ * and not systematically signed. So the blend stays declined, now on its stated
+ * grounds. The cost is real, too. This function is pure and
  * called once per aircraft per frame; a blend needs the previously *drawn*
  * position kept per aircraft between frames, which means mutable render state
  * with its own eviction, reset-on-reconnect and store-reset invalidation. And
@@ -82,6 +111,14 @@ import type { GeoPosition } from "@/lib/api/live";
  * per-delta anchor and far too short against this one: it would re-freeze a
  * distant aircraft for most of every gap between fixes, reintroducing the
  * stutter from the other side.
+ *
+ * Since slice 064 this measures the fix's *true* age — the store's anchor now
+ * includes the decode age the frame arrived with (issue #144) — which is what
+ * the bound always meant. It reads a few seconds sooner in wall-clock terms
+ * than it used to, and correctly so: an aircraft last placed 15 s ago is
+ * equally unfit to project whether the client learned that 15 s ago or 5 s ago.
+ * The same constant doubles as the store's clamp on a reported age, since a fix
+ * older than this is not projected anyway.
  */
 export const INTERPOLATION_MAX_FIX_AGE_MS = 15_000;
 

--- a/frontend/src/features/map/aircraft/interpolation.ts
+++ b/frontend/src/features/map/aircraft/interpolation.ts
@@ -18,8 +18,9 @@
  * position was *fixed*, which is what the store now records.
  *
  * **And the fix was already old when it arrived** — issue #144. The store dates
- * a new fix at `receivedAt - seen_pos_s`, the decoder's own age for the CPR
- * solution, rather than at the instant the frame landed; see
+ * a new fix at `receivedAt - seen_pos_s * 1000`, the decoder's own age for the
+ * CPR solution converted from seconds to the milliseconds these timestamps are
+ * kept in, rather than at the instant the frame landed; see
  * `useLiveAircraftStore` for the dating rules and why a *repeated* fix is never
  * re-dated. That is what makes this projection continuous across fixes. With
  * both anchors honest, the projection running from fix N at the moment fix N+1

--- a/frontend/src/features/map/aircraft/snapback.regression.test.ts
+++ b/frontend/src/features/map/aircraft/snapback.regression.test.ts
@@ -1,5 +1,5 @@
 /**
- * Regression: markers crept forward then teleported back (issue #119).
+ * Regression: markers crept forward then teleported back (issues #119, #144).
  *
  * Driven through the real store rather than hand-built records, because the
  * defect lived in the seam between the two: `displayPosition` dead-reckoned
@@ -8,12 +8,20 @@
  * aircraft. Each no-new-fix delta reset elapsed time to zero and snapped the
  * marker back to the stale fix. A unit test over a fabricated record cannot
  * see that; only applying a real delta sequence can.
+ *
+ * Issue #144 is the same symptom from the residue that fix left: the anchor was
+ * still late by the fix's own decode age, so a *genuine* new fix landed behind
+ * the projection running from the last one and stepped the marker back. The
+ * first block below pins the #119 behaviour with `seen_pos_s: 0`, which must
+ * stay bit-for-bit what it was; the second drives the same seam with the
+ * nonzero ages a distant aircraft actually reports.
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { displayPosition } from "@/features/map/aircraft/interpolation";
 import { useLiveAircraftStore } from "@/features/map/aircraft/store/useLiveAircraftStore";
+import type { LiveAircraft } from "@/lib/api/live";
 import { makeAircraft } from "@/test/liveAircraftFixtures";
 
 const T0 = 1_700_000_000_000;
@@ -22,12 +30,16 @@ const ICAO = "aaaaaa";
 /** Due north at 360 kt: 0.1 nm a second, or 1/600 of a degree of latitude. */
 const DEGREES_PER_SECOND = 0.1 / 60;
 
-function inbound(overrides = {}) {
+/** The #119 scenario's aircraft: a reported age of zero, so every anchor here
+ * is the arrival instant and the expectations below are the pre-#144 ones
+ * unchanged. */
+function inbound(overrides: Partial<LiveAircraft> = {}) {
   return makeAircraft({
     icao: ICAO,
     position: { lat: 0, lon: 0 },
     track_deg: 0,
     ground_speed_kt: 360,
+    seen_pos_s: 0,
     ...overrides,
   });
 }
@@ -139,5 +151,155 @@ describe("live map motion across deltas that do not move the fix", () => {
     const coasted = drawnLat(T0 + 60_000);
     expect(coasted).toBeGreaterThan(0);
     expect(drawnLat(T0 + 600_000)).toBe(coasted);
+  });
+});
+
+/**
+ * Issue #144, modelled as the receiver and the network actually behave.
+ *
+ * A CPR fix is measured at some true instant, read by a backend poll some time
+ * later — that gap is what the frame reports as `seen_pos_s` — and reaches the
+ * browser after a further transport delay the frame says nothing about. The
+ * decode gap varies fix by fix; the transport delay is shared by every frame
+ * alike. Back-dating cancels the part that varies, which is the whole claim:
+ * what is left is a constant lag no client-side arithmetic could remove.
+ */
+describe("live map motion when fixes arrive already aged", () => {
+  /** The delay every frame shares: poll to socket to browser. Constant, so it
+   * cannot be recovered from the data and does not need to be. */
+  const TRANSPORT_MS = 1000;
+
+  /** True instants the receiver decoded a position, on the irregular 2-10 s
+   * cadence of a distant aircraft. */
+  const FIX_TIMES_MS = [500, 4300, 9100];
+
+  const POLL_TIMES_MS = [
+    1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10_000, 11_000,
+    12_000,
+  ];
+
+  /** Where the aircraft truly is `trueMs` after T0. */
+  function latAtTrue(trueMs: number): number {
+    return (trueMs / 1000) * DEGREES_PER_SECOND;
+  }
+
+  /** The newest fix the decoder held when the backend polled at `pollMs`. */
+  function fixHeldAt(pollMs: number): number {
+    let held = FIX_TIMES_MS[0] as number;
+    for (const measuredAt of FIX_TIMES_MS) {
+      if (measuredAt <= pollMs) {
+        held = measuredAt;
+      }
+    }
+    return held;
+  }
+
+  /** Applies the frame built by the poll at `pollMs`, at the browser instant it
+   * would land. Returns that instant. */
+  function deliverPoll(pollMs: number): number {
+    const measuredAt = fixHeldAt(pollMs);
+    const arrivesAt = T0 + pollMs + TRANSPORT_MS;
+    useLiveAircraftStore.getState().applyDelta(
+      {
+        updated: [
+          inbound({
+            position: { lat: latAtTrue(measuredAt), lon: 0 },
+            seen_pos_s: (pollMs - measuredAt) / 1000,
+          }),
+        ],
+        stale: [],
+        removed: [],
+      },
+      arrivesAt,
+    );
+    return arrivesAt;
+  }
+
+  function rawLat(): number {
+    const lat =
+      useLiveAircraftStore.getState().aircraft[ICAO]?.aircraft.position?.lat;
+    if (lat === undefined) {
+      throw new Error(`${ICAO} has no reported position`);
+    }
+    return lat;
+  }
+
+  beforeEach(() => {
+    // The suite-wide snapshot seeds an unaged fix; this scenario builds its own
+    // history from the first poll.
+    useLiveAircraftStore.getState().reset();
+  });
+
+  it("never draws the aircraft behind where it was a moment earlier", () => {
+    // The reported symptom: a periodic back-step, once per genuine decode. The
+    // last sample of each second sits 1 ms before the next frame lands, so a
+    // step at the handover has nowhere to hide between samples.
+    let previous = Number.NEGATIVE_INFINITY;
+    for (const pollMs of POLL_TIMES_MS) {
+      const arrivesAt = deliverPoll(pollMs);
+      for (const offset of [0, 250, 500, 750, 999]) {
+        const current = drawnLat(arrivesAt + offset);
+        expect(
+          current,
+          `drew backwards at poll ${pollMs} ms +${offset}: ${current} < ${previous}`,
+        ).toBeGreaterThanOrEqual(previous);
+        previous = current;
+      }
+    }
+  });
+
+  it("hands over from one fix to the next without a step", () => {
+    // The fix measured at 4300 first reaches the browser at T0+6000, carried by
+    // the 5000 poll and 0.7 s old. Either side of that instant the drawn path
+    // must differ by one millisecond of travel and nothing more.
+    for (const pollMs of [1000, 2000, 3000, 4000]) {
+      deliverPoll(pollMs);
+    }
+    const before = drawnLat(T0 + 5999);
+
+    deliverPoll(5000);
+
+    expect(drawnLat(T0 + 6000) - before).toBeCloseTo(
+      DEGREES_PER_SECOND / 1000,
+      12,
+    );
+  });
+
+  it("draws a new fix ahead of its raw coordinates, never back at them", () => {
+    // Why the old dating had to rewind: the coordinates a frame reports were
+    // measured before the poll that carried them, so they are already behind
+    // the projection running from the previous fix. Drawing them where they
+    // are read is the back-step; drawing them plus their own age is not.
+    for (const pollMs of [1000, 2000, 3000, 4000]) {
+      deliverPoll(pollMs);
+    }
+    const before = drawnLat(T0 + 5999);
+
+    deliverPoll(5000);
+
+    expect(rawLat()).toBeLessThan(before);
+    expect(drawnLat(T0 + 6000)).toBeGreaterThan(rawLat());
+    expect(drawnLat(T0 + 6000)).toBeGreaterThanOrEqual(before);
+  });
+
+  it("tracks the true position, lagged only by the transport it cannot see", () => {
+    // The strongest statement of the fix: at the moment each frame lands, the
+    // marker sits exactly where the aircraft was when the backend polled —
+    // every fix, whatever its decode age. Only the shared transport lag is
+    // left, and no arithmetic on this data could remove it.
+    for (const pollMs of POLL_TIMES_MS) {
+      const arrivesAt = deliverPoll(pollMs);
+      expect(drawnLat(arrivesAt)).toBeCloseTo(latAtTrue(pollMs), 9);
+    }
+  });
+
+  it("still freezes rather than rewinding when the stream dies mid-flight", () => {
+    // Slice 054's stall grace is untouched: it is measured from `receivedAt`,
+    // which back-dating does not move.
+    const arrivesAt = deliverPoll(1000);
+    const coasted = drawnLat(arrivesAt + 60_000);
+
+    expect(coasted).toBeGreaterThan(drawnLat(arrivesAt));
+    expect(drawnLat(arrivesAt + 600_000)).toBe(coasted);
   });
 });

--- a/frontend/src/features/map/aircraft/store/useLiveAircraftStore.test.ts
+++ b/frontend/src/features/map/aircraft/store/useLiveAircraftStore.test.ts
@@ -854,8 +854,11 @@ describe("positionChangedAt back-dating (issue #144)", () => {
 
   it("clamps an outlier age to the fix-age cap", () => {
     // Five minutes: the decoder reporting something the interpolator has long
-    // given up projecting. Clamped, so the anchor lands at the cap rather than
-    // minutes into the past.
+    // given up projecting. This pins the *stored field*, not a drawn position:
+    // `displayPosition` caps elapsed time at the same constant, so clamped or
+    // not the marker sits frozen at the bound either way. The point is that
+    // `positionChangedAt` keeps meaning what its name says for anyone reading
+    // it directly.
     snapshot({ seen_pos_s: 300 }, T0);
 
     expect(anchor()).toBe(T0 - INTERPOLATION_MAX_FIX_AGE_MS);

--- a/frontend/src/features/map/aircraft/store/useLiveAircraftStore.test.ts
+++ b/frontend/src/features/map/aircraft/store/useLiveAircraftStore.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
+import { INTERPOLATION_MAX_FIX_AGE_MS } from "@/features/map/aircraft/interpolation";
 import {
   REMOVAL_FADE_MS,
   useLiveAircraftStore,
 } from "@/features/map/aircraft/store/useLiveAircraftStore";
 import { TRACK_MAX_POINTS } from "@/features/map/aircraft/track";
+import type { LiveAircraft } from "@/lib/api/live";
 import { makeAircraft } from "@/test/liveAircraftFixtures";
 
 const T0 = 1_800_000_000_000;
@@ -639,7 +641,14 @@ describe("batching", () => {
 });
 
 describe("positionChangedAt", () => {
-  const AT = { icao: "aaaaaa", position: { lat: 47, lon: -122 } } as const;
+  // `seen_pos_s: 0` throughout: these cases are about *which* frame re-anchors,
+  // and pinning the reported age at zero keeps every expectation below the
+  // exact pre-#144 dating. Back-dating a nonzero age is the next block.
+  const AT = {
+    icao: "aaaaaa",
+    position: { lat: 47, lon: -122 },
+    seen_pos_s: 0,
+  } as const;
 
   function anchor(): number | undefined {
     return store().aircraft.aaaaaa?.positionChangedAt;
@@ -760,5 +769,125 @@ describe("positionChangedAt", () => {
     );
 
     expect(anchor()).toBe(T0 + 1000);
+  });
+});
+
+describe("positionChangedAt back-dating (issue #144)", () => {
+  const AT = { icao: "aaaaaa", position: { lat: 47, lon: -122 } } as const;
+  const MOVED = { ...AT, position: { lat: 47.01, lon: -122 } } as const;
+
+  function anchor(): number | undefined {
+    return store().aircraft.aaaaaa?.positionChangedAt;
+  }
+
+  function snapshot(overrides: Partial<LiveAircraft>, now: number): void {
+    store().applySnapshot(
+      { aircraft: [makeAircraft({ ...AT, ...overrides })], receiver: null },
+      now,
+    );
+  }
+
+  function delta(overrides: Partial<LiveAircraft>, now: number): void {
+    store().applyDelta(
+      {
+        updated: [makeAircraft({ ...AT, ...overrides })],
+        stale: [],
+        removed: [],
+      },
+      now,
+    );
+  }
+
+  it("dates a first fix at the age the decoder reports", () => {
+    // The frame landed at T0, but the CPR solution behind it is 3 s old.
+    snapshot({ seen_pos_s: 3 }, T0);
+
+    expect(anchor()).toBe(T0 - 3000);
+  });
+
+  it("dates a new fix on the delta path by the same rule", () => {
+    // Both application paths must date a position identically; a snapshot
+    // arriving mid-stream must not shift a marker the deltas were placing.
+    snapshot({ seen_pos_s: 0 }, T0);
+    delta({ ...MOVED, seen_pos_s: 2.5 }, T0 + 4000);
+
+    expect(anchor()).toBe(T0 + 1500);
+  });
+
+  it("dates the same fix identically whichever path delivers it", () => {
+    snapshot({ seen_pos_s: 0 }, T0);
+    delta({ ...MOVED, seen_pos_s: 2.5 }, T0 + 4000);
+    const viaDelta = anchor();
+
+    store().reset();
+    snapshot({ seen_pos_s: 0 }, T0);
+    snapshot({ ...MOVED, seen_pos_s: 2.5 }, T0 + 4000);
+
+    expect(anchor()).toBe(viaDelta);
+  });
+
+  it("falls back to the arrival instant when no age is reported", () => {
+    // §2.7 makes `null` the representation of "unknown"; without an age the
+    // arrival instant is the best available guess, exactly as before #144.
+    snapshot({ seen_pos_s: null }, T0);
+
+    expect(anchor()).toBe(T0);
+  });
+
+  it("dates a zero-age fix at the arrival instant", () => {
+    snapshot({ seen_pos_s: 0 }, T0);
+
+    expect(anchor()).toBe(T0);
+  });
+
+  it.each([
+    ["negative", -5],
+    ["not a number", Number.NaN],
+    ["infinite", Number.POSITIVE_INFINITY],
+  ])("falls back to the arrival instant for a %s age", (_label, seen) => {
+    // A nonsense age must not throw the anchor anywhere; under-projecting is
+    // the safe direction.
+    snapshot({ seen_pos_s: seen }, T0);
+
+    expect(anchor()).toBe(T0);
+  });
+
+  it("clamps an outlier age to the fix-age cap", () => {
+    // Five minutes: the decoder reporting something the interpolator has long
+    // given up projecting. Clamped, so the anchor lands at the cap rather than
+    // minutes into the past.
+    snapshot({ seen_pos_s: 300 }, T0);
+
+    expect(anchor()).toBe(T0 - INTERPOLATION_MAX_FIX_AGE_MS);
+  });
+
+  it("keeps the anchor when a repeated fix reports a growing age", () => {
+    // The aircraft has not been placed anywhere new, so the moment it was
+    // placed has not changed. The ages below outrun wall time — the decoder's
+    // age is sampled afresh each poll and need not track the gap between the
+    // frames that carry it — so re-dating each repeat would walk the anchor
+    // backwards frame by frame, which is #119 inverted.
+    snapshot({ seen_pos_s: 1 }, T0);
+    delta({ seen_pos_s: 2.5 }, T0 + 1000);
+    delta({ seen_pos_s: 4.5 }, T0 + 2000);
+    delta({ seen_pos_s: 12 }, T0 + 8000);
+
+    expect(anchor()).toBe(T0 - 1000);
+    expect(store().aircraft.aaaaaa?.receivedAt).toBe(T0 + 8000);
+  });
+
+  it("keeps the anchor when a snapshot repeats a fix with a growing age", () => {
+    snapshot({ seen_pos_s: 1 }, T0);
+    snapshot({ seen_pos_s: 9 }, T0 + 5000);
+
+    expect(anchor()).toBe(T0 - 1000);
+  });
+
+  it("re-dates only once the fix itself moves", () => {
+    snapshot({ seen_pos_s: 1 }, T0);
+    delta({ seen_pos_s: 6 }, T0 + 3000);
+    delta({ ...MOVED, seen_pos_s: 1 }, T0 + 4000);
+
+    expect(anchor()).toBe(T0 + 3000);
   });
 });

--- a/frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
+++ b/frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
@@ -39,9 +39,10 @@
  * *late*: the projection from fix N had already run past fix N+1's raw
  * coordinates by the time they were drawn, so each new fix stepped the marker
  * backwards before it crept forward again. {@link fixAnchor} instead dates a
- * new fix at `now - seen_pos_s`, the age the decoder itself reports (§3.3,
- * honest since slice 062) — the client-side mirror of that slice's server-side
- * ageing.
+ * new fix at `now - seen_pos_s * 1000` — the age the decoder itself reports
+ * (§3.3, honest since slice 062), in seconds, converted to the milliseconds
+ * these timestamps are kept in — the client-side mirror of that slice's
+ * server-side ageing.
  *
  * This keeps the #119 rule that only the browser's clock is read. `seen_pos_s`
  * is a *duration*, not an instant: subtracting it from a browser timestamp
@@ -232,15 +233,20 @@ function samePosition(previous: LiveAircraft, next: LiveAircraft): boolean {
 }
 
 /**
- * The most reported fix age this store will honour, in seconds.
+ * The most reported fix age this store will honour, in milliseconds.
  *
  * {@link INTERPOLATION_MAX_FIX_AGE_MS} is the natural bound and not a second
  * arbitrary number: it is the age past which the interpolator stops projecting
- * a fix at all, so back-dating further can only change how long the marker sits
- * frozen, never where it is drawn. Anything above it is a decoder reporting
- * something the map has already given up on — an aircraft heard for minutes
- * without a usable CPR pair, or a malformed age — and clamping keeps such a
- * value from throwing the anchor minutes into the past.
+ * a fix at all. Nothing rendered depends on the clamp, in fact —
+ * `displayPosition` caps elapsed time at the same constant, so an anchor five
+ * minutes in the past and one clamped to fifteen seconds draw the marker in
+ * exactly the same place, frozen at the bound, for as long as either survives.
+ * What the clamp buys is a `positionChangedAt` that still means what the field
+ * says it means: anything above the bound is a decoder reporting something the
+ * map has already given up on — an aircraft heard for minutes without a usable
+ * CPR pair, or a malformed age — and a stored anchor minutes adrift would be a
+ * trap for the next reader, and for anything that later measures fix age from
+ * this field rather than through the interpolator.
  */
 const MAX_REPORTED_FIX_AGE_MS = INTERPOLATION_MAX_FIX_AGE_MS;
 
@@ -248,11 +254,12 @@ const MAX_REPORTED_FIX_AGE_MS = INTERPOLATION_MAX_FIX_AGE_MS;
  * When the receiver fixed the position `entry` reports, on the browser's clock.
  *
  * The frame arrived at `now`, but the decoder says it placed the aircraft
- * `seen_pos_s` seconds earlier, so that is the anchor (issue #144). A missing,
- * negative or non-finite age falls back to `now`, which is exactly the pre-#144
- * behaviour: without a reported age the arrival instant is the best guess
- * available, and it is the conservative one — it under-projects rather than
- * inventing motion.
+ * `seen_pos_s` seconds earlier, so the anchor is `now - seen_pos_s * 1000`
+ * (issue #144) — the reported age is in seconds, `now` and the anchor in
+ * milliseconds. A missing, negative or non-finite age falls back to `now`,
+ * which is exactly the pre-#144 behaviour: without a reported age the arrival
+ * instant is the best guess available, and it is the conservative one — it
+ * under-projects rather than inventing motion.
  */
 function fixAnchor(entry: LiveAircraft, now: number): number {
   const reportedS = entry.seen_pos_s;

--- a/frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
+++ b/frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
@@ -20,20 +20,46 @@
  *
  * * `receivedAt` — when this object arrived. Dates the *data*: how long ago the
  *   client last heard anything at all about this aircraft.
- * * `positionChangedAt` — when the reported fix last actually moved. Dates the
- *   *position*, which is a different thing entirely, because the backend sends
- *   complete aircraft objects every frame: a delta carrying nothing but a new
- *   RSSI still repeats the last decoded position verbatim.
+ * * `positionChangedAt` — when the receiver *fixed* the position the record now
+ *   reports. Dates the *position*, which is a different thing entirely, because
+ *   the backend sends complete aircraft objects every frame: a delta carrying
+ *   nothing but a new RSSI still repeats the last decoded position verbatim.
  *
  * The interpolator dead-reckons from `positionChangedAt`. Anchoring it to
  * `receivedAt` was issue #119: distant aircraft decode a CPR position only
  * every 2-10 s while transmitting Mode S every second, so every intervening
  * delta reset elapsed time to zero and snapped the marker back to the stale
  * fix before it crept forward again.
+ *
+ * **A fix is already old when it arrives** — issue #144, the residual error
+ * #119's fix left behind. The decoder needs a CPR pair to place an aircraft, so
+ * the position in a frame was measured `seen_pos_s` seconds before the poll
+ * that read it, and the poll and the socket add their own second or two on top.
+ * Stamping the arrival instant therefore anchored every fix systematically
+ * *late*: the projection from fix N had already run past fix N+1's raw
+ * coordinates by the time they were drawn, so each new fix stepped the marker
+ * backwards before it crept forward again. {@link fixAnchor} instead dates a
+ * new fix at `now - seen_pos_s`, the age the decoder itself reports (§3.3,
+ * honest since slice 062) — the client-side mirror of that slice's server-side
+ * ageing.
+ *
+ * This keeps the #119 rule that only the browser's clock is read. `seen_pos_s`
+ * is a *duration*, not an instant: subtracting it from a browser timestamp
+ * never mixes the two clocks, so a receiver hours out of step with the browser
+ * changes nothing — the same skew-immunity argument slice 062 made in the other
+ * direction.
+ *
+ * A repeated fix is **not** re-dated, however far its reported age has grown
+ * since. The aircraft has not been placed anywhere new, so the anchor it
+ * already carries is still exactly when it was placed; letting an ageing
+ * `seen_pos_s` push the anchor backwards frame by frame would reintroduce #119
+ * inverted — the marker racing ahead of the fix and jerking back on each
+ * genuine decode. Only a position that actually changed takes a new anchor.
  */
 
 import { create } from "zustand";
 
+import { INTERPOLATION_MAX_FIX_AGE_MS } from "@/features/map/aircraft/interpolation";
 import type { SelectedTrack, TrackPoint } from "@/features/map/aircraft/track";
 import {
   appendTrackPoint,
@@ -48,9 +74,10 @@ export interface LiveAircraftRecord {
   aircraft: LiveAircraft;
   /** `Date.now()` when this object was applied. */
   receivedAt: number;
-  /** `Date.now()` when `aircraft.position` last changed — the moment the
-   * receiver placed the aircraft where the record now says it is. Carried
-   * forward unchanged by every frame that repeats the same fix. */
+  /** On the browser's clock, the moment the receiver placed the aircraft where
+   * the record now says it is: the arrival of the frame that first carried this
+   * fix, back-dated by the fix's own reported age (see {@link fixAnchor}).
+   * Carried forward unchanged by every frame that repeats the same fix. */
   positionChangedAt: number;
 }
 
@@ -204,8 +231,40 @@ function samePosition(previous: LiveAircraft, next: LiveAircraft): boolean {
   );
 }
 
+/**
+ * The most reported fix age this store will honour, in seconds.
+ *
+ * {@link INTERPOLATION_MAX_FIX_AGE_MS} is the natural bound and not a second
+ * arbitrary number: it is the age past which the interpolator stops projecting
+ * a fix at all, so back-dating further can only change how long the marker sits
+ * frozen, never where it is drawn. Anything above it is a decoder reporting
+ * something the map has already given up on — an aircraft heard for minutes
+ * without a usable CPR pair, or a malformed age — and clamping keeps such a
+ * value from throwing the anchor minutes into the past.
+ */
+const MAX_REPORTED_FIX_AGE_MS = INTERPOLATION_MAX_FIX_AGE_MS;
+
+/**
+ * When the receiver fixed the position `entry` reports, on the browser's clock.
+ *
+ * The frame arrived at `now`, but the decoder says it placed the aircraft
+ * `seen_pos_s` seconds earlier, so that is the anchor (issue #144). A missing,
+ * negative or non-finite age falls back to `now`, which is exactly the pre-#144
+ * behaviour: without a reported age the arrival instant is the best guess
+ * available, and it is the conservative one — it under-projects rather than
+ * inventing motion.
+ */
+function fixAnchor(entry: LiveAircraft, now: number): number {
+  const reportedS = entry.seen_pos_s;
+  if (reportedS === null || !Number.isFinite(reportedS) || reportedS <= 0) {
+    return now;
+  }
+  return now - Math.min(reportedS * 1000, MAX_REPORTED_FIX_AGE_MS);
+}
+
 /** The record for a freshly delivered aircraft object, inheriting the position
- * anchor from the record it replaces when the fix has not moved. */
+ * anchor from the record it replaces when the fix has not moved — a repeated
+ * fix keeps the anchor it was given, whatever its reported age has grown to. */
 function upsert(
   entry: LiveAircraft,
   previous: LiveAircraftRecord | undefined,
@@ -217,7 +276,7 @@ function upsert(
     positionChangedAt:
       previous && samePosition(previous.aircraft, entry)
         ? previous.positionChangedAt
-        : now,
+        : fixAnchor(entry, now),
   };
 }
 

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1619,6 +1619,45 @@ slices:
     risk_level: medium
     notes: "Owner measured 80 shown against 59 audible on the Pi at v0.2.0. Fixes GitHub issue #134. Added by Fable outside the phase plan."
 
+  - id: "064"
+    title: "Honest position-fix anchor"
+    phase: 8
+    branch: "064-fix-age-anchor"
+    status: merged
+    depends_on: ["054"]
+    objective: "Date each position fix by the age the decoder reports for it instead of by the instant the frame arrived, so dead reckoning hands over from one fix to the next without the periodic backwards step slice 054's fix left behind (issue #144)."
+    scope:
+      - "`useLiveAircraftStore` dates a *new* fix at `receivedAt - seen_pos_s * 1000`, clamped to `[0, INTERPOLATION_MAX_FIX_AGE_MS]`, falling back to `receivedAt` for a null, negative or non-finite reported age"
+      - "the same dating on both application paths, so a snapshot and a delta carrying one fix anchor it identically"
+      - "a repeated fix keeps the anchor it already has, however far its reported age has grown — an ageing `seen_pos_s` on an unchanged position must not walk the anchor backwards"
+      - "`INTERPOLATION_MAX_FIX_AGE_MS` doubles as the clamp: a fix older than the interpolator will project cannot be back-dated further than that bound"
+      - "the `interpolation.ts` and store module docstrings record the dating scheme, why the projection is now continuous across fixes for straight flight (the shared transport latency cancels; only the decode age differs between fixes), and why the correction blend declined in 054 stays declined now that its premise holds"
+    out_of_scope:
+      - "backend changes: `seen_pos_s` is already served (§3.3) and already honest since slice 062"
+      - "a correction blend or any other change to `displayPosition`, its two bounds, or the stall-grace path, all unchanged"
+      - "reading the receiver's clock: the #119 rule stands, and a reported *duration* subtracted from a browser timestamp mixes no clocks"
+      - "the track layer, the detail panel, and every other consumer of the reported position, which read the payload rather than the projection"
+    acceptance_criteria:
+      - "a distant aircraft on a 2-10 s CPR cadence with nonzero `seen_pos_s` draws a continuous path: the projection either side of a new fix's arrival differs by the sampling interval's travel and no more"
+      - "at the moment a frame lands the marker sits where the aircraft was when the backend polled, leaving only the shared transport lag no client-side arithmetic could remove"
+      - "an aircraft reporting `seen_pos_s` null or 0 behaves bit-for-bit as before the slice"
+      - "an outlier reported age is clamped to the fix-age bound rather than throwing the anchor minutes into the past"
+      - "frames repeating a fix with a growing reported age leave the anchor untouched"
+      - "no regression in the slice-054 stall and staleness freezes"
+    required_tests:
+      - store tests for back-dating on the snapshot and delta paths, their agreement on one fix, and the null/zero/negative/NaN/infinite fallbacks
+      - store tests for the outlier clamp and for repeated fixes with growing reported ages on both paths
+      - regression tests driving the store with modelled decode ages and a constant transport lag - no back-step across the sequence, no step at the fix handover, a new fix drawn ahead of its raw coordinates, and the drawn path tracking truth lagged only by transport
+      - the existing #119 scenario re-pinned at `seen_pos_s: 0` so its expectations stay the pre-slice ones exactly
+    expected_artifacts:
+      - frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
+      - frontend/src/features/map/aircraft/interpolation.ts
+      - frontend/src/features/map/aircraft/snapback.regression.test.ts
+      - frontend/src/features/map/aircraft/store/useLiveAircraftStore.test.ts
+    preferred_agent: opus
+    risk_level: low
+    notes: "Owner reported markers still oscillating on the Pi at v0.3.0. Fixes GitHub issue #144, the residual systematic term slice 054's no-correction-blend rationale underestimated. Frontend-only, client-side mirror of slice 062's server-side ageing. Added by Fable outside the phase plan."
+
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,
 # 027, 031, 033, 035, 037, 038, 052) are ADDITIONALLY serialized against each other


### PR DESCRIPTION
Slice 064 — closes #144.

Aircraft markers oscillated forward/back: `positionChangedAt` was stamped at frame arrival, but a fix is already `seen_pos` old when it arrives (CPR decode age up to ~10 s for distant aircraft, plus poll/WS transport). Dead reckoning from a late anchor made every projection overrun the next fix, stepping the marker backwards on each decode.

- New fixes are dated `arrival − clamp(seen_pos_s·1000, 0, 15 s)` in the single `upsert` funnel both snapshot and delta paths share; null/zero/invalid ages fall back to arrival (bit-for-bit today's behavior, pinned).
- Repeated fixes keep their anchor as reported age grows (re-dating repeats would be #119 inverted).
- Continuity result (reviewer-verified algebraically): consecutive projections coincide at handover for straight flight — the shared transport latency cancels — so the back-step disappears rather than being smoothed over. Slice 054's declined correction blend stays declined, now on true premises.
- Browser-clock-only rule preserved: a relative age subtracted from a browser timestamp mixes no clocks (mirror of slice 062's server-side argument).

Adversarial review verdict: MERGE (regression tests hand-verified to fail on the old code; no other consumer of the timestamp). Review findings F3/F4 (track-point dating conventions) filed as #145.

17 new tests (1667 total green); lint/typecheck/format:check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTAJUucu2ZPAD235B3GQeZ