### PR TITLE
fix(map): stop aircraft labels blinking — density hysteresis and relocate-before-hide (slice 063)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -143,6 +143,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 060 | Raspberry Pi 4 performance baseline | 049, 050 | opus | low | Record the first Pi 4 baseline in docs/PERFORMANCE.md §5.4 and defer §5.3 promotion to the pending clean re-run (issues #101, #132) |
 | 061 | Selected aircraft track backfill | 014, 052 | opus | low | Backfill the selected aircraft's track from its open sighting so a click draws the whole current sighting, not just what arrives after it (issue #133) |
 | 062 | Live-set ghost expiry | 007, 008, 009 | opus | medium | Age live records by the decoder's own "last heard" report so dump1090's ~5-minute retention window stops inflating the live count and the 15 s / 60 s thresholds fire on time (issue #134) |
+| 063 | Aircraft label stability | 014, 015 | opus | low | Stop aircraft labels blinking: a hysteresis band on the density tier, and variable anchoring so a colliding label relocates before it hides (issue #143) |
 
 ## Parallelization Guide
 

--- a/frontend/src/features/map/aircraft/AircraftLayer.test.tsx
+++ b/frontend/src/features/map/aircraft/AircraftLayer.test.tsx
@@ -10,7 +10,7 @@ import { getDefaultBasemap } from "@/features/map/basemaps";
 import { DEV_PLACEHOLDER_MAP_CONFIG } from "@/features/map/mapConfig";
 import { MapLibreMap } from "@/features/map/MapLibreMap";
 import {
-  DENSITY_CALLSIGN_THRESHOLD,
+  DENSITY_CALLSIGN_ENTER,
   ZOOM_LABELS_FULL,
   ZOOM_LABELS_MIN,
 } from "@/features/map/labels/priority";
@@ -134,7 +134,7 @@ describe("AircraftLayer label integration", () => {
     map.zoom = ZOOM_LABELS_FULL;
 
     const crowd = Array.from(
-      { length: DENSITY_CALLSIGN_THRESHOLD + 5 },
+      { length: DENSITY_CALLSIGN_ENTER + 5 },
       (_, index) =>
         makeAircraft({
           icao: (index + 1).toString(16).padStart(6, "0"),

--- a/frontend/src/features/map/aircraft/aircraftLayers.test.ts
+++ b/frontend/src/features/map/aircraft/aircraftLayers.test.ts
@@ -233,6 +233,10 @@ describe("ensureAircraftLayers", () => {
     expect(layout["text-anchor"]).toBeUndefined();
     expect(layout["text-offset"]).toBeUndefined();
     expect(layout["text-radial-offset"]).toEqual(expect.any(Number));
+    // Justification has to follow the anchor that won. At MapLibre's default
+    // of "center", a multi-line label relocated to the left or right anchor
+    // stays centre-justified and turns a ragged edge toward its own aircraft.
+    expect(layout["text-justify"]).toBe("auto");
   });
 
   it("keeps the selected label on a fixed anchor, never a variable one", () => {
@@ -246,6 +250,9 @@ describe("ensureAircraftLayers", () => {
     expect(layout["text-radial-offset"]).toBeUndefined();
     expect(layout["text-anchor"]).toBe("top");
     expect(layout["text-offset"]).toEqual([0, 1]);
+    // "auto" justification only means anything under variable anchoring, and
+    // this layer has none — so it stays off rather than riding along.
+    expect(layout["text-justify"]).toBeUndefined();
   });
 
   it("prioritizes interesting aircraft over ordinary ones in the label collision order", () => {

--- a/frontend/src/features/map/aircraft/aircraftLayers.test.ts
+++ b/frontend/src/features/map/aircraft/aircraftLayers.test.ts
@@ -213,6 +213,41 @@ describe("ensureAircraftLayers", () => {
     expect(selected["text-ignore-placement"]).toBe(true);
   });
 
+  it("lets an ordinary label try other placements before it is hidden", () => {
+    // Issue #143's second mechanism: with one fixed anchor, a label that
+    // loses the collision contest blinks out entirely. Variable anchoring
+    // makes hiding the last resort rather than the first response.
+    ensureAircraftLayers(map);
+    const layout = mock.layers.get(AIRCRAFT_LABEL_LAYER_ID)?.layout as Record<
+      string,
+      unknown
+    >;
+    const anchors = layout["text-variable-anchor"] as string[];
+    expect(anchors.length).toBeGreaterThan(1);
+    // "top" first keeps the uncontested placement exactly where it was.
+    expect(anchors[0]).toBe("top");
+    expect(new Set(anchors).size).toBe(anchors.length);
+    // MapLibre ignores both of these once text-variable-anchor is set, so
+    // leaving either behind would be dead configuration that reads as if it
+    // still placed the label.
+    expect(layout["text-anchor"]).toBeUndefined();
+    expect(layout["text-offset"]).toBeUndefined();
+    expect(layout["text-radial-offset"]).toEqual(expect.any(Number));
+  });
+
+  it("keeps the selected label on a fixed anchor, never a variable one", () => {
+    // The selected label must not wander around its aircraft either — the
+    // fixed pair is what pins it under the icon, and it can never collide
+    // away, so it has nothing to relocate for.
+    ensureAircraftLayers(map);
+    const layout = mock.layers.get(AIRCRAFT_SELECTED_LABEL_LAYER_ID)
+      ?.layout as Record<string, unknown>;
+    expect(layout["text-variable-anchor"]).toBeUndefined();
+    expect(layout["text-radial-offset"]).toBeUndefined();
+    expect(layout["text-anchor"]).toBe("top");
+    expect(layout["text-offset"]).toEqual([0, 1]);
+  });
+
   it("prioritizes interesting aircraft over ordinary ones in the label collision order", () => {
     ensureAircraftLayers(map);
     const layout = mock.layers.get(AIRCRAFT_LABEL_LAYER_ID)?.layout as Record<

--- a/frontend/src/features/map/aircraft/aircraftLayers.ts
+++ b/frontend/src/features/map/aircraft/aircraftLayers.ts
@@ -21,9 +21,11 @@
  *    position source is distinguishable without relying on colour (SPEC §36);
  * 5. the aircraft symbols themselves, rotated to `track_deg`;
  * 6. non-selected aircraft labels — `text-allow-overlap: false`, so
- *    MapLibre's own collision system hides whichever labels lose the
- *    `symbol-sort-key` contest (roadmap slice 015: "MapLibre's own collision
- *    system plus zoom/density-driven tiering");
+ *    MapLibre's own collision system arbitrates, in `symbol-sort-key` order
+ *    (roadmap slice 015: "MapLibre's own collision system plus
+ *    zoom/density-driven tiering"). A label that loses the contest first
+ *    tries the other placements in `text-variable-anchor` (issue #143) and
+ *    is only hidden when none of them fits;
  * 7. the selected aircraft's label — its own layer because
  *    `text-allow-overlap`/`text-ignore-placement` are layer-level, not
  *    data-driven, and the selected label must never be the one collision
@@ -78,6 +80,44 @@ const SELECTION_COLOR = "#8ab4ff";
 const LABEL_TEXT_COLOR = "#f2f6ff";
 const LABEL_HALO_COLOR = "#0b1220";
 const LABEL_HALO_WIDTH = 1.2;
+
+/**
+ * Placements MapLibre tries, in order, for a non-selected label before it
+ * gives up and hides it (issue #143).
+ *
+ * `text-variable-anchor` is the whole fix for the second half of that issue:
+ * with a single fixed anchor, a label that loses the collision contest is
+ * simply not drawn, so two aircraft converging make one label blink out and
+ * back as the gap opens and closes. With a candidate list, MapLibre walks it
+ * and draws the first placement that fits — the label steps around its
+ * aircraft instead of vanishing. Hiding still happens when *no* candidate
+ * fits, which is the behaviour slice 015 wanted; it is now the last resort
+ * rather than the first response.
+ *
+ * `"top"` leads deliberately: it reproduces the fixed placement this layer
+ * used before (label below the icon, reading downward), so an uncontested
+ * label sits exactly where it always did and only a contested one moves.
+ * `"bottom"` next — the opposite side is the largest free area when a
+ * neighbour is crowding from one direction — then the two horizontal
+ * placements.
+ *
+ * MapLibre note: `text-anchor` and `text-offset` are both *ignored* on a
+ * layer with `text-variable-anchor`, which is why this layer sets neither and
+ * uses {@link LABEL_RADIAL_OFFSET} instead. The selected-label layer keeps
+ * the fixed anchor/offset pair precisely because it must never move.
+ */
+const LABEL_VARIABLE_ANCHORS: ("top" | "bottom" | "right" | "left")[] = [
+  "top",
+  "bottom",
+  "right",
+  "left",
+];
+
+/** Distance from the aircraft to its label, in ems, for every candidate
+ * anchor. Matches the magnitude of the fixed `text-offset: [0, 1]` the
+ * selected-label layer still uses, so the two layers place their labels the
+ * same distance out and a selection does not visibly nudge its own label. */
+const LABEL_RADIAL_OFFSET = 1;
 
 /**
  * The attention ring's severity palette (SPEC §36 "interesting/alerting:
@@ -348,11 +388,16 @@ export function ensureAircraftLayers(map: MapLibreGlMap): void {
       layout: {
         "text-field": ["get", "label"],
         "text-size": 11,
-        "text-anchor": "top",
-        "text-offset": [0, 1],
+        // Placement is variable, not fixed: see LABEL_VARIABLE_ANCHORS.
+        // `text-anchor`/`text-offset` are deliberately absent — MapLibre
+        // ignores both once `text-variable-anchor` is set, so leaving them
+        // in would read as configuration that does nothing.
+        "text-variable-anchor": LABEL_VARIABLE_ANCHORS,
+        "text-radial-offset": LABEL_RADIAL_OFFSET,
         "text-line-height": 1.15,
-        // MapLibre's own collision system: a label that loses the
-        // placement contest is hidden rather than drawn over its neighbour.
+        // MapLibre's own collision system: a label that fits none of the
+        // candidate placements is hidden rather than drawn over its
+        // neighbour.
         "text-allow-overlap": false,
         "text-optional": true,
         // Interesting aircraft win a collision against an ordinary one;

--- a/frontend/src/features/map/aircraft/aircraftLayers.ts
+++ b/frontend/src/features/map/aircraft/aircraftLayers.ts
@@ -105,6 +105,14 @@ const LABEL_HALO_WIDTH = 1.2;
  * layer with `text-variable-anchor`, which is why this layer sets neither and
  * uses {@link LABEL_RADIAL_OFFSET} instead. The selected-label layer keeps
  * the fixed anchor/offset pair precisely because it must never move.
+ *
+ * The layer pairs this with `text-justify: "auto"`, which is only meaningful
+ * under variable anchoring: at the default `center`, a multi-line label that
+ * relocates to the `left` or `right` anchor stays centre-justified, leaving a
+ * ragged inner edge facing the aircraft it belongs to. `auto` derives the
+ * justification from whichever anchor won, so a right-placed label is
+ * left-justified against the icon and a left-placed one right-justified — the
+ * text keeps a straight edge pointing at its aircraft however it moved.
  */
 const LABEL_VARIABLE_ANCHORS: ("top" | "bottom" | "right" | "left")[] = [
   "top",
@@ -394,6 +402,9 @@ export function ensureAircraftLayers(map: MapLibreGlMap): void {
         // in would read as configuration that does nothing.
         "text-variable-anchor": LABEL_VARIABLE_ANCHORS,
         "text-radial-offset": LABEL_RADIAL_OFFSET,
+        // Justify from the anchor that actually won, so a relocated
+        // multi-line label keeps a straight edge facing its aircraft.
+        "text-justify": "auto",
         "text-line-height": 1.15,
         // MapLibre's own collision system: a label that fits none of the
         // candidate placements is hidden rather than drawn over its

--- a/frontend/src/features/map/aircraft/frame.test.ts
+++ b/frontend/src/features/map/aircraft/frame.test.ts
@@ -13,22 +13,46 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { resetFilteredLiveAircraftCache } from "@/features/filters/lib/filteredLiveAircraftCache";
 import { DEFAULT_FILTERS } from "@/features/filters/types";
 import { drawAircraftFrame } from "@/features/map/aircraft/frame";
+import { resetDensityLatch } from "@/features/map/labels/densityLatch";
+import {
+  DENSITY_CALLSIGN_ENTER,
+  DENSITY_CALLSIGN_EXIT,
+} from "@/features/map/labels/priority";
 import { makeAircraft } from "@/test/liveAircraftFixtures";
+
+interface DrawnFeature {
+  properties: { label: string };
+}
 
 function fakeMap(): {
   map: MapLibreGlMap;
   dataByFeatureCount: () => number;
+  firstLabel: () => string | undefined;
 } {
-  let lastData: { features?: unknown[] } = { features: [] };
+  let lastData: { features?: DrawnFeature[] } = { features: [] };
   const map = {
     getSource: () => ({
-      setData: (data: { features?: unknown[] }) => {
+      setData: (data: { features?: DrawnFeature[] }) => {
         lastData = data;
       },
     }),
     getZoom: () => 10,
   } as unknown as MapLibreGlMap;
-  return { map, dataByFeatureCount: () => lastData.features?.length ?? 0 };
+  return {
+    map,
+    dataByFeatureCount: () => lastData.features?.length ?? 0,
+    firstLabel: () => lastData.features?.[0]?.properties.label,
+  };
+}
+
+/** `count` distinct positioned aircraft, all inside the default radius. */
+function crowd(count: number): ReturnType<typeof makeAircraft>[] {
+  return Array.from({ length: count }, (_, index) =>
+    makeAircraft({
+      icao: index.toString(16).padStart(6, "0"),
+      callsign: `AA${index}`,
+    }),
+  );
 }
 
 function state(aircraftList: ReturnType<typeof makeAircraft>[]) {
@@ -52,6 +76,7 @@ function state(aircraftList: ReturnType<typeof makeAircraft>[]) {
 
 beforeEach(() => {
   resetFilteredLiveAircraftCache();
+  resetDensityLatch();
 });
 
 describe("drawAircraftFrame filtering", () => {
@@ -101,5 +126,52 @@ describe("drawAircraftFrame filtering", () => {
       { filters: { ...DEFAULT_FILTERS, groundTraffic: "hide" } },
     );
     expect(dataByFeatureCount()).toBe(1);
+  });
+});
+
+describe("drawAircraftFrame label-density hysteresis", () => {
+  // Issue #143: the frame loop is what turns the pure band into a latch, so
+  // the sequence of frames — not any one of them — is the behaviour.
+  const FULL = "AA0\nFL310";
+  const CALLSIGN_ONLY = "AA0";
+
+  it("keeps the full stack while a rising count is still inside the band", () => {
+    const { map, firstLabel } = fakeMap();
+    drawAircraftFrame(map, state(crowd(DENSITY_CALLSIGN_EXIT + 1)), 0);
+    expect(firstLabel()).toBe(FULL);
+    drawAircraftFrame(map, state(crowd(DENSITY_CALLSIGN_ENTER)), 0);
+    expect(firstLabel()).toBe(FULL);
+  });
+
+  it("stays on callsign-only once latched, until the count clears the lower edge", () => {
+    const { map, firstLabel } = fakeMap();
+    // Above the upper edge: latch on.
+    drawAircraftFrame(map, state(crowd(DENSITY_CALLSIGN_ENTER + 1)), 0);
+    expect(firstLabel()).toBe(CALLSIGN_ONLY);
+
+    // Back inside the band — the flapping that produced the blink. The
+    // label content must not move.
+    for (const count of [
+      DENSITY_CALLSIGN_ENTER - 1,
+      DENSITY_CALLSIGN_ENTER + 1,
+      DENSITY_CALLSIGN_EXIT + 1,
+      DENSITY_CALLSIGN_ENTER,
+    ]) {
+      drawAircraftFrame(map, state(crowd(count)), 0);
+      expect(firstLabel()).toBe(CALLSIGN_ONLY);
+    }
+
+    // Below the lower edge: the picture really has thinned out.
+    drawAircraftFrame(map, state(crowd(DENSITY_CALLSIGN_EXIT - 1)), 0);
+    expect(firstLabel()).toBe(FULL);
+  });
+
+  it("unlatches once the picture empties, so a reconnect starts fresh", () => {
+    const { map, firstLabel } = fakeMap();
+    drawAircraftFrame(map, state(crowd(DENSITY_CALLSIGN_ENTER + 1)), 0);
+    expect(firstLabel()).toBe(CALLSIGN_ONLY);
+    drawAircraftFrame(map, state([]), 0);
+    drawAircraftFrame(map, state(crowd(DENSITY_CALLSIGN_ENTER)), 0);
+    expect(firstLabel()).toBe(FULL);
   });
 });

--- a/frontend/src/features/map/aircraft/frame.ts
+++ b/frontend/src/features/map/aircraft/frame.ts
@@ -22,6 +22,7 @@ import type {
   LiveAircraftRecord,
 } from "@/features/map/aircraft/store/useLiveAircraftStore";
 import type { SelectedTrack } from "@/features/map/aircraft/track";
+import { updateDensityLatch } from "@/features/map/labels/densityLatch";
 import { DEFAULT_DISPLAY_RADIUS_NM } from "@/features/map/mapConfig";
 import { getFilteredLiveAircraft } from "@/features/filters/lib/filteredLiveAircraftCache";
 import { DEFAULT_FILTERS, type LiveFilters } from "@/features/filters/types";
@@ -76,6 +77,11 @@ export function drawAircraftFrame(
       zoom: map.getZoom(),
       visibleIcaos: filterResult.visibleIcaos,
       dimmedIcaos: filterResult.dimmedIcaos,
+      // The frame loop is the one caller that draws a *sequence*, so it is
+      // the one that owns the label-density latch (issue #143). Advancing it
+      // here — once per frame, on the same post-filter count `geojson.ts`
+      // would have derived — keeps the builder itself pure.
+      densityLatched: updateDensityLatch(filterResult.visibleIcaos.size),
     }),
   );
   if (options.includeTrack) {

--- a/frontend/src/features/map/aircraft/geojson.test.ts
+++ b/frontend/src/features/map/aircraft/geojson.test.ts
@@ -14,7 +14,7 @@ import type {
 } from "@/features/map/aircraft/store/useLiveAircraftStore";
 import { REMOVAL_FADE_MS } from "@/features/map/aircraft/store/useLiveAircraftStore";
 import {
-  DENSITY_CALLSIGN_THRESHOLD,
+  DENSITY_CALLSIGN_ENTER,
   ZOOM_LABELS_FULL,
   ZOOM_LABELS_MIN,
 } from "@/features/map/labels/priority";
@@ -329,7 +329,7 @@ describe("buildAircraftFeatureCollection", () => {
 
     it("drops a non-priority label to callsign-only when the live picture is dense, even at high zoom", () => {
       const dense = records(
-        ...Array.from({ length: DENSITY_CALLSIGN_THRESHOLD + 1 }, (_, i) => ({
+        ...Array.from({ length: DENSITY_CALLSIGN_ENTER + 1 }, (_, i) => ({
           icao: i.toString(16).padStart(6, "0"),
           callsign: `AA${i}`,
           altitude_ft: 35000,
@@ -340,6 +340,46 @@ describe("buildAircraftFeatureCollection", () => {
       );
       for (const feature of collection.features) {
         expect(feature.properties.label).toBe(feature.properties.callsign);
+      }
+    });
+
+    it("honours a caller-supplied density latch over this frame's own count", () => {
+      // The hysteresis band (issue #143) lives with the frame loop, so a
+      // sparse frame drawn while the latch is still held must stay on the
+      // callsign-only tier rather than snapping back to the full stack.
+      const collection = buildAircraftFeatureCollection(
+        input({
+          aircraft: records({
+            icao: "aaaaaa",
+            callsign: "BAW123",
+            altitude_ft: 35000,
+          }),
+          zoom: ZOOM_LABELS_FULL,
+          densityLatched: true,
+        }),
+      );
+      expect(collection.features[0]?.properties.label).toBe("BAW123");
+    });
+
+    it("honours a cleared density latch over a count that is inside the band", () => {
+      const inBand = records(
+        ...Array.from({ length: DENSITY_CALLSIGN_ENTER }, (_, i) => ({
+          icao: i.toString(16).padStart(6, "0"),
+          callsign: `AA${i}`,
+          altitude_ft: 35000,
+        })),
+      );
+      const collection = buildAircraftFeatureCollection(
+        input({
+          aircraft: inBand,
+          zoom: ZOOM_LABELS_FULL,
+          densityLatched: false,
+        }),
+      );
+      for (const feature of collection.features) {
+        expect(feature.properties.label).toBe(
+          `${feature.properties.callsign}\nFL350`,
+        );
       }
     });
 
@@ -366,7 +406,7 @@ describe("buildAircraftFeatureCollection", () => {
           altitude_ft: 35000,
           interesting: { severity: "high", reasons: ["test"] },
         },
-        ...Array.from({ length: DENSITY_CALLSIGN_THRESHOLD }, (_, i) => ({
+        ...Array.from({ length: DENSITY_CALLSIGN_ENTER }, (_, i) => ({
           icao: (i + 1).toString(16).padStart(6, "0"),
           callsign: `AA${i}`,
         })),
@@ -486,7 +526,7 @@ describe("filtering (features/filters integration)", () => {
     // aircraft is entitled to, not the callsign-only tier a genuinely
     // crowded sky would force.
     const crowd = records(
-      ...Array.from({ length: DENSITY_CALLSIGN_THRESHOLD + 5 }, (_, i) => ({
+      ...Array.from({ length: DENSITY_CALLSIGN_ENTER + 5 }, (_, i) => ({
         icao: (i + 1).toString(16).padStart(6, "0"),
         callsign: `AA${i}`,
         altitude_ft: 35000,

--- a/frontend/src/features/map/aircraft/geojson.ts
+++ b/frontend/src/features/map/aircraft/geojson.ts
@@ -30,6 +30,7 @@ import {
 } from "@/features/map/labels/labelContent";
 import {
   deriveLabelTier,
+  nextDensityLatched,
   ZOOM_LABELS_FULL,
 } from "@/features/map/labels/priority";
 
@@ -112,6 +113,17 @@ export interface AircraftFrameInput {
   /** Subset of `visibleIcaos` that should render de-emphasized rather
    * than at full strength — the ground-traffic filter's "dim" mode. */
   dimmedIcaos?: ReadonlySet<string>;
+  /**
+   * Whether the label-density override is currently latched on
+   * (`labels/densityLatch.ts`), carried in because the hysteresis band that
+   * decides it (issue #143) needs to know what the *previous* frame chose,
+   * and this builder is pure.
+   *
+   * `undefined` means "no history": the frame is judged on its own count
+   * alone, which is exactly right for a one-off caller — and for every test
+   * that hands over a picture without drawing a sequence.
+   */
+  densityLatched?: boolean;
 }
 
 function feature(
@@ -154,6 +166,9 @@ export function buildAircraftFeatureCollection(
   const liveCount = visibleIcaos
     ? visibleIcaos.size
     : Object.keys(aircraft).length;
+  // One decision for the whole frame, resolved once rather than per feature.
+  const densityLatched =
+    input.densityLatched ?? nextDensityLatched(false, liveCount);
 
   for (const icao in aircraft) {
     const record = aircraft[icao];
@@ -174,7 +189,7 @@ export function buildAircraftFeatureCollection(
     const interesting = view.interesting !== null;
     const tier = deriveLabelTier({
       zoom,
-      liveCount,
+      densityLatched,
       priority: selected || interesting,
     });
     features.push(

--- a/frontend/src/features/map/aircraft/useLiveConnection.ts
+++ b/frontend/src/features/map/aircraft/useLiveConnection.ts
@@ -26,6 +26,7 @@ import { useEffect } from "react";
 
 import { useActivityFeedStore } from "@/features/activity/store/useActivityFeedStore";
 import { useLiveAircraftStore } from "@/features/map/aircraft/store/useLiveAircraftStore";
+import { resetDensityLatch } from "@/features/map/labels/densityLatch";
 import { dispatchAlertNotification } from "@/features/notifications/lib/dispatch";
 import { LiveSocket } from "@/lib/ws/liveSocket";
 
@@ -58,6 +59,12 @@ export function useLiveConnection(): void {
       socket.stop();
       store().reset();
       activity().reset();
+      // The label-density latch (issue #143) is memory *about* the picture
+      // the store just dropped, so it is cleared with it. It would clear
+      // itself on the next drawn frame anyway — an empty picture is a count
+      // of zero — but a remount should not have to spend a frame in the
+      // dead connection's tier to get there.
+      resetDensityLatch();
     };
   }, []);
 }

--- a/frontend/src/features/map/labels/densityLatch.test.ts
+++ b/frontend/src/features/map/labels/densityLatch.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  resetDensityLatch,
+  updateDensityLatch,
+} from "@/features/map/labels/densityLatch";
+import {
+  DENSITY_CALLSIGN_ENTER,
+  DENSITY_CALLSIGN_EXIT,
+} from "@/features/map/labels/priority";
+
+afterEach(() => {
+  resetDensityLatch();
+});
+
+describe("updateDensityLatch", () => {
+  it("starts unlatched", () => {
+    expect(updateDensityLatch(DENSITY_CALLSIGN_ENTER)).toBe(false);
+  });
+
+  it("carries the latch across calls, which is the whole point of it", () => {
+    expect(updateDensityLatch(DENSITY_CALLSIGN_ENTER + 1)).toBe(true);
+    expect(updateDensityLatch(DENSITY_CALLSIGN_EXIT + 1)).toBe(true);
+    expect(updateDensityLatch(DENSITY_CALLSIGN_EXIT - 1)).toBe(false);
+    expect(updateDensityLatch(DENSITY_CALLSIGN_EXIT + 1)).toBe(false);
+  });
+});
+
+describe("resetDensityLatch", () => {
+  it("drops a held latch so the next frame is judged with no history", () => {
+    expect(updateDensityLatch(DENSITY_CALLSIGN_ENTER + 1)).toBe(true);
+    resetDensityLatch();
+    expect(updateDensityLatch(DENSITY_CALLSIGN_ENTER)).toBe(false);
+  });
+});

--- a/frontend/src/features/map/labels/densityLatch.ts
+++ b/frontend/src/features/map/labels/densityLatch.ts
@@ -1,0 +1,40 @@
+/**
+ * The one piece of memory the label tiering needs (issue #143).
+ *
+ * `labels/priority.ts` decides the density tier from a *latch* rather than
+ * from a bare count, so a live picture hovering on the threshold cannot
+ * toggle the altitude line on and off every frame. Something has to remember
+ * which side of the band the last frame landed on, and this module is that
+ * something — deliberately the smallest possible amount of state, kept out of
+ * both the pure tier function and the pure GeoJSON builder.
+ *
+ * Module-level rather than per-map, the same shape (and for the same reason)
+ * as `features/filters/lib/filteredLiveAircraftCache`: the frame loop is a
+ * single imperative path with no instance to hang state off, there is exactly
+ * one live picture per tab, and a `let` here is a great deal cheaper than
+ * threading a mutable box through `drawAircraftFrame` on every tick.
+ *
+ * It self-clears without help — an empty picture is a count of zero, which is
+ * below the band's lower edge — so a store reset already unlatches on the
+ * next drawn frame. {@link resetDensityLatch} exists so teardown does not
+ * have to *wait* for that frame (`useLiveConnection` calls it alongside the
+ * stores' own resets), and so one test's dense picture can never leak into
+ * the next test's sparse one.
+ */
+
+import { nextDensityLatched } from "@/features/map/labels/priority";
+
+let latched = false;
+
+/** Advances the latch with this frame's live count and returns the new state
+ * — what `deriveLabelTier` takes as `densityLatched`. */
+export function updateDensityLatch(liveCount: number): boolean {
+  latched = nextDensityLatched(latched, liveCount);
+  return latched;
+}
+
+/** Drops the latch back to "not dense", so the next frame is judged with no
+ * history behind it. */
+export function resetDensityLatch(): void {
+  latched = false;
+}

--- a/frontend/src/features/map/labels/priority.test.ts
+++ b/frontend/src/features/map/labels/priority.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  DENSITY_CALLSIGN_THRESHOLD,
+  DENSITY_CALLSIGN_ENTER,
+  DENSITY_CALLSIGN_EXIT,
   deriveLabelSortKey,
   deriveLabelTier,
+  nextDensityLatched,
   SORT_KEY_DEFAULT,
   SORT_KEY_INTERESTING,
   SORT_KEY_SELECTED,
@@ -16,7 +18,7 @@ describe("deriveLabelTier", () => {
     expect(
       deriveLabelTier({
         zoom: ZOOM_LABELS_MIN - 0.1,
-        liveCount: 1,
+        densityLatched: false,
         priority: false,
       }),
     ).toBe("none");
@@ -24,12 +26,16 @@ describe("deriveLabelTier", () => {
 
   it("shows callsign only from the minimum zoom up to (not including) the full-label zoom", () => {
     expect(
-      deriveLabelTier({ zoom: ZOOM_LABELS_MIN, liveCount: 1, priority: false }),
+      deriveLabelTier({
+        zoom: ZOOM_LABELS_MIN,
+        densityLatched: false,
+        priority: false,
+      }),
     ).toBe("callsign");
     expect(
       deriveLabelTier({
         zoom: ZOOM_LABELS_FULL - 0.1,
-        liveCount: 1,
+        densityLatched: false,
         priority: false,
       }),
     ).toBe("callsign");
@@ -39,50 +45,102 @@ describe("deriveLabelTier", () => {
     expect(
       deriveLabelTier({
         zoom: ZOOM_LABELS_FULL,
-        liveCount: 1,
+        densityLatched: false,
         priority: false,
       }),
     ).toBe("full");
   });
 
-  it("drops to callsign-only once the live count exceeds the density threshold, even above the full-label zoom", () => {
+  it("drops to callsign-only while the density latch is on, even above the full-label zoom", () => {
     expect(
       deriveLabelTier({
         zoom: ZOOM_LABELS_FULL,
-        liveCount: DENSITY_CALLSIGN_THRESHOLD,
-        priority: false,
-      }),
-    ).toBe("full");
-    expect(
-      deriveLabelTier({
-        zoom: ZOOM_LABELS_FULL,
-        liveCount: DENSITY_CALLSIGN_THRESHOLD + 1,
+        densityLatched: true,
         priority: false,
       }),
     ).toBe("callsign");
   });
 
-  it("never lets density push a label all the way to none", () => {
+  it("still hides a latched label below the minimum zoom — zoom wins over density", () => {
     expect(
       deriveLabelTier({
-        zoom: ZOOM_LABELS_FULL,
-        liveCount: 100_000,
+        zoom: ZOOM_LABELS_MIN - 0.1,
+        densityLatched: true,
         priority: false,
       }),
-    ).toBe("callsign");
+    ).toBe("none");
   });
 
   it("always returns full for a priority aircraft, regardless of zoom or density", () => {
     expect(
-      deriveLabelTier({ zoom: 0, liveCount: 100_000, priority: true }),
+      deriveLabelTier({ zoom: 0, densityLatched: true, priority: true }),
     ).toBe("full");
     expect(
       deriveLabelTier({
         zoom: ZOOM_LABELS_MIN - 1,
-        liveCount: 0,
+        densityLatched: false,
         priority: true,
       }),
     ).toBe("full");
+  });
+});
+
+describe("nextDensityLatched", () => {
+  it("keeps the band's edges apart, entering above the exit count", () => {
+    // A single threshold is the bug (issue #143) — pin that there are two,
+    // and which way round they go.
+    expect(DENSITY_CALLSIGN_EXIT).toBeLessThan(DENSITY_CALLSIGN_ENTER);
+  });
+
+  it("latches on only once the count rises above the upper edge", () => {
+    expect(nextDensityLatched(false, DENSITY_CALLSIGN_ENTER - 1)).toBe(false);
+    expect(nextDensityLatched(false, DENSITY_CALLSIGN_ENTER)).toBe(false);
+    expect(nextDensityLatched(false, DENSITY_CALLSIGN_ENTER + 1)).toBe(true);
+  });
+
+  it("stays latched while the count falls back through the band", () => {
+    // The blink itself: 61 -> 55 -> 61 must not change the label content.
+    let latched = nextDensityLatched(false, DENSITY_CALLSIGN_ENTER + 1);
+    expect(latched).toBe(true);
+    latched = nextDensityLatched(latched, DENSITY_CALLSIGN_EXIT + 5);
+    expect(latched).toBe(true);
+    latched = nextDensityLatched(latched, DENSITY_CALLSIGN_ENTER - 1);
+    expect(latched).toBe(true);
+  });
+
+  it("unlatches only once the count falls below the lower edge", () => {
+    expect(nextDensityLatched(true, DENSITY_CALLSIGN_EXIT + 1)).toBe(true);
+    expect(nextDensityLatched(true, DENSITY_CALLSIGN_EXIT)).toBe(true);
+    expect(nextDensityLatched(true, DENSITY_CALLSIGN_EXIT - 1)).toBe(false);
+  });
+
+  it("holds whatever the previous frame decided while inside the band", () => {
+    for (
+      let count = DENSITY_CALLSIGN_EXIT;
+      count <= DENSITY_CALLSIGN_ENTER;
+      count += 1
+    ) {
+      expect(nextDensityLatched(true, count)).toBe(true);
+      expect(nextDensityLatched(false, count)).toBe(false);
+    }
+  });
+
+  it("unlatches on an empty picture whatever the previous frame said", () => {
+    // What makes a store reset or a dropped connection settle on its own.
+    expect(nextDensityLatched(true, 0)).toBe(false);
+  });
+
+  it("does not oscillate for a count churning across the upper edge", () => {
+    // The reported symptom: a receiver gaining and losing a contact around
+    // 60 produced a new tier every frame. Walk that sequence and assert the
+    // latch never moves after the first crossing.
+    let latched = false;
+    const seen: boolean[] = [];
+    for (const count of [59, 61, 60, 59, 61, 58, 60, 61]) {
+      latched = nextDensityLatched(latched, count);
+      seen.push(latched);
+    }
+    expect(seen).toEqual([false, true, true, true, true, true, true, true]);
   });
 });
 

--- a/frontend/src/features/map/labels/priority.ts
+++ b/frontend/src/features/map/labels/priority.ts
@@ -12,7 +12,10 @@
  *    zoom and the live picture's density before MapLibre ever sees a
  *    feature. Selected and interesting aircraft always get the full stack;
  *    everyone else steps from full → callsign-only → nothing as the view
- *    zooms out or the picture gets crowded.
+ *    zooms out or the picture gets crowded. The density step is latched
+ *    through a hysteresis band (issue #143) so a live count sitting on the
+ *    edge cannot toggle the label content frame after frame; the latch
+ *    itself lives with the caller, not here.
  *
  * Roadmap slice 015 asks for "suppress operator first, then secondary
  * text". The operator line already suppresses itself whenever the metadata
@@ -35,22 +38,74 @@ export const ZOOM_LABELS_MIN = 7;
  * Between {@link ZOOM_LABELS_MIN} and this, callsign only. */
 export const ZOOM_LABELS_FULL = 10;
 
-/** Live aircraft count above which every non-priority label drops to
- * callsign-only regardless of zoom (the density override). Chosen well
- * under the 500-aircraft rendering target (roadmap slice 014): a dense
- * scene reads as a wall of three-line labels long before it reads as 500
+/**
+ * The density override's hysteresis band (issue #143).
+ *
+ * Every non-priority label drops to callsign-only, regardless of zoom, once
+ * the live count rises *above* {@link DENSITY_CALLSIGN_ENTER}, and the full
+ * stack only comes back once it falls *below* {@link DENSITY_CALLSIGN_EXIT}.
+ * Between the two edges the previous decision stands.
+ *
+ * The upper edge is where the override has always sat: well under the
+ * 500-aircraft rendering target (roadmap slice 014), because a dense scene
+ * reads as a wall of three-line labels long before it reads as 500
  * individual aircraft, so decluttering has to kick in far earlier than the
- * performance ceiling does. */
-export const DENSITY_CALLSIGN_THRESHOLD = 60;
+ * performance ceiling does.
+ *
+ * The lower edge is what stops the labels blinking. A single threshold means
+ * a picture hovering at the edge — which is the *normal* state of a busy
+ * receiver, gaining and losing a contact every second or two — toggles the
+ * altitude line on and off continuously. A ten-aircraft band is wide enough
+ * that ordinary churn cannot cross it, and narrow enough that a picture
+ * genuinely thinning out gets its full labels back within a frame or two of
+ * actually being sparse.
+ *
+ * The zoom edges ({@link ZOOM_LABELS_MIN}, {@link ZOOM_LABELS_FULL}) get no
+ * such band, deliberately: zoom only changes because the viewer changed it,
+ * so a boundary crossing there is an intended act rather than the picture
+ * flapping under its own noise.
+ */
+export const DENSITY_CALLSIGN_ENTER = 60;
+
+/** The band's lower edge — see {@link DENSITY_CALLSIGN_ENTER}. */
+export const DENSITY_CALLSIGN_EXIT = 50;
+
+/**
+ * The density override's next latch state, given the previous one and this
+ * frame's live count.
+ *
+ * Pure, and the *only* place the band is interpreted: `deriveLabelTier` takes
+ * the answer, so the latch's owner is whoever is drawing frames in sequence
+ * (`aircraft/frame.ts` via `labels/densityLatch.ts`) rather than this module.
+ * A one-off caller with no history passes `false` and gets the plain
+ * "is this picture dense right now" answer.
+ */
+export function nextDensityLatched(
+  previous: boolean,
+  liveCount: number,
+): boolean {
+  if (liveCount > DENSITY_CALLSIGN_ENTER) {
+    return true;
+  }
+  if (liveCount < DENSITY_CALLSIGN_EXIT) {
+    return false;
+  }
+  return previous;
+}
 
 export interface LabelTierInput {
   /** Current map zoom (`map.getZoom()`). */
   zoom: number;
-  /** Count of live aircraft in the picture
-   * (`Object.keys(store.aircraft).length`) — cheap, and a reasonable proxy
-   * for "how much text is about to compete for the same screen" without a
-   * per-frame viewport query. */
-  liveCount: number;
+  /**
+   * Whether the density override is currently latched on — the resolved
+   * output of {@link nextDensityLatched} for this frame's live count.
+   *
+   * A boolean rather than the count itself so this function stays pure while
+   * the decision it depends on is stateful: the count is cheap (the size of
+   * the drawn picture, not a per-frame viewport query), but "is the picture
+   * dense" is only answerable with reference to what it was a frame ago.
+   */
+  densityLatched: boolean;
   /** True for the selected aircraft or one carrying an active interesting
    * match — both always get the full stack, in and out of zoom/density. */
   priority: boolean;
@@ -59,7 +114,7 @@ export interface LabelTierInput {
 /** Resolves how much of the label stack an aircraft gets this frame. */
 export function deriveLabelTier({
   zoom,
-  liveCount,
+  densityLatched,
   priority,
 }: LabelTierInput): LabelTier {
   if (priority) {
@@ -68,7 +123,7 @@ export function deriveLabelTier({
   if (zoom < ZOOM_LABELS_MIN) {
     return "none";
   }
-  if (liveCount > DENSITY_CALLSIGN_THRESHOLD) {
+  if (densityLatched) {
     return "callsign";
   }
   return zoom >= ZOOM_LABELS_FULL ? "full" : "callsign";

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach, vi } from "vitest";
 
+import { resetDensityLatch } from "@/features/map/labels/densityLatch";
 import * as echartsCoreMock from "@/test/echartsMock";
 import { resetEchartsMock } from "@/test/echartsMock";
 import { AttributionControlMock, MapLibreMockMap } from "@/test/maplibreGlMock";
@@ -123,4 +124,8 @@ afterEach(() => {
   cleanup();
   resetWebSocketMock();
   resetEchartsMock();
+  // The label-density latch (issue #143) is module-level and deliberately
+  // remembers the previous frame, so one test's crowded picture would
+  // otherwise decide the next test's label tier.
+  resetDensityLatch();
 });

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1619,6 +1619,50 @@ slices:
     risk_level: medium
     notes: "Owner measured 80 shown against 59 audible on the Pi at v0.2.0. Fixes GitHub issue #134. Added by Fable outside the phase plan."
 
+  - id: "063"
+    title: "Aircraft label stability"
+    phase: 8
+    branch: "063-label-stability"
+    status: merged
+    depends_on: ["014", "015"]
+    objective: "Stop aircraft labels blinking on a busy picture: give slice 015's density tier a hysteresis band so a live count sitting on the threshold cannot toggle the label content every frame, and let a colliding non-selected label try other placements before MapLibre hides it (issue #143)."
+    scope:
+      - "`labels/priority.ts` replaces the single `DENSITY_CALLSIGN_THRESHOLD` with a documented band — `DENSITY_CALLSIGN_ENTER` (60) to enter callsign-only, `DENSITY_CALLSIGN_EXIT` (50) to return to the full stack — resolved by a pure `nextDensityLatched(previous, liveCount)`"
+      - "`deriveLabelTier` stays pure by taking the resolved `densityLatched` boolean instead of the raw count; the zoom edges (7/10) keep no band, because zoom only moves when the viewer moves it"
+      - "`labels/densityLatch.ts` holds the one latch bit for the frame loop, module-level in the shape `filteredLiveAircraftCache` already uses, with an explicit reset"
+      - "`aircraft/frame.ts` advances the latch once per frame on the same post-filter count and passes it into the GeoJSON builder, which keeps its own count-only fallback for callers that draw a single frame"
+      - "`useLiveConnection` clears the latch alongside the store resets on teardown; an empty picture unlatches on its own regardless"
+      - "the non-selected label layer swaps its fixed `text-anchor`/`text-offset` for `text-variable-anchor` (top, bottom, right, left) plus `text-radial-offset`, so a label that loses the collision contest relocates around its aircraft and is hidden only when no candidate fits"
+    out_of_scope:
+      - "the selected-aircraft label layer, which keeps its fixed anchor and its always-visible `text-allow-overlap`/`text-ignore-placement` pair (slice 015's acceptance criterion)"
+      - "the `symbol-sort-key` collision priorities and the label content builder, both unchanged"
+      - "the zoom tier boundaries and the tier ladder itself"
+      - "backend changes; the live count this reads is slice 062's, already honest"
+      - "visual-regression baselines: the live-map baseline hides the MapLibre canvas, so no placement change can reach it"
+    acceptance_criteria:
+      - "a live count oscillating across 60 does not toggle label content; the tier changes only after the count clears the far edge of the band"
+      - "a count rising 59 -> 61 latches to callsign-only, falling back to 55 stays latched, and only below 50 returns to the full stack"
+      - "selected and interesting aircraft keep the full stack at any count, latched or not"
+      - "the non-selected label layer offers more than one placement, leads with the placement it used before, and sets neither `text-anchor` nor `text-offset` (which MapLibre ignores under variable anchoring)"
+      - "the selected label layer still uses the fixed anchor/offset pair and no variable anchoring"
+      - "a store reset or a dropped connection leaves the latch cleared, so a reconnect is judged on its own picture"
+    required_tests:
+      - hysteresis band unit tests over the rising, falling, in-band and empty-picture cases, plus a churning-count sequence that must not oscillate
+      - latch module tests for carry-across-calls and reset
+      - frame-loop tests drawing a sequence of frames and asserting the drawn label text through the real frame -> geojson path
+      - geojson tests for an explicitly latched and an explicitly cleared frame
+      - layer tests pinning variable anchoring on the non-selected label layer and its absence on the selected one
+    expected_artifacts:
+      - frontend/src/features/map/labels/priority.ts
+      - frontend/src/features/map/labels/densityLatch.ts
+      - frontend/src/features/map/aircraft/geojson.ts
+      - frontend/src/features/map/aircraft/frame.ts
+      - frontend/src/features/map/aircraft/aircraftLayers.ts
+      - frontend/src/features/map/aircraft/useLiveConnection.ts
+    preferred_agent: opus
+    risk_level: low
+    notes: "Owner-reported on the Pi at v0.3.0; slice 062's honester live count made the threshold flapping more visible. Fixes GitHub issue #143. Frontend-only. Added by Fable outside the phase plan."
+
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,
 # 027, 031, 033, 035, 037, 038, 052) are ADDITIONALLY serialized against each other


### PR DESCRIPTION
Slice 063 — closes #143.

Aircraft labels blinked for two designed-but-rough reasons, both fixed:

- **Density tier hysteresis**: the callsign-only tier now latches above 60 visible aircraft and releases only below 50 (was a single 60 threshold re-decided every frame, so a count hovering there toggled the altitude line continuously). The latch is a pure function + one frame-loop-owned bit, reset on teardown, with the band's edge semantics pinned by tests.
- **Relocate before hiding**: non-selected labels now use `text-variable-anchor` (top/bottom/right/left) with radial offset and `text-justify: auto`, so a colliding label first tries the other sides of its aircraft before MapLibre hides it. Uncontested labels sit exactly where they did. The selected label layer is untouched — always visible, fixed placement.

Adversarial review verdict: MERGE (MapLibre layout semantics verified against maplibre-gl@6.6.0 source; visual baselines confirmed unreachable by label placement). Non-blocking observations filed as #147.

17 new/extended tests (1667 total green); lint/typecheck/format:check clean. Re-synced with dev after the slice 064 merge (roadmap numeric-order union).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTAJUucu2ZPAD235B3GQeZ