### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ follows [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/) (`0.x.y` during pre-1.0 development).
 This file is updated only on release branches (see `docs/RELEASE.md`).
 
+## [0.3.1] — 2026-09-02
+
+A same-day patch for two owner-reported live-map irritations.
+
+### Fixed
+- **Aircraft labels no longer blink**: the density-driven label tier latches
+  through a hysteresis band (callsign-only above 60 visible aircraft,
+  full stack again below 50) instead of flapping on a single threshold, and
+  a colliding label now tries the other sides of its aircraft
+  (`text-variable-anchor`, per-anchor justification) before MapLibre hides
+  it; the selected aircraft's label remains always visible (#143)
+- **Aircraft markers no longer oscillate forward and back**: position fixes
+  are dated by the decoder's own `seen_pos` age instead of their arrival
+  time, so dead reckoning projects from the moment the fix was actually
+  measured and consecutive projections hand over continuously — the
+  per-decode backwards step (fix age × ground speed, ~0.1–0.3 nm at jet
+  speeds) is gone (#144)
+
 ## [0.3.0] — 2026-09-02
 
 A fresh-install polish and live-picture correctness release, driven by the

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flightsite"
-version = "0.3.0"
+version = "0.3.1"
 description = "FlightSite backend: self-hosted ADS-B observatory API and ingestion service."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "flightsite"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -143,6 +143,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 060 | Raspberry Pi 4 performance baseline | 049, 050 | opus | low | Record the first Pi 4 baseline in docs/PERFORMANCE.md §5.4 and defer §5.3 promotion to the pending clean re-run (issues #101, #132) |
 | 061 | Selected aircraft track backfill | 014, 052 | opus | low | Backfill the selected aircraft's track from its open sighting so a click draws the whole current sighting, not just what arrives after it (issue #133) |
 | 062 | Live-set ghost expiry | 007, 008, 009 | opus | medium | Age live records by the decoder's own "last heard" report so dump1090's ~5-minute retention window stops inflating the live count and the 15 s / 60 s thresholds fire on time (issue #134) |
+| 063 | Aircraft label stability | 014, 015 | opus | low | Stop aircraft labels blinking: a hysteresis band on the density tier, and variable anchoring so a colliding label relocates before it hides (issue #143) |
 
 ## Parallelization Guide
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -143,6 +143,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 060 | Raspberry Pi 4 performance baseline | 049, 050 | opus | low | Record the first Pi 4 baseline in docs/PERFORMANCE.md §5.4 and defer §5.3 promotion to the pending clean re-run (issues #101, #132) |
 | 061 | Selected aircraft track backfill | 014, 052 | opus | low | Backfill the selected aircraft's track from its open sighting so a click draws the whole current sighting, not just what arrives after it (issue #133) |
 | 062 | Live-set ghost expiry | 007, 008, 009 | opus | medium | Age live records by the decoder's own "last heard" report so dump1090's ~5-minute retention window stops inflating the live count and the 15 s / 60 s thresholds fire on time (issue #134) |
+| 064 | Honest position-fix anchor | 054 | opus | low | Date each position fix by the decode age the frame reports rather than by its arrival, so dead reckoning hands over between fixes without the periodic backwards step (issue #144) |
 
 ## Parallelization Guide
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flightsite-frontend",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flightsite-frontend",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@radix-ui/react-separator": "^1.1.15",
         "@radix-ui/react-slot": "^1.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flightsite-frontend",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/frontend/src/features/map/aircraft/AircraftLayer.test.tsx
+++ b/frontend/src/features/map/aircraft/AircraftLayer.test.tsx
@@ -10,7 +10,7 @@ import { getDefaultBasemap } from "@/features/map/basemaps";
 import { DEV_PLACEHOLDER_MAP_CONFIG } from "@/features/map/mapConfig";
 import { MapLibreMap } from "@/features/map/MapLibreMap";
 import {
-  DENSITY_CALLSIGN_THRESHOLD,
+  DENSITY_CALLSIGN_ENTER,
   ZOOM_LABELS_FULL,
   ZOOM_LABELS_MIN,
 } from "@/features/map/labels/priority";
@@ -134,7 +134,7 @@ describe("AircraftLayer label integration", () => {
     map.zoom = ZOOM_LABELS_FULL;
 
     const crowd = Array.from(
-      { length: DENSITY_CALLSIGN_THRESHOLD + 5 },
+      { length: DENSITY_CALLSIGN_ENTER + 5 },
       (_, index) =>
         makeAircraft({
           icao: (index + 1).toString(16).padStart(6, "0"),

--- a/frontend/src/features/map/aircraft/aircraftLayers.test.ts
+++ b/frontend/src/features/map/aircraft/aircraftLayers.test.ts
@@ -233,6 +233,10 @@ describe("ensureAircraftLayers", () => {
     expect(layout["text-anchor"]).toBeUndefined();
     expect(layout["text-offset"]).toBeUndefined();
     expect(layout["text-radial-offset"]).toEqual(expect.any(Number));
+    // Justification has to follow the anchor that won. At MapLibre's default
+    // of "center", a multi-line label relocated to the left or right anchor
+    // stays centre-justified and turns a ragged edge toward its own aircraft.
+    expect(layout["text-justify"]).toBe("auto");
   });
 
   it("keeps the selected label on a fixed anchor, never a variable one", () => {
@@ -246,6 +250,9 @@ describe("ensureAircraftLayers", () => {
     expect(layout["text-radial-offset"]).toBeUndefined();
     expect(layout["text-anchor"]).toBe("top");
     expect(layout["text-offset"]).toEqual([0, 1]);
+    // "auto" justification only means anything under variable anchoring, and
+    // this layer has none — so it stays off rather than riding along.
+    expect(layout["text-justify"]).toBeUndefined();
   });
 
   it("prioritizes interesting aircraft over ordinary ones in the label collision order", () => {

--- a/frontend/src/features/map/aircraft/aircraftLayers.test.ts
+++ b/frontend/src/features/map/aircraft/aircraftLayers.test.ts
@@ -213,6 +213,41 @@ describe("ensureAircraftLayers", () => {
     expect(selected["text-ignore-placement"]).toBe(true);
   });
 
+  it("lets an ordinary label try other placements before it is hidden", () => {
+    // Issue #143's second mechanism: with one fixed anchor, a label that
+    // loses the collision contest blinks out entirely. Variable anchoring
+    // makes hiding the last resort rather than the first response.
+    ensureAircraftLayers(map);
+    const layout = mock.layers.get(AIRCRAFT_LABEL_LAYER_ID)?.layout as Record<
+      string,
+      unknown
+    >;
+    const anchors = layout["text-variable-anchor"] as string[];
+    expect(anchors.length).toBeGreaterThan(1);
+    // "top" first keeps the uncontested placement exactly where it was.
+    expect(anchors[0]).toBe("top");
+    expect(new Set(anchors).size).toBe(anchors.length);
+    // MapLibre ignores both of these once text-variable-anchor is set, so
+    // leaving either behind would be dead configuration that reads as if it
+    // still placed the label.
+    expect(layout["text-anchor"]).toBeUndefined();
+    expect(layout["text-offset"]).toBeUndefined();
+    expect(layout["text-radial-offset"]).toEqual(expect.any(Number));
+  });
+
+  it("keeps the selected label on a fixed anchor, never a variable one", () => {
+    // The selected label must not wander around its aircraft either — the
+    // fixed pair is what pins it under the icon, and it can never collide
+    // away, so it has nothing to relocate for.
+    ensureAircraftLayers(map);
+    const layout = mock.layers.get(AIRCRAFT_SELECTED_LABEL_LAYER_ID)
+      ?.layout as Record<string, unknown>;
+    expect(layout["text-variable-anchor"]).toBeUndefined();
+    expect(layout["text-radial-offset"]).toBeUndefined();
+    expect(layout["text-anchor"]).toBe("top");
+    expect(layout["text-offset"]).toEqual([0, 1]);
+  });
+
   it("prioritizes interesting aircraft over ordinary ones in the label collision order", () => {
     ensureAircraftLayers(map);
     const layout = mock.layers.get(AIRCRAFT_LABEL_LAYER_ID)?.layout as Record<

--- a/frontend/src/features/map/aircraft/aircraftLayers.ts
+++ b/frontend/src/features/map/aircraft/aircraftLayers.ts
@@ -21,9 +21,11 @@
  *    position source is distinguishable without relying on colour (SPEC §36);
  * 5. the aircraft symbols themselves, rotated to `track_deg`;
  * 6. non-selected aircraft labels — `text-allow-overlap: false`, so
- *    MapLibre's own collision system hides whichever labels lose the
- *    `symbol-sort-key` contest (roadmap slice 015: "MapLibre's own collision
- *    system plus zoom/density-driven tiering");
+ *    MapLibre's own collision system arbitrates, in `symbol-sort-key` order
+ *    (roadmap slice 015: "MapLibre's own collision system plus
+ *    zoom/density-driven tiering"). A label that loses the contest first
+ *    tries the other placements in `text-variable-anchor` (issue #143) and
+ *    is only hidden when none of them fits;
  * 7. the selected aircraft's label — its own layer because
  *    `text-allow-overlap`/`text-ignore-placement` are layer-level, not
  *    data-driven, and the selected label must never be the one collision
@@ -78,6 +80,44 @@ const SELECTION_COLOR = "#8ab4ff";
 const LABEL_TEXT_COLOR = "#f2f6ff";
 const LABEL_HALO_COLOR = "#0b1220";
 const LABEL_HALO_WIDTH = 1.2;
+
+/**
+ * Placements MapLibre tries, in order, for a non-selected label before it
+ * gives up and hides it (issue #143).
+ *
+ * `text-variable-anchor` is the whole fix for the second half of that issue:
+ * with a single fixed anchor, a label that loses the collision contest is
+ * simply not drawn, so two aircraft converging make one label blink out and
+ * back as the gap opens and closes. With a candidate list, MapLibre walks it
+ * and draws the first placement that fits — the label steps around its
+ * aircraft instead of vanishing. Hiding still happens when *no* candidate
+ * fits, which is the behaviour slice 015 wanted; it is now the last resort
+ * rather than the first response.
+ *
+ * `"top"` leads deliberately: it reproduces the fixed placement this layer
+ * used before (label below the icon, reading downward), so an uncontested
+ * label sits exactly where it always did and only a contested one moves.
+ * `"bottom"` next — the opposite side is the largest free area when a
+ * neighbour is crowding from one direction — then the two horizontal
+ * placements.
+ *
+ * MapLibre note: `text-anchor` and `text-offset` are both *ignored* on a
+ * layer with `text-variable-anchor`, which is why this layer sets neither and
+ * uses {@link LABEL_RADIAL_OFFSET} instead. The selected-label layer keeps
+ * the fixed anchor/offset pair precisely because it must never move.
+ */
+const LABEL_VARIABLE_ANCHORS: ("top" | "bottom" | "right" | "left")[] = [
+  "top",
+  "bottom",
+  "right",
+  "left",
+];
+
+/** Distance from the aircraft to its label, in ems, for every candidate
+ * anchor. Matches the magnitude of the fixed `text-offset: [0, 1]` the
+ * selected-label layer still uses, so the two layers place their labels the
+ * same distance out and a selection does not visibly nudge its own label. */
+const LABEL_RADIAL_OFFSET = 1;
 
 /**
  * The attention ring's severity palette (SPEC §36 "interesting/alerting:
@@ -348,11 +388,16 @@ export function ensureAircraftLayers(map: MapLibreGlMap): void {
       layout: {
         "text-field": ["get", "label"],
         "text-size": 11,
-        "text-anchor": "top",
-        "text-offset": [0, 1],
+        // Placement is variable, not fixed: see LABEL_VARIABLE_ANCHORS.
+        // `text-anchor`/`text-offset` are deliberately absent — MapLibre
+        // ignores both once `text-variable-anchor` is set, so leaving them
+        // in would read as configuration that does nothing.
+        "text-variable-anchor": LABEL_VARIABLE_ANCHORS,
+        "text-radial-offset": LABEL_RADIAL_OFFSET,
         "text-line-height": 1.15,
-        // MapLibre's own collision system: a label that loses the
-        // placement contest is hidden rather than drawn over its neighbour.
+        // MapLibre's own collision system: a label that fits none of the
+        // candidate placements is hidden rather than drawn over its
+        // neighbour.
         "text-allow-overlap": false,
         "text-optional": true,
         // Interesting aircraft win a collision against an ordinary one;

--- a/frontend/src/features/map/aircraft/aircraftLayers.ts
+++ b/frontend/src/features/map/aircraft/aircraftLayers.ts
@@ -105,6 +105,14 @@ const LABEL_HALO_WIDTH = 1.2;
  * layer with `text-variable-anchor`, which is why this layer sets neither and
  * uses {@link LABEL_RADIAL_OFFSET} instead. The selected-label layer keeps
  * the fixed anchor/offset pair precisely because it must never move.
+ *
+ * The layer pairs this with `text-justify: "auto"`, which is only meaningful
+ * under variable anchoring: at the default `center`, a multi-line label that
+ * relocates to the `left` or `right` anchor stays centre-justified, leaving a
+ * ragged inner edge facing the aircraft it belongs to. `auto` derives the
+ * justification from whichever anchor won, so a right-placed label is
+ * left-justified against the icon and a left-placed one right-justified — the
+ * text keeps a straight edge pointing at its aircraft however it moved.
  */
 const LABEL_VARIABLE_ANCHORS: ("top" | "bottom" | "right" | "left")[] = [
   "top",
@@ -394,6 +402,9 @@ export function ensureAircraftLayers(map: MapLibreGlMap): void {
         // in would read as configuration that does nothing.
         "text-variable-anchor": LABEL_VARIABLE_ANCHORS,
         "text-radial-offset": LABEL_RADIAL_OFFSET,
+        // Justify from the anchor that actually won, so a relocated
+        // multi-line label keeps a straight edge facing its aircraft.
+        "text-justify": "auto",
         "text-line-height": 1.15,
         // MapLibre's own collision system: a label that fits none of the
         // candidate placements is hidden rather than drawn over its

--- a/frontend/src/features/map/aircraft/frame.test.ts
+++ b/frontend/src/features/map/aircraft/frame.test.ts
@@ -13,22 +13,46 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { resetFilteredLiveAircraftCache } from "@/features/filters/lib/filteredLiveAircraftCache";
 import { DEFAULT_FILTERS } from "@/features/filters/types";
 import { drawAircraftFrame } from "@/features/map/aircraft/frame";
+import { resetDensityLatch } from "@/features/map/labels/densityLatch";
+import {
+  DENSITY_CALLSIGN_ENTER,
+  DENSITY_CALLSIGN_EXIT,
+} from "@/features/map/labels/priority";
 import { makeAircraft } from "@/test/liveAircraftFixtures";
+
+interface DrawnFeature {
+  properties: { label: string };
+}
 
 function fakeMap(): {
   map: MapLibreGlMap;
   dataByFeatureCount: () => number;
+  firstLabel: () => string | undefined;
 } {
-  let lastData: { features?: unknown[] } = { features: [] };
+  let lastData: { features?: DrawnFeature[] } = { features: [] };
   const map = {
     getSource: () => ({
-      setData: (data: { features?: unknown[] }) => {
+      setData: (data: { features?: DrawnFeature[] }) => {
         lastData = data;
       },
     }),
     getZoom: () => 10,
   } as unknown as MapLibreGlMap;
-  return { map, dataByFeatureCount: () => lastData.features?.length ?? 0 };
+  return {
+    map,
+    dataByFeatureCount: () => lastData.features?.length ?? 0,
+    firstLabel: () => lastData.features?.[0]?.properties.label,
+  };
+}
+
+/** `count` distinct positioned aircraft, all inside the default radius. */
+function crowd(count: number): ReturnType<typeof makeAircraft>[] {
+  return Array.from({ length: count }, (_, index) =>
+    makeAircraft({
+      icao: index.toString(16).padStart(6, "0"),
+      callsign: `AA${index}`,
+    }),
+  );
 }
 
 function state(aircraftList: ReturnType<typeof makeAircraft>[]) {
@@ -52,6 +76,7 @@ function state(aircraftList: ReturnType<typeof makeAircraft>[]) {
 
 beforeEach(() => {
   resetFilteredLiveAircraftCache();
+  resetDensityLatch();
 });
 
 describe("drawAircraftFrame filtering", () => {
@@ -101,5 +126,52 @@ describe("drawAircraftFrame filtering", () => {
       { filters: { ...DEFAULT_FILTERS, groundTraffic: "hide" } },
     );
     expect(dataByFeatureCount()).toBe(1);
+  });
+});
+
+describe("drawAircraftFrame label-density hysteresis", () => {
+  // Issue #143: the frame loop is what turns the pure band into a latch, so
+  // the sequence of frames — not any one of them — is the behaviour.
+  const FULL = "AA0\nFL310";
+  const CALLSIGN_ONLY = "AA0";
+
+  it("keeps the full stack while a rising count is still inside the band", () => {
+    const { map, firstLabel } = fakeMap();
+    drawAircraftFrame(map, state(crowd(DENSITY_CALLSIGN_EXIT + 1)), 0);
+    expect(firstLabel()).toBe(FULL);
+    drawAircraftFrame(map, state(crowd(DENSITY_CALLSIGN_ENTER)), 0);
+    expect(firstLabel()).toBe(FULL);
+  });
+
+  it("stays on callsign-only once latched, until the count clears the lower edge", () => {
+    const { map, firstLabel } = fakeMap();
+    // Above the upper edge: latch on.
+    drawAircraftFrame(map, state(crowd(DENSITY_CALLSIGN_ENTER + 1)), 0);
+    expect(firstLabel()).toBe(CALLSIGN_ONLY);
+
+    // Back inside the band — the flapping that produced the blink. The
+    // label content must not move.
+    for (const count of [
+      DENSITY_CALLSIGN_ENTER - 1,
+      DENSITY_CALLSIGN_ENTER + 1,
+      DENSITY_CALLSIGN_EXIT + 1,
+      DENSITY_CALLSIGN_ENTER,
+    ]) {
+      drawAircraftFrame(map, state(crowd(count)), 0);
+      expect(firstLabel()).toBe(CALLSIGN_ONLY);
+    }
+
+    // Below the lower edge: the picture really has thinned out.
+    drawAircraftFrame(map, state(crowd(DENSITY_CALLSIGN_EXIT - 1)), 0);
+    expect(firstLabel()).toBe(FULL);
+  });
+
+  it("unlatches once the picture empties, so a reconnect starts fresh", () => {
+    const { map, firstLabel } = fakeMap();
+    drawAircraftFrame(map, state(crowd(DENSITY_CALLSIGN_ENTER + 1)), 0);
+    expect(firstLabel()).toBe(CALLSIGN_ONLY);
+    drawAircraftFrame(map, state([]), 0);
+    drawAircraftFrame(map, state(crowd(DENSITY_CALLSIGN_ENTER)), 0);
+    expect(firstLabel()).toBe(FULL);
   });
 });

--- a/frontend/src/features/map/aircraft/frame.ts
+++ b/frontend/src/features/map/aircraft/frame.ts
@@ -22,6 +22,7 @@ import type {
   LiveAircraftRecord,
 } from "@/features/map/aircraft/store/useLiveAircraftStore";
 import type { SelectedTrack } from "@/features/map/aircraft/track";
+import { updateDensityLatch } from "@/features/map/labels/densityLatch";
 import { DEFAULT_DISPLAY_RADIUS_NM } from "@/features/map/mapConfig";
 import { getFilteredLiveAircraft } from "@/features/filters/lib/filteredLiveAircraftCache";
 import { DEFAULT_FILTERS, type LiveFilters } from "@/features/filters/types";
@@ -76,6 +77,11 @@ export function drawAircraftFrame(
       zoom: map.getZoom(),
       visibleIcaos: filterResult.visibleIcaos,
       dimmedIcaos: filterResult.dimmedIcaos,
+      // The frame loop is the one caller that draws a *sequence*, so it is
+      // the one that owns the label-density latch (issue #143). Advancing it
+      // here — once per frame, on the same post-filter count `geojson.ts`
+      // would have derived — keeps the builder itself pure.
+      densityLatched: updateDensityLatch(filterResult.visibleIcaos.size),
     }),
   );
   if (options.includeTrack) {

--- a/frontend/src/features/map/aircraft/geojson.test.ts
+++ b/frontend/src/features/map/aircraft/geojson.test.ts
@@ -14,7 +14,7 @@ import type {
 } from "@/features/map/aircraft/store/useLiveAircraftStore";
 import { REMOVAL_FADE_MS } from "@/features/map/aircraft/store/useLiveAircraftStore";
 import {
-  DENSITY_CALLSIGN_THRESHOLD,
+  DENSITY_CALLSIGN_ENTER,
   ZOOM_LABELS_FULL,
   ZOOM_LABELS_MIN,
 } from "@/features/map/labels/priority";
@@ -329,7 +329,7 @@ describe("buildAircraftFeatureCollection", () => {
 
     it("drops a non-priority label to callsign-only when the live picture is dense, even at high zoom", () => {
       const dense = records(
-        ...Array.from({ length: DENSITY_CALLSIGN_THRESHOLD + 1 }, (_, i) => ({
+        ...Array.from({ length: DENSITY_CALLSIGN_ENTER + 1 }, (_, i) => ({
           icao: i.toString(16).padStart(6, "0"),
           callsign: `AA${i}`,
           altitude_ft: 35000,
@@ -340,6 +340,46 @@ describe("buildAircraftFeatureCollection", () => {
       );
       for (const feature of collection.features) {
         expect(feature.properties.label).toBe(feature.properties.callsign);
+      }
+    });
+
+    it("honours a caller-supplied density latch over this frame's own count", () => {
+      // The hysteresis band (issue #143) lives with the frame loop, so a
+      // sparse frame drawn while the latch is still held must stay on the
+      // callsign-only tier rather than snapping back to the full stack.
+      const collection = buildAircraftFeatureCollection(
+        input({
+          aircraft: records({
+            icao: "aaaaaa",
+            callsign: "BAW123",
+            altitude_ft: 35000,
+          }),
+          zoom: ZOOM_LABELS_FULL,
+          densityLatched: true,
+        }),
+      );
+      expect(collection.features[0]?.properties.label).toBe("BAW123");
+    });
+
+    it("honours a cleared density latch over a count that is inside the band", () => {
+      const inBand = records(
+        ...Array.from({ length: DENSITY_CALLSIGN_ENTER }, (_, i) => ({
+          icao: i.toString(16).padStart(6, "0"),
+          callsign: `AA${i}`,
+          altitude_ft: 35000,
+        })),
+      );
+      const collection = buildAircraftFeatureCollection(
+        input({
+          aircraft: inBand,
+          zoom: ZOOM_LABELS_FULL,
+          densityLatched: false,
+        }),
+      );
+      for (const feature of collection.features) {
+        expect(feature.properties.label).toBe(
+          `${feature.properties.callsign}\nFL350`,
+        );
       }
     });
 
@@ -366,7 +406,7 @@ describe("buildAircraftFeatureCollection", () => {
           altitude_ft: 35000,
           interesting: { severity: "high", reasons: ["test"] },
         },
-        ...Array.from({ length: DENSITY_CALLSIGN_THRESHOLD }, (_, i) => ({
+        ...Array.from({ length: DENSITY_CALLSIGN_ENTER }, (_, i) => ({
           icao: (i + 1).toString(16).padStart(6, "0"),
           callsign: `AA${i}`,
         })),
@@ -486,7 +526,7 @@ describe("filtering (features/filters integration)", () => {
     // aircraft is entitled to, not the callsign-only tier a genuinely
     // crowded sky would force.
     const crowd = records(
-      ...Array.from({ length: DENSITY_CALLSIGN_THRESHOLD + 5 }, (_, i) => ({
+      ...Array.from({ length: DENSITY_CALLSIGN_ENTER + 5 }, (_, i) => ({
         icao: (i + 1).toString(16).padStart(6, "0"),
         callsign: `AA${i}`,
         altitude_ft: 35000,

--- a/frontend/src/features/map/aircraft/geojson.ts
+++ b/frontend/src/features/map/aircraft/geojson.ts
@@ -30,6 +30,7 @@ import {
 } from "@/features/map/labels/labelContent";
 import {
   deriveLabelTier,
+  nextDensityLatched,
   ZOOM_LABELS_FULL,
 } from "@/features/map/labels/priority";
 
@@ -112,6 +113,17 @@ export interface AircraftFrameInput {
   /** Subset of `visibleIcaos` that should render de-emphasized rather
    * than at full strength — the ground-traffic filter's "dim" mode. */
   dimmedIcaos?: ReadonlySet<string>;
+  /**
+   * Whether the label-density override is currently latched on
+   * (`labels/densityLatch.ts`), carried in because the hysteresis band that
+   * decides it (issue #143) needs to know what the *previous* frame chose,
+   * and this builder is pure.
+   *
+   * `undefined` means "no history": the frame is judged on its own count
+   * alone, which is exactly right for a one-off caller — and for every test
+   * that hands over a picture without drawing a sequence.
+   */
+  densityLatched?: boolean;
 }
 
 function feature(
@@ -154,6 +166,9 @@ export function buildAircraftFeatureCollection(
   const liveCount = visibleIcaos
     ? visibleIcaos.size
     : Object.keys(aircraft).length;
+  // One decision for the whole frame, resolved once rather than per feature.
+  const densityLatched =
+    input.densityLatched ?? nextDensityLatched(false, liveCount);
 
   for (const icao in aircraft) {
     const record = aircraft[icao];
@@ -174,7 +189,7 @@ export function buildAircraftFeatureCollection(
     const interesting = view.interesting !== null;
     const tier = deriveLabelTier({
       zoom,
-      liveCount,
+      densityLatched,
       priority: selected || interesting,
     });
     features.push(

--- a/frontend/src/features/map/aircraft/interpolation.ts
+++ b/frontend/src/features/map/aircraft/interpolation.ts
@@ -17,6 +17,28 @@
  * crept forward again. Elapsed time has to be measured from the moment the
  * position was *fixed*, which is what the store now records.
  *
+ * **And the fix was already old when it arrived** — issue #144. The store dates
+ * a new fix at `receivedAt - seen_pos_s`, the decoder's own age for the CPR
+ * solution, rather than at the instant the frame landed; see
+ * `useLiveAircraftStore` for the dating rules and why a *repeated* fix is never
+ * re-dated. That is what makes this projection continuous across fixes. With
+ * both anchors honest, the projection running from fix N at the moment fix N+1
+ * lands and the projection starting from fix N+1 are the same point for an
+ * aircraft flying straight: N+1's coordinates sit behind N's projection by
+ * exactly the travel N+1's own age immediately adds back. Whatever poll and
+ * socket latency the frames share cancels in the subtraction, so it need not be
+ * known — only the part of the delay the decoder measures differs between
+ * fixes, and that is the part `seen_pos_s` reports. Dating both fixes at
+ * arrival instead dropped the age term from one side only, which is why the
+ * marker stepped back by (fix age × ground speed) on every decode.
+ *
+ * A back-dated fix is therefore projected forward the moment it arrives, with
+ * `elapsed` already positive. That is the intent, not an edge case: `elapsed`
+ * asks how long the aircraft has been flying since it was placed, and the
+ * answer at arrival is `seen_pos_s`, not zero. The `elapsed === 0` shortcut
+ * below still covers what it always covered — no time to project, so nothing
+ * to compute.
+ *
  * **Why dead reckoning rather than tweening between the last two positions.**
  * Tweening is smooth but wrong twice over: it renders the aircraft a full
  * update *behind* where it was last reported, and it needs two positions, which
@@ -45,13 +67,20 @@
  * has stopped hearing them, so their last known position is the honest thing to
  * draw.
  *
- * **No correction blend on a new fix**, considered and declined in slice 054. A
- * new fix still moves the marker by however far the projection had drifted, and
- * easing into it instead of snapping was the obvious next refinement. It is not
- * worth it: with the anchor correct that step is the dead-reckoning error over
- * one fix interval — metres for an aircraft flying straight, against the ~0.8 nm
- * the mis-anchored version jumped — so the blend would smooth something already
- * near the noise floor. The cost is real, though. This function is pure and
+ * **No correction blend on a new fix**, considered and declined in slice 054
+ * and re-examined in 064. A new fix still moves the marker by however far the
+ * projection had drifted, and easing into it instead of snapping is the obvious
+ * next refinement. Slice 054 declined it on the grounds that the step is only
+ * the dead-reckoning error over one fix interval — metres for an aircraft
+ * flying straight, against the ~0.8 nm the #119 anchor jumped. That was the
+ * right conclusion from a premise that was not yet true: the anchor was still
+ * late by the fix's own age, leaving a systematic step of (fix age × ground
+ * speed), ~0.1-0.3 nm at jet speeds and reliably backwards, which is the
+ * oscillation issue #144 reported. Back-dating removes that term rather than
+ * masking it, and what remains is the error the paragraph always claimed —
+ * genuine manoeuvring between fixes, near the noise floor for straight flight,
+ * and not systematically signed. So the blend stays declined, now on its stated
+ * grounds. The cost is real, too. This function is pure and
  * called once per aircraft per frame; a blend needs the previously *drawn*
  * position kept per aircraft between frames, which means mutable render state
  * with its own eviction, reset-on-reconnect and store-reset invalidation. And
@@ -82,6 +111,14 @@ import type { GeoPosition } from "@/lib/api/live";
  * per-delta anchor and far too short against this one: it would re-freeze a
  * distant aircraft for most of every gap between fixes, reintroducing the
  * stutter from the other side.
+ *
+ * Since slice 064 this measures the fix's *true* age — the store's anchor now
+ * includes the decode age the frame arrived with (issue #144) — which is what
+ * the bound always meant. It reads a few seconds sooner in wall-clock terms
+ * than it used to, and correctly so: an aircraft last placed 15 s ago is
+ * equally unfit to project whether the client learned that 15 s ago or 5 s ago.
+ * The same constant doubles as the store's clamp on a reported age, since a fix
+ * older than this is not projected anyway.
  */
 export const INTERPOLATION_MAX_FIX_AGE_MS = 15_000;
 

--- a/frontend/src/features/map/aircraft/interpolation.ts
+++ b/frontend/src/features/map/aircraft/interpolation.ts
@@ -18,8 +18,9 @@
  * position was *fixed*, which is what the store now records.
  *
  * **And the fix was already old when it arrived** — issue #144. The store dates
- * a new fix at `receivedAt - seen_pos_s`, the decoder's own age for the CPR
- * solution, rather than at the instant the frame landed; see
+ * a new fix at `receivedAt - seen_pos_s * 1000`, the decoder's own age for the
+ * CPR solution converted from seconds to the milliseconds these timestamps are
+ * kept in, rather than at the instant the frame landed; see
  * `useLiveAircraftStore` for the dating rules and why a *repeated* fix is never
  * re-dated. That is what makes this projection continuous across fixes. With
  * both anchors honest, the projection running from fix N at the moment fix N+1

--- a/frontend/src/features/map/aircraft/snapback.regression.test.ts
+++ b/frontend/src/features/map/aircraft/snapback.regression.test.ts
@@ -1,5 +1,5 @@
 /**
- * Regression: markers crept forward then teleported back (issue #119).
+ * Regression: markers crept forward then teleported back (issues #119, #144).
  *
  * Driven through the real store rather than hand-built records, because the
  * defect lived in the seam between the two: `displayPosition` dead-reckoned
@@ -8,12 +8,20 @@
  * aircraft. Each no-new-fix delta reset elapsed time to zero and snapped the
  * marker back to the stale fix. A unit test over a fabricated record cannot
  * see that; only applying a real delta sequence can.
+ *
+ * Issue #144 is the same symptom from the residue that fix left: the anchor was
+ * still late by the fix's own decode age, so a *genuine* new fix landed behind
+ * the projection running from the last one and stepped the marker back. The
+ * first block below pins the #119 behaviour with `seen_pos_s: 0`, which must
+ * stay bit-for-bit what it was; the second drives the same seam with the
+ * nonzero ages a distant aircraft actually reports.
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { displayPosition } from "@/features/map/aircraft/interpolation";
 import { useLiveAircraftStore } from "@/features/map/aircraft/store/useLiveAircraftStore";
+import type { LiveAircraft } from "@/lib/api/live";
 import { makeAircraft } from "@/test/liveAircraftFixtures";
 
 const T0 = 1_700_000_000_000;
@@ -22,12 +30,16 @@ const ICAO = "aaaaaa";
 /** Due north at 360 kt: 0.1 nm a second, or 1/600 of a degree of latitude. */
 const DEGREES_PER_SECOND = 0.1 / 60;
 
-function inbound(overrides = {}) {
+/** The #119 scenario's aircraft: a reported age of zero, so every anchor here
+ * is the arrival instant and the expectations below are the pre-#144 ones
+ * unchanged. */
+function inbound(overrides: Partial<LiveAircraft> = {}) {
   return makeAircraft({
     icao: ICAO,
     position: { lat: 0, lon: 0 },
     track_deg: 0,
     ground_speed_kt: 360,
+    seen_pos_s: 0,
     ...overrides,
   });
 }
@@ -139,5 +151,155 @@ describe("live map motion across deltas that do not move the fix", () => {
     const coasted = drawnLat(T0 + 60_000);
     expect(coasted).toBeGreaterThan(0);
     expect(drawnLat(T0 + 600_000)).toBe(coasted);
+  });
+});
+
+/**
+ * Issue #144, modelled as the receiver and the network actually behave.
+ *
+ * A CPR fix is measured at some true instant, read by a backend poll some time
+ * later — that gap is what the frame reports as `seen_pos_s` — and reaches the
+ * browser after a further transport delay the frame says nothing about. The
+ * decode gap varies fix by fix; the transport delay is shared by every frame
+ * alike. Back-dating cancels the part that varies, which is the whole claim:
+ * what is left is a constant lag no client-side arithmetic could remove.
+ */
+describe("live map motion when fixes arrive already aged", () => {
+  /** The delay every frame shares: poll to socket to browser. Constant, so it
+   * cannot be recovered from the data and does not need to be. */
+  const TRANSPORT_MS = 1000;
+
+  /** True instants the receiver decoded a position, on the irregular 2-10 s
+   * cadence of a distant aircraft. */
+  const FIX_TIMES_MS = [500, 4300, 9100];
+
+  const POLL_TIMES_MS = [
+    1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10_000, 11_000,
+    12_000,
+  ];
+
+  /** Where the aircraft truly is `trueMs` after T0. */
+  function latAtTrue(trueMs: number): number {
+    return (trueMs / 1000) * DEGREES_PER_SECOND;
+  }
+
+  /** The newest fix the decoder held when the backend polled at `pollMs`. */
+  function fixHeldAt(pollMs: number): number {
+    let held = FIX_TIMES_MS[0] as number;
+    for (const measuredAt of FIX_TIMES_MS) {
+      if (measuredAt <= pollMs) {
+        held = measuredAt;
+      }
+    }
+    return held;
+  }
+
+  /** Applies the frame built by the poll at `pollMs`, at the browser instant it
+   * would land. Returns that instant. */
+  function deliverPoll(pollMs: number): number {
+    const measuredAt = fixHeldAt(pollMs);
+    const arrivesAt = T0 + pollMs + TRANSPORT_MS;
+    useLiveAircraftStore.getState().applyDelta(
+      {
+        updated: [
+          inbound({
+            position: { lat: latAtTrue(measuredAt), lon: 0 },
+            seen_pos_s: (pollMs - measuredAt) / 1000,
+          }),
+        ],
+        stale: [],
+        removed: [],
+      },
+      arrivesAt,
+    );
+    return arrivesAt;
+  }
+
+  function rawLat(): number {
+    const lat =
+      useLiveAircraftStore.getState().aircraft[ICAO]?.aircraft.position?.lat;
+    if (lat === undefined) {
+      throw new Error(`${ICAO} has no reported position`);
+    }
+    return lat;
+  }
+
+  beforeEach(() => {
+    // The suite-wide snapshot seeds an unaged fix; this scenario builds its own
+    // history from the first poll.
+    useLiveAircraftStore.getState().reset();
+  });
+
+  it("never draws the aircraft behind where it was a moment earlier", () => {
+    // The reported symptom: a periodic back-step, once per genuine decode. The
+    // last sample of each second sits 1 ms before the next frame lands, so a
+    // step at the handover has nowhere to hide between samples.
+    let previous = Number.NEGATIVE_INFINITY;
+    for (const pollMs of POLL_TIMES_MS) {
+      const arrivesAt = deliverPoll(pollMs);
+      for (const offset of [0, 250, 500, 750, 999]) {
+        const current = drawnLat(arrivesAt + offset);
+        expect(
+          current,
+          `drew backwards at poll ${pollMs} ms +${offset}: ${current} < ${previous}`,
+        ).toBeGreaterThanOrEqual(previous);
+        previous = current;
+      }
+    }
+  });
+
+  it("hands over from one fix to the next without a step", () => {
+    // The fix measured at 4300 first reaches the browser at T0+6000, carried by
+    // the 5000 poll and 0.7 s old. Either side of that instant the drawn path
+    // must differ by one millisecond of travel and nothing more.
+    for (const pollMs of [1000, 2000, 3000, 4000]) {
+      deliverPoll(pollMs);
+    }
+    const before = drawnLat(T0 + 5999);
+
+    deliverPoll(5000);
+
+    expect(drawnLat(T0 + 6000) - before).toBeCloseTo(
+      DEGREES_PER_SECOND / 1000,
+      12,
+    );
+  });
+
+  it("draws a new fix ahead of its raw coordinates, never back at them", () => {
+    // Why the old dating had to rewind: the coordinates a frame reports were
+    // measured before the poll that carried them, so they are already behind
+    // the projection running from the previous fix. Drawing them where they
+    // are read is the back-step; drawing them plus their own age is not.
+    for (const pollMs of [1000, 2000, 3000, 4000]) {
+      deliverPoll(pollMs);
+    }
+    const before = drawnLat(T0 + 5999);
+
+    deliverPoll(5000);
+
+    expect(rawLat()).toBeLessThan(before);
+    expect(drawnLat(T0 + 6000)).toBeGreaterThan(rawLat());
+    expect(drawnLat(T0 + 6000)).toBeGreaterThanOrEqual(before);
+  });
+
+  it("tracks the true position, lagged only by the transport it cannot see", () => {
+    // The strongest statement of the fix: at the moment each frame lands, the
+    // marker sits exactly where the aircraft was when the backend polled —
+    // every fix, whatever its decode age. Only the shared transport lag is
+    // left, and no arithmetic on this data could remove it.
+    for (const pollMs of POLL_TIMES_MS) {
+      const arrivesAt = deliverPoll(pollMs);
+      expect(drawnLat(arrivesAt)).toBeCloseTo(latAtTrue(pollMs), 9);
+    }
+  });
+
+  it("still freezes rather than rewinding when the stream dies mid-flight", () => {
+    // Slice 054's stall grace is untouched: it is measured from `receivedAt`,
+    // which back-dating does not move.
+    const arrivesAt = deliverPoll(1000);
+    const coasted = drawnLat(arrivesAt + 60_000);
+
+    expect(coasted).toBeGreaterThan(drawnLat(arrivesAt));
+    expect(drawnLat(arrivesAt + 600_000)).toBe(coasted);
   });
 });

--- a/frontend/src/features/map/aircraft/store/useLiveAircraftStore.test.ts
+++ b/frontend/src/features/map/aircraft/store/useLiveAircraftStore.test.ts
@@ -854,8 +854,11 @@ describe("positionChangedAt back-dating (issue #144)", () => {
 
   it("clamps an outlier age to the fix-age cap", () => {
     // Five minutes: the decoder reporting something the interpolator has long
-    // given up projecting. Clamped, so the anchor lands at the cap rather than
-    // minutes into the past.
+    // given up projecting. This pins the *stored field*, not a drawn position:
+    // `displayPosition` caps elapsed time at the same constant, so clamped or
+    // not the marker sits frozen at the bound either way. The point is that
+    // `positionChangedAt` keeps meaning what its name says for anyone reading
+    // it directly.
     snapshot({ seen_pos_s: 300 }, T0);
 
     expect(anchor()).toBe(T0 - INTERPOLATION_MAX_FIX_AGE_MS);

--- a/frontend/src/features/map/aircraft/store/useLiveAircraftStore.test.ts
+++ b/frontend/src/features/map/aircraft/store/useLiveAircraftStore.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
+import { INTERPOLATION_MAX_FIX_AGE_MS } from "@/features/map/aircraft/interpolation";
 import {
   REMOVAL_FADE_MS,
   useLiveAircraftStore,
 } from "@/features/map/aircraft/store/useLiveAircraftStore";
 import { TRACK_MAX_POINTS } from "@/features/map/aircraft/track";
+import type { LiveAircraft } from "@/lib/api/live";
 import { makeAircraft } from "@/test/liveAircraftFixtures";
 
 const T0 = 1_800_000_000_000;
@@ -639,7 +641,14 @@ describe("batching", () => {
 });
 
 describe("positionChangedAt", () => {
-  const AT = { icao: "aaaaaa", position: { lat: 47, lon: -122 } } as const;
+  // `seen_pos_s: 0` throughout: these cases are about *which* frame re-anchors,
+  // and pinning the reported age at zero keeps every expectation below the
+  // exact pre-#144 dating. Back-dating a nonzero age is the next block.
+  const AT = {
+    icao: "aaaaaa",
+    position: { lat: 47, lon: -122 },
+    seen_pos_s: 0,
+  } as const;
 
   function anchor(): number | undefined {
     return store().aircraft.aaaaaa?.positionChangedAt;
@@ -760,5 +769,125 @@ describe("positionChangedAt", () => {
     );
 
     expect(anchor()).toBe(T0 + 1000);
+  });
+});
+
+describe("positionChangedAt back-dating (issue #144)", () => {
+  const AT = { icao: "aaaaaa", position: { lat: 47, lon: -122 } } as const;
+  const MOVED = { ...AT, position: { lat: 47.01, lon: -122 } } as const;
+
+  function anchor(): number | undefined {
+    return store().aircraft.aaaaaa?.positionChangedAt;
+  }
+
+  function snapshot(overrides: Partial<LiveAircraft>, now: number): void {
+    store().applySnapshot(
+      { aircraft: [makeAircraft({ ...AT, ...overrides })], receiver: null },
+      now,
+    );
+  }
+
+  function delta(overrides: Partial<LiveAircraft>, now: number): void {
+    store().applyDelta(
+      {
+        updated: [makeAircraft({ ...AT, ...overrides })],
+        stale: [],
+        removed: [],
+      },
+      now,
+    );
+  }
+
+  it("dates a first fix at the age the decoder reports", () => {
+    // The frame landed at T0, but the CPR solution behind it is 3 s old.
+    snapshot({ seen_pos_s: 3 }, T0);
+
+    expect(anchor()).toBe(T0 - 3000);
+  });
+
+  it("dates a new fix on the delta path by the same rule", () => {
+    // Both application paths must date a position identically; a snapshot
+    // arriving mid-stream must not shift a marker the deltas were placing.
+    snapshot({ seen_pos_s: 0 }, T0);
+    delta({ ...MOVED, seen_pos_s: 2.5 }, T0 + 4000);
+
+    expect(anchor()).toBe(T0 + 1500);
+  });
+
+  it("dates the same fix identically whichever path delivers it", () => {
+    snapshot({ seen_pos_s: 0 }, T0);
+    delta({ ...MOVED, seen_pos_s: 2.5 }, T0 + 4000);
+    const viaDelta = anchor();
+
+    store().reset();
+    snapshot({ seen_pos_s: 0 }, T0);
+    snapshot({ ...MOVED, seen_pos_s: 2.5 }, T0 + 4000);
+
+    expect(anchor()).toBe(viaDelta);
+  });
+
+  it("falls back to the arrival instant when no age is reported", () => {
+    // §2.7 makes `null` the representation of "unknown"; without an age the
+    // arrival instant is the best available guess, exactly as before #144.
+    snapshot({ seen_pos_s: null }, T0);
+
+    expect(anchor()).toBe(T0);
+  });
+
+  it("dates a zero-age fix at the arrival instant", () => {
+    snapshot({ seen_pos_s: 0 }, T0);
+
+    expect(anchor()).toBe(T0);
+  });
+
+  it.each([
+    ["negative", -5],
+    ["not a number", Number.NaN],
+    ["infinite", Number.POSITIVE_INFINITY],
+  ])("falls back to the arrival instant for a %s age", (_label, seen) => {
+    // A nonsense age must not throw the anchor anywhere; under-projecting is
+    // the safe direction.
+    snapshot({ seen_pos_s: seen }, T0);
+
+    expect(anchor()).toBe(T0);
+  });
+
+  it("clamps an outlier age to the fix-age cap", () => {
+    // Five minutes: the decoder reporting something the interpolator has long
+    // given up projecting. Clamped, so the anchor lands at the cap rather than
+    // minutes into the past.
+    snapshot({ seen_pos_s: 300 }, T0);
+
+    expect(anchor()).toBe(T0 - INTERPOLATION_MAX_FIX_AGE_MS);
+  });
+
+  it("keeps the anchor when a repeated fix reports a growing age", () => {
+    // The aircraft has not been placed anywhere new, so the moment it was
+    // placed has not changed. The ages below outrun wall time — the decoder's
+    // age is sampled afresh each poll and need not track the gap between the
+    // frames that carry it — so re-dating each repeat would walk the anchor
+    // backwards frame by frame, which is #119 inverted.
+    snapshot({ seen_pos_s: 1 }, T0);
+    delta({ seen_pos_s: 2.5 }, T0 + 1000);
+    delta({ seen_pos_s: 4.5 }, T0 + 2000);
+    delta({ seen_pos_s: 12 }, T0 + 8000);
+
+    expect(anchor()).toBe(T0 - 1000);
+    expect(store().aircraft.aaaaaa?.receivedAt).toBe(T0 + 8000);
+  });
+
+  it("keeps the anchor when a snapshot repeats a fix with a growing age", () => {
+    snapshot({ seen_pos_s: 1 }, T0);
+    snapshot({ seen_pos_s: 9 }, T0 + 5000);
+
+    expect(anchor()).toBe(T0 - 1000);
+  });
+
+  it("re-dates only once the fix itself moves", () => {
+    snapshot({ seen_pos_s: 1 }, T0);
+    delta({ seen_pos_s: 6 }, T0 + 3000);
+    delta({ ...MOVED, seen_pos_s: 1 }, T0 + 4000);
+
+    expect(anchor()).toBe(T0 + 3000);
   });
 });

--- a/frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
+++ b/frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
@@ -39,9 +39,10 @@
  * *late*: the projection from fix N had already run past fix N+1's raw
  * coordinates by the time they were drawn, so each new fix stepped the marker
  * backwards before it crept forward again. {@link fixAnchor} instead dates a
- * new fix at `now - seen_pos_s`, the age the decoder itself reports (§3.3,
- * honest since slice 062) — the client-side mirror of that slice's server-side
- * ageing.
+ * new fix at `now - seen_pos_s * 1000` — the age the decoder itself reports
+ * (§3.3, honest since slice 062), in seconds, converted to the milliseconds
+ * these timestamps are kept in — the client-side mirror of that slice's
+ * server-side ageing.
  *
  * This keeps the #119 rule that only the browser's clock is read. `seen_pos_s`
  * is a *duration*, not an instant: subtracting it from a browser timestamp
@@ -232,15 +233,20 @@ function samePosition(previous: LiveAircraft, next: LiveAircraft): boolean {
 }
 
 /**
- * The most reported fix age this store will honour, in seconds.
+ * The most reported fix age this store will honour, in milliseconds.
  *
  * {@link INTERPOLATION_MAX_FIX_AGE_MS} is the natural bound and not a second
  * arbitrary number: it is the age past which the interpolator stops projecting
- * a fix at all, so back-dating further can only change how long the marker sits
- * frozen, never where it is drawn. Anything above it is a decoder reporting
- * something the map has already given up on — an aircraft heard for minutes
- * without a usable CPR pair, or a malformed age — and clamping keeps such a
- * value from throwing the anchor minutes into the past.
+ * a fix at all. Nothing rendered depends on the clamp, in fact —
+ * `displayPosition` caps elapsed time at the same constant, so an anchor five
+ * minutes in the past and one clamped to fifteen seconds draw the marker in
+ * exactly the same place, frozen at the bound, for as long as either survives.
+ * What the clamp buys is a `positionChangedAt` that still means what the field
+ * says it means: anything above the bound is a decoder reporting something the
+ * map has already given up on — an aircraft heard for minutes without a usable
+ * CPR pair, or a malformed age — and a stored anchor minutes adrift would be a
+ * trap for the next reader, and for anything that later measures fix age from
+ * this field rather than through the interpolator.
  */
 const MAX_REPORTED_FIX_AGE_MS = INTERPOLATION_MAX_FIX_AGE_MS;
 
@@ -248,11 +254,12 @@ const MAX_REPORTED_FIX_AGE_MS = INTERPOLATION_MAX_FIX_AGE_MS;
  * When the receiver fixed the position `entry` reports, on the browser's clock.
  *
  * The frame arrived at `now`, but the decoder says it placed the aircraft
- * `seen_pos_s` seconds earlier, so that is the anchor (issue #144). A missing,
- * negative or non-finite age falls back to `now`, which is exactly the pre-#144
- * behaviour: without a reported age the arrival instant is the best guess
- * available, and it is the conservative one — it under-projects rather than
- * inventing motion.
+ * `seen_pos_s` seconds earlier, so the anchor is `now - seen_pos_s * 1000`
+ * (issue #144) — the reported age is in seconds, `now` and the anchor in
+ * milliseconds. A missing, negative or non-finite age falls back to `now`,
+ * which is exactly the pre-#144 behaviour: without a reported age the arrival
+ * instant is the best guess available, and it is the conservative one — it
+ * under-projects rather than inventing motion.
  */
 function fixAnchor(entry: LiveAircraft, now: number): number {
   const reportedS = entry.seen_pos_s;

--- a/frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
+++ b/frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
@@ -20,20 +20,46 @@
  *
  * * `receivedAt` — when this object arrived. Dates the *data*: how long ago the
  *   client last heard anything at all about this aircraft.
- * * `positionChangedAt` — when the reported fix last actually moved. Dates the
- *   *position*, which is a different thing entirely, because the backend sends
- *   complete aircraft objects every frame: a delta carrying nothing but a new
- *   RSSI still repeats the last decoded position verbatim.
+ * * `positionChangedAt` — when the receiver *fixed* the position the record now
+ *   reports. Dates the *position*, which is a different thing entirely, because
+ *   the backend sends complete aircraft objects every frame: a delta carrying
+ *   nothing but a new RSSI still repeats the last decoded position verbatim.
  *
  * The interpolator dead-reckons from `positionChangedAt`. Anchoring it to
  * `receivedAt` was issue #119: distant aircraft decode a CPR position only
  * every 2-10 s while transmitting Mode S every second, so every intervening
  * delta reset elapsed time to zero and snapped the marker back to the stale
  * fix before it crept forward again.
+ *
+ * **A fix is already old when it arrives** — issue #144, the residual error
+ * #119's fix left behind. The decoder needs a CPR pair to place an aircraft, so
+ * the position in a frame was measured `seen_pos_s` seconds before the poll
+ * that read it, and the poll and the socket add their own second or two on top.
+ * Stamping the arrival instant therefore anchored every fix systematically
+ * *late*: the projection from fix N had already run past fix N+1's raw
+ * coordinates by the time they were drawn, so each new fix stepped the marker
+ * backwards before it crept forward again. {@link fixAnchor} instead dates a
+ * new fix at `now - seen_pos_s`, the age the decoder itself reports (§3.3,
+ * honest since slice 062) — the client-side mirror of that slice's server-side
+ * ageing.
+ *
+ * This keeps the #119 rule that only the browser's clock is read. `seen_pos_s`
+ * is a *duration*, not an instant: subtracting it from a browser timestamp
+ * never mixes the two clocks, so a receiver hours out of step with the browser
+ * changes nothing — the same skew-immunity argument slice 062 made in the other
+ * direction.
+ *
+ * A repeated fix is **not** re-dated, however far its reported age has grown
+ * since. The aircraft has not been placed anywhere new, so the anchor it
+ * already carries is still exactly when it was placed; letting an ageing
+ * `seen_pos_s` push the anchor backwards frame by frame would reintroduce #119
+ * inverted — the marker racing ahead of the fix and jerking back on each
+ * genuine decode. Only a position that actually changed takes a new anchor.
  */
 
 import { create } from "zustand";
 
+import { INTERPOLATION_MAX_FIX_AGE_MS } from "@/features/map/aircraft/interpolation";
 import type { SelectedTrack, TrackPoint } from "@/features/map/aircraft/track";
 import {
   appendTrackPoint,
@@ -48,9 +74,10 @@ export interface LiveAircraftRecord {
   aircraft: LiveAircraft;
   /** `Date.now()` when this object was applied. */
   receivedAt: number;
-  /** `Date.now()` when `aircraft.position` last changed — the moment the
-   * receiver placed the aircraft where the record now says it is. Carried
-   * forward unchanged by every frame that repeats the same fix. */
+  /** On the browser's clock, the moment the receiver placed the aircraft where
+   * the record now says it is: the arrival of the frame that first carried this
+   * fix, back-dated by the fix's own reported age (see {@link fixAnchor}).
+   * Carried forward unchanged by every frame that repeats the same fix. */
   positionChangedAt: number;
 }
 
@@ -204,8 +231,40 @@ function samePosition(previous: LiveAircraft, next: LiveAircraft): boolean {
   );
 }
 
+/**
+ * The most reported fix age this store will honour, in seconds.
+ *
+ * {@link INTERPOLATION_MAX_FIX_AGE_MS} is the natural bound and not a second
+ * arbitrary number: it is the age past which the interpolator stops projecting
+ * a fix at all, so back-dating further can only change how long the marker sits
+ * frozen, never where it is drawn. Anything above it is a decoder reporting
+ * something the map has already given up on — an aircraft heard for minutes
+ * without a usable CPR pair, or a malformed age — and clamping keeps such a
+ * value from throwing the anchor minutes into the past.
+ */
+const MAX_REPORTED_FIX_AGE_MS = INTERPOLATION_MAX_FIX_AGE_MS;
+
+/**
+ * When the receiver fixed the position `entry` reports, on the browser's clock.
+ *
+ * The frame arrived at `now`, but the decoder says it placed the aircraft
+ * `seen_pos_s` seconds earlier, so that is the anchor (issue #144). A missing,
+ * negative or non-finite age falls back to `now`, which is exactly the pre-#144
+ * behaviour: without a reported age the arrival instant is the best guess
+ * available, and it is the conservative one — it under-projects rather than
+ * inventing motion.
+ */
+function fixAnchor(entry: LiveAircraft, now: number): number {
+  const reportedS = entry.seen_pos_s;
+  if (reportedS === null || !Number.isFinite(reportedS) || reportedS <= 0) {
+    return now;
+  }
+  return now - Math.min(reportedS * 1000, MAX_REPORTED_FIX_AGE_MS);
+}
+
 /** The record for a freshly delivered aircraft object, inheriting the position
- * anchor from the record it replaces when the fix has not moved. */
+ * anchor from the record it replaces when the fix has not moved — a repeated
+ * fix keeps the anchor it was given, whatever its reported age has grown to. */
 function upsert(
   entry: LiveAircraft,
   previous: LiveAircraftRecord | undefined,
@@ -217,7 +276,7 @@ function upsert(
     positionChangedAt:
       previous && samePosition(previous.aircraft, entry)
         ? previous.positionChangedAt
-        : now,
+        : fixAnchor(entry, now),
   };
 }
 

--- a/frontend/src/features/map/aircraft/useLiveConnection.ts
+++ b/frontend/src/features/map/aircraft/useLiveConnection.ts
@@ -26,6 +26,7 @@ import { useEffect } from "react";
 
 import { useActivityFeedStore } from "@/features/activity/store/useActivityFeedStore";
 import { useLiveAircraftStore } from "@/features/map/aircraft/store/useLiveAircraftStore";
+import { resetDensityLatch } from "@/features/map/labels/densityLatch";
 import { dispatchAlertNotification } from "@/features/notifications/lib/dispatch";
 import { LiveSocket } from "@/lib/ws/liveSocket";
 
@@ -58,6 +59,12 @@ export function useLiveConnection(): void {
       socket.stop();
       store().reset();
       activity().reset();
+      // The label-density latch (issue #143) is memory *about* the picture
+      // the store just dropped, so it is cleared with it. It would clear
+      // itself on the next drawn frame anyway — an empty picture is a count
+      // of zero — but a remount should not have to spend a frame in the
+      // dead connection's tier to get there.
+      resetDensityLatch();
     };
   }, []);
 }

--- a/frontend/src/features/map/labels/densityLatch.test.ts
+++ b/frontend/src/features/map/labels/densityLatch.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  resetDensityLatch,
+  updateDensityLatch,
+} from "@/features/map/labels/densityLatch";
+import {
+  DENSITY_CALLSIGN_ENTER,
+  DENSITY_CALLSIGN_EXIT,
+} from "@/features/map/labels/priority";
+
+afterEach(() => {
+  resetDensityLatch();
+});
+
+describe("updateDensityLatch", () => {
+  it("starts unlatched", () => {
+    expect(updateDensityLatch(DENSITY_CALLSIGN_ENTER)).toBe(false);
+  });
+
+  it("carries the latch across calls, which is the whole point of it", () => {
+    expect(updateDensityLatch(DENSITY_CALLSIGN_ENTER + 1)).toBe(true);
+    expect(updateDensityLatch(DENSITY_CALLSIGN_EXIT + 1)).toBe(true);
+    expect(updateDensityLatch(DENSITY_CALLSIGN_EXIT - 1)).toBe(false);
+    expect(updateDensityLatch(DENSITY_CALLSIGN_EXIT + 1)).toBe(false);
+  });
+});
+
+describe("resetDensityLatch", () => {
+  it("drops a held latch so the next frame is judged with no history", () => {
+    expect(updateDensityLatch(DENSITY_CALLSIGN_ENTER + 1)).toBe(true);
+    resetDensityLatch();
+    expect(updateDensityLatch(DENSITY_CALLSIGN_ENTER)).toBe(false);
+  });
+});

--- a/frontend/src/features/map/labels/densityLatch.ts
+++ b/frontend/src/features/map/labels/densityLatch.ts
@@ -1,0 +1,40 @@
+/**
+ * The one piece of memory the label tiering needs (issue #143).
+ *
+ * `labels/priority.ts` decides the density tier from a *latch* rather than
+ * from a bare count, so a live picture hovering on the threshold cannot
+ * toggle the altitude line on and off every frame. Something has to remember
+ * which side of the band the last frame landed on, and this module is that
+ * something — deliberately the smallest possible amount of state, kept out of
+ * both the pure tier function and the pure GeoJSON builder.
+ *
+ * Module-level rather than per-map, the same shape (and for the same reason)
+ * as `features/filters/lib/filteredLiveAircraftCache`: the frame loop is a
+ * single imperative path with no instance to hang state off, there is exactly
+ * one live picture per tab, and a `let` here is a great deal cheaper than
+ * threading a mutable box through `drawAircraftFrame` on every tick.
+ *
+ * It self-clears without help — an empty picture is a count of zero, which is
+ * below the band's lower edge — so a store reset already unlatches on the
+ * next drawn frame. {@link resetDensityLatch} exists so teardown does not
+ * have to *wait* for that frame (`useLiveConnection` calls it alongside the
+ * stores' own resets), and so one test's dense picture can never leak into
+ * the next test's sparse one.
+ */
+
+import { nextDensityLatched } from "@/features/map/labels/priority";
+
+let latched = false;
+
+/** Advances the latch with this frame's live count and returns the new state
+ * — what `deriveLabelTier` takes as `densityLatched`. */
+export function updateDensityLatch(liveCount: number): boolean {
+  latched = nextDensityLatched(latched, liveCount);
+  return latched;
+}
+
+/** Drops the latch back to "not dense", so the next frame is judged with no
+ * history behind it. */
+export function resetDensityLatch(): void {
+  latched = false;
+}

--- a/frontend/src/features/map/labels/priority.test.ts
+++ b/frontend/src/features/map/labels/priority.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  DENSITY_CALLSIGN_THRESHOLD,
+  DENSITY_CALLSIGN_ENTER,
+  DENSITY_CALLSIGN_EXIT,
   deriveLabelSortKey,
   deriveLabelTier,
+  nextDensityLatched,
   SORT_KEY_DEFAULT,
   SORT_KEY_INTERESTING,
   SORT_KEY_SELECTED,
@@ -16,7 +18,7 @@ describe("deriveLabelTier", () => {
     expect(
       deriveLabelTier({
         zoom: ZOOM_LABELS_MIN - 0.1,
-        liveCount: 1,
+        densityLatched: false,
         priority: false,
       }),
     ).toBe("none");
@@ -24,12 +26,16 @@ describe("deriveLabelTier", () => {
 
   it("shows callsign only from the minimum zoom up to (not including) the full-label zoom", () => {
     expect(
-      deriveLabelTier({ zoom: ZOOM_LABELS_MIN, liveCount: 1, priority: false }),
+      deriveLabelTier({
+        zoom: ZOOM_LABELS_MIN,
+        densityLatched: false,
+        priority: false,
+      }),
     ).toBe("callsign");
     expect(
       deriveLabelTier({
         zoom: ZOOM_LABELS_FULL - 0.1,
-        liveCount: 1,
+        densityLatched: false,
         priority: false,
       }),
     ).toBe("callsign");
@@ -39,50 +45,102 @@ describe("deriveLabelTier", () => {
     expect(
       deriveLabelTier({
         zoom: ZOOM_LABELS_FULL,
-        liveCount: 1,
+        densityLatched: false,
         priority: false,
       }),
     ).toBe("full");
   });
 
-  it("drops to callsign-only once the live count exceeds the density threshold, even above the full-label zoom", () => {
+  it("drops to callsign-only while the density latch is on, even above the full-label zoom", () => {
     expect(
       deriveLabelTier({
         zoom: ZOOM_LABELS_FULL,
-        liveCount: DENSITY_CALLSIGN_THRESHOLD,
-        priority: false,
-      }),
-    ).toBe("full");
-    expect(
-      deriveLabelTier({
-        zoom: ZOOM_LABELS_FULL,
-        liveCount: DENSITY_CALLSIGN_THRESHOLD + 1,
+        densityLatched: true,
         priority: false,
       }),
     ).toBe("callsign");
   });
 
-  it("never lets density push a label all the way to none", () => {
+  it("still hides a latched label below the minimum zoom — zoom wins over density", () => {
     expect(
       deriveLabelTier({
-        zoom: ZOOM_LABELS_FULL,
-        liveCount: 100_000,
+        zoom: ZOOM_LABELS_MIN - 0.1,
+        densityLatched: true,
         priority: false,
       }),
-    ).toBe("callsign");
+    ).toBe("none");
   });
 
   it("always returns full for a priority aircraft, regardless of zoom or density", () => {
     expect(
-      deriveLabelTier({ zoom: 0, liveCount: 100_000, priority: true }),
+      deriveLabelTier({ zoom: 0, densityLatched: true, priority: true }),
     ).toBe("full");
     expect(
       deriveLabelTier({
         zoom: ZOOM_LABELS_MIN - 1,
-        liveCount: 0,
+        densityLatched: false,
         priority: true,
       }),
     ).toBe("full");
+  });
+});
+
+describe("nextDensityLatched", () => {
+  it("keeps the band's edges apart, entering above the exit count", () => {
+    // A single threshold is the bug (issue #143) — pin that there are two,
+    // and which way round they go.
+    expect(DENSITY_CALLSIGN_EXIT).toBeLessThan(DENSITY_CALLSIGN_ENTER);
+  });
+
+  it("latches on only once the count rises above the upper edge", () => {
+    expect(nextDensityLatched(false, DENSITY_CALLSIGN_ENTER - 1)).toBe(false);
+    expect(nextDensityLatched(false, DENSITY_CALLSIGN_ENTER)).toBe(false);
+    expect(nextDensityLatched(false, DENSITY_CALLSIGN_ENTER + 1)).toBe(true);
+  });
+
+  it("stays latched while the count falls back through the band", () => {
+    // The blink itself: 61 -> 55 -> 61 must not change the label content.
+    let latched = nextDensityLatched(false, DENSITY_CALLSIGN_ENTER + 1);
+    expect(latched).toBe(true);
+    latched = nextDensityLatched(latched, DENSITY_CALLSIGN_EXIT + 5);
+    expect(latched).toBe(true);
+    latched = nextDensityLatched(latched, DENSITY_CALLSIGN_ENTER - 1);
+    expect(latched).toBe(true);
+  });
+
+  it("unlatches only once the count falls below the lower edge", () => {
+    expect(nextDensityLatched(true, DENSITY_CALLSIGN_EXIT + 1)).toBe(true);
+    expect(nextDensityLatched(true, DENSITY_CALLSIGN_EXIT)).toBe(true);
+    expect(nextDensityLatched(true, DENSITY_CALLSIGN_EXIT - 1)).toBe(false);
+  });
+
+  it("holds whatever the previous frame decided while inside the band", () => {
+    for (
+      let count = DENSITY_CALLSIGN_EXIT;
+      count <= DENSITY_CALLSIGN_ENTER;
+      count += 1
+    ) {
+      expect(nextDensityLatched(true, count)).toBe(true);
+      expect(nextDensityLatched(false, count)).toBe(false);
+    }
+  });
+
+  it("unlatches on an empty picture whatever the previous frame said", () => {
+    // What makes a store reset or a dropped connection settle on its own.
+    expect(nextDensityLatched(true, 0)).toBe(false);
+  });
+
+  it("does not oscillate for a count churning across the upper edge", () => {
+    // The reported symptom: a receiver gaining and losing a contact around
+    // 60 produced a new tier every frame. Walk that sequence and assert the
+    // latch never moves after the first crossing.
+    let latched = false;
+    const seen: boolean[] = [];
+    for (const count of [59, 61, 60, 59, 61, 58, 60, 61]) {
+      latched = nextDensityLatched(latched, count);
+      seen.push(latched);
+    }
+    expect(seen).toEqual([false, true, true, true, true, true, true, true]);
   });
 });
 

--- a/frontend/src/features/map/labels/priority.ts
+++ b/frontend/src/features/map/labels/priority.ts
@@ -12,7 +12,10 @@
  *    zoom and the live picture's density before MapLibre ever sees a
  *    feature. Selected and interesting aircraft always get the full stack;
  *    everyone else steps from full → callsign-only → nothing as the view
- *    zooms out or the picture gets crowded.
+ *    zooms out or the picture gets crowded. The density step is latched
+ *    through a hysteresis band (issue #143) so a live count sitting on the
+ *    edge cannot toggle the label content frame after frame; the latch
+ *    itself lives with the caller, not here.
  *
  * Roadmap slice 015 asks for "suppress operator first, then secondary
  * text". The operator line already suppresses itself whenever the metadata
@@ -35,22 +38,74 @@ export const ZOOM_LABELS_MIN = 7;
  * Between {@link ZOOM_LABELS_MIN} and this, callsign only. */
 export const ZOOM_LABELS_FULL = 10;
 
-/** Live aircraft count above which every non-priority label drops to
- * callsign-only regardless of zoom (the density override). Chosen well
- * under the 500-aircraft rendering target (roadmap slice 014): a dense
- * scene reads as a wall of three-line labels long before it reads as 500
+/**
+ * The density override's hysteresis band (issue #143).
+ *
+ * Every non-priority label drops to callsign-only, regardless of zoom, once
+ * the live count rises *above* {@link DENSITY_CALLSIGN_ENTER}, and the full
+ * stack only comes back once it falls *below* {@link DENSITY_CALLSIGN_EXIT}.
+ * Between the two edges the previous decision stands.
+ *
+ * The upper edge is where the override has always sat: well under the
+ * 500-aircraft rendering target (roadmap slice 014), because a dense scene
+ * reads as a wall of three-line labels long before it reads as 500
  * individual aircraft, so decluttering has to kick in far earlier than the
- * performance ceiling does. */
-export const DENSITY_CALLSIGN_THRESHOLD = 60;
+ * performance ceiling does.
+ *
+ * The lower edge is what stops the labels blinking. A single threshold means
+ * a picture hovering at the edge — which is the *normal* state of a busy
+ * receiver, gaining and losing a contact every second or two — toggles the
+ * altitude line on and off continuously. A ten-aircraft band is wide enough
+ * that ordinary churn cannot cross it, and narrow enough that a picture
+ * genuinely thinning out gets its full labels back within a frame or two of
+ * actually being sparse.
+ *
+ * The zoom edges ({@link ZOOM_LABELS_MIN}, {@link ZOOM_LABELS_FULL}) get no
+ * such band, deliberately: zoom only changes because the viewer changed it,
+ * so a boundary crossing there is an intended act rather than the picture
+ * flapping under its own noise.
+ */
+export const DENSITY_CALLSIGN_ENTER = 60;
+
+/** The band's lower edge — see {@link DENSITY_CALLSIGN_ENTER}. */
+export const DENSITY_CALLSIGN_EXIT = 50;
+
+/**
+ * The density override's next latch state, given the previous one and this
+ * frame's live count.
+ *
+ * Pure, and the *only* place the band is interpreted: `deriveLabelTier` takes
+ * the answer, so the latch's owner is whoever is drawing frames in sequence
+ * (`aircraft/frame.ts` via `labels/densityLatch.ts`) rather than this module.
+ * A one-off caller with no history passes `false` and gets the plain
+ * "is this picture dense right now" answer.
+ */
+export function nextDensityLatched(
+  previous: boolean,
+  liveCount: number,
+): boolean {
+  if (liveCount > DENSITY_CALLSIGN_ENTER) {
+    return true;
+  }
+  if (liveCount < DENSITY_CALLSIGN_EXIT) {
+    return false;
+  }
+  return previous;
+}
 
 export interface LabelTierInput {
   /** Current map zoom (`map.getZoom()`). */
   zoom: number;
-  /** Count of live aircraft in the picture
-   * (`Object.keys(store.aircraft).length`) — cheap, and a reasonable proxy
-   * for "how much text is about to compete for the same screen" without a
-   * per-frame viewport query. */
-  liveCount: number;
+  /**
+   * Whether the density override is currently latched on — the resolved
+   * output of {@link nextDensityLatched} for this frame's live count.
+   *
+   * A boolean rather than the count itself so this function stays pure while
+   * the decision it depends on is stateful: the count is cheap (the size of
+   * the drawn picture, not a per-frame viewport query), but "is the picture
+   * dense" is only answerable with reference to what it was a frame ago.
+   */
+  densityLatched: boolean;
   /** True for the selected aircraft or one carrying an active interesting
    * match — both always get the full stack, in and out of zoom/density. */
   priority: boolean;
@@ -59,7 +114,7 @@ export interface LabelTierInput {
 /** Resolves how much of the label stack an aircraft gets this frame. */
 export function deriveLabelTier({
   zoom,
-  liveCount,
+  densityLatched,
   priority,
 }: LabelTierInput): LabelTier {
   if (priority) {
@@ -68,7 +123,7 @@ export function deriveLabelTier({
   if (zoom < ZOOM_LABELS_MIN) {
     return "none";
   }
-  if (liveCount > DENSITY_CALLSIGN_THRESHOLD) {
+  if (densityLatched) {
     return "callsign";
   }
   return zoom >= ZOOM_LABELS_FULL ? "full" : "callsign";

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach, vi } from "vitest";
 
+import { resetDensityLatch } from "@/features/map/labels/densityLatch";
 import * as echartsCoreMock from "@/test/echartsMock";
 import { resetEchartsMock } from "@/test/echartsMock";
 import { AttributionControlMock, MapLibreMockMap } from "@/test/maplibreGlMock";
@@ -123,4 +124,8 @@ afterEach(() => {
   cleanup();
   resetWebSocketMock();
   resetEchartsMock();
+  // The label-density latch (issue #143) is module-level and deliberately
+  // remembers the previous frame, so one test's crowded picture would
+  // otherwise decide the next test's label tier.
+  resetDensityLatch();
 });

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1619,6 +1619,50 @@ slices:
     risk_level: medium
     notes: "Owner measured 80 shown against 59 audible on the Pi at v0.2.0. Fixes GitHub issue #134. Added by Fable outside the phase plan."
 
+  - id: "063"
+    title: "Aircraft label stability"
+    phase: 8
+    branch: "063-label-stability"
+    status: merged
+    depends_on: ["014", "015"]
+    objective: "Stop aircraft labels blinking on a busy picture: give slice 015's density tier a hysteresis band so a live count sitting on the threshold cannot toggle the label content every frame, and let a colliding non-selected label try other placements before MapLibre hides it (issue #143)."
+    scope:
+      - "`labels/priority.ts` replaces the single `DENSITY_CALLSIGN_THRESHOLD` with a documented band — `DENSITY_CALLSIGN_ENTER` (60) to enter callsign-only, `DENSITY_CALLSIGN_EXIT` (50) to return to the full stack — resolved by a pure `nextDensityLatched(previous, liveCount)`"
+      - "`deriveLabelTier` stays pure by taking the resolved `densityLatched` boolean instead of the raw count; the zoom edges (7/10) keep no band, because zoom only moves when the viewer moves it"
+      - "`labels/densityLatch.ts` holds the one latch bit for the frame loop, module-level in the shape `filteredLiveAircraftCache` already uses, with an explicit reset"
+      - "`aircraft/frame.ts` advances the latch once per frame on the same post-filter count and passes it into the GeoJSON builder, which keeps its own count-only fallback for callers that draw a single frame"
+      - "`useLiveConnection` clears the latch alongside the store resets on teardown; an empty picture unlatches on its own regardless"
+      - "the non-selected label layer swaps its fixed `text-anchor`/`text-offset` for `text-variable-anchor` (top, bottom, right, left) plus `text-radial-offset`, so a label that loses the collision contest relocates around its aircraft and is hidden only when no candidate fits"
+    out_of_scope:
+      - "the selected-aircraft label layer, which keeps its fixed anchor and its always-visible `text-allow-overlap`/`text-ignore-placement` pair (slice 015's acceptance criterion)"
+      - "the `symbol-sort-key` collision priorities and the label content builder, both unchanged"
+      - "the zoom tier boundaries and the tier ladder itself"
+      - "backend changes; the live count this reads is slice 062's, already honest"
+      - "visual-regression baselines: the live-map baseline hides the MapLibre canvas, so no placement change can reach it"
+    acceptance_criteria:
+      - "a live count oscillating across 60 does not toggle label content; the tier changes only after the count clears the far edge of the band"
+      - "a count rising 59 -> 61 latches to callsign-only, falling back to 55 stays latched, and only below 50 returns to the full stack"
+      - "selected and interesting aircraft keep the full stack at any count, latched or not"
+      - "the non-selected label layer offers more than one placement, leads with the placement it used before, and sets neither `text-anchor` nor `text-offset` (which MapLibre ignores under variable anchoring)"
+      - "the selected label layer still uses the fixed anchor/offset pair and no variable anchoring"
+      - "a store reset or a dropped connection leaves the latch cleared, so a reconnect is judged on its own picture"
+    required_tests:
+      - hysteresis band unit tests over the rising, falling, in-band and empty-picture cases, plus a churning-count sequence that must not oscillate
+      - latch module tests for carry-across-calls and reset
+      - frame-loop tests drawing a sequence of frames and asserting the drawn label text through the real frame -> geojson path
+      - geojson tests for an explicitly latched and an explicitly cleared frame
+      - layer tests pinning variable anchoring on the non-selected label layer and its absence on the selected one
+    expected_artifacts:
+      - frontend/src/features/map/labels/priority.ts
+      - frontend/src/features/map/labels/densityLatch.ts
+      - frontend/src/features/map/aircraft/geojson.ts
+      - frontend/src/features/map/aircraft/frame.ts
+      - frontend/src/features/map/aircraft/aircraftLayers.ts
+      - frontend/src/features/map/aircraft/useLiveConnection.ts
+    preferred_agent: opus
+    risk_level: low
+    notes: "Owner-reported on the Pi at v0.3.0; slice 062's honester live count made the threshold flapping more visible. Fixes GitHub issue #143. Frontend-only. Added by Fable outside the phase plan."
+
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,
 # 027, 031, 033, 035, 037, 038, 052) are ADDITIONALLY serialized against each other

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1619,6 +1619,45 @@ slices:
     risk_level: medium
     notes: "Owner measured 80 shown against 59 audible on the Pi at v0.2.0. Fixes GitHub issue #134. Added by Fable outside the phase plan."
 
+  - id: "064"
+    title: "Honest position-fix anchor"
+    phase: 8
+    branch: "064-fix-age-anchor"
+    status: merged
+    depends_on: ["054"]
+    objective: "Date each position fix by the age the decoder reports for it instead of by the instant the frame arrived, so dead reckoning hands over from one fix to the next without the periodic backwards step slice 054's fix left behind (issue #144)."
+    scope:
+      - "`useLiveAircraftStore` dates a *new* fix at `receivedAt - seen_pos_s * 1000`, clamped to `[0, INTERPOLATION_MAX_FIX_AGE_MS]`, falling back to `receivedAt` for a null, negative or non-finite reported age"
+      - "the same dating on both application paths, so a snapshot and a delta carrying one fix anchor it identically"
+      - "a repeated fix keeps the anchor it already has, however far its reported age has grown — an ageing `seen_pos_s` on an unchanged position must not walk the anchor backwards"
+      - "`INTERPOLATION_MAX_FIX_AGE_MS` doubles as the clamp: a fix older than the interpolator will project cannot be back-dated further than that bound"
+      - "the `interpolation.ts` and store module docstrings record the dating scheme, why the projection is now continuous across fixes for straight flight (the shared transport latency cancels; only the decode age differs between fixes), and why the correction blend declined in 054 stays declined now that its premise holds"
+    out_of_scope:
+      - "backend changes: `seen_pos_s` is already served (§3.3) and already honest since slice 062"
+      - "a correction blend or any other change to `displayPosition`, its two bounds, or the stall-grace path, all unchanged"
+      - "reading the receiver's clock: the #119 rule stands, and a reported *duration* subtracted from a browser timestamp mixes no clocks"
+      - "the track layer, the detail panel, and every other consumer of the reported position, which read the payload rather than the projection"
+    acceptance_criteria:
+      - "a distant aircraft on a 2-10 s CPR cadence with nonzero `seen_pos_s` draws a continuous path: the projection either side of a new fix's arrival differs by the sampling interval's travel and no more"
+      - "at the moment a frame lands the marker sits where the aircraft was when the backend polled, leaving only the shared transport lag no client-side arithmetic could remove"
+      - "an aircraft reporting `seen_pos_s` null or 0 behaves bit-for-bit as before the slice"
+      - "an outlier reported age is clamped to the fix-age bound rather than throwing the anchor minutes into the past"
+      - "frames repeating a fix with a growing reported age leave the anchor untouched"
+      - "no regression in the slice-054 stall and staleness freezes"
+    required_tests:
+      - store tests for back-dating on the snapshot and delta paths, their agreement on one fix, and the null/zero/negative/NaN/infinite fallbacks
+      - store tests for the outlier clamp and for repeated fixes with growing reported ages on both paths
+      - regression tests driving the store with modelled decode ages and a constant transport lag - no back-step across the sequence, no step at the fix handover, a new fix drawn ahead of its raw coordinates, and the drawn path tracking truth lagged only by transport
+      - the existing #119 scenario re-pinned at `seen_pos_s: 0` so its expectations stay the pre-slice ones exactly
+    expected_artifacts:
+      - frontend/src/features/map/aircraft/store/useLiveAircraftStore.ts
+      - frontend/src/features/map/aircraft/interpolation.ts
+      - frontend/src/features/map/aircraft/snapback.regression.test.ts
+      - frontend/src/features/map/aircraft/store/useLiveAircraftStore.test.ts
+    preferred_agent: opus
+    risk_level: low
+    notes: "Owner reported markers still oscillating on the Pi at v0.3.0. Fixes GitHub issue #144, the residual systematic term slice 054's no-correction-blend rationale underestimated. Frontend-only, client-side mirror of slice 062's server-side ageing. Added by Fable outside the phase plan."
+
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,
 # 027, 031, 033, 035, 037, 038, 052) are ADDITIONALLY serialized against each other

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -79,6 +79,10 @@ releases:
       real deployment: first-run ingestion hot-start, activity WS batching,
       quick-wins bundle, OpenSky metadata source, Pi 4 baseline, selected-track
       backfill, live-set ghost expiry (slices 056-062). Recorded 2026-09-02."
+  - version: "v0.3.1"
+    after_phase: 8
+    theme: "Same-day patch: aircraft label stability (hysteresis + relocate-before-hide)
+      and the honest position-fix anchor (slices 063-064). Recorded 2026-09-02."
   - version: "v1.0.0"
     after_phase: 8
     theme: "Qualified stable release per SPEC.md §114 definition of done."


### PR DESCRIPTION
Release v0.3.1 — same-day patch for two owner-reported live-map irritations (slices 063–064).

- **Labels no longer blink** (#143): density hysteresis band (enter callsign-only >60, exit <50) + colliding labels relocate around their aircraft before hiding
- **Markers no longer oscillate forward/back** (#144): fixes dated by the decoder's own `seen_pos` age — projections hand over continuously between fixes

Both slices built by Opus agents with adversarial Opus reviews (MERGE verdicts; follow-ups tracked in #145, #147). Release mechanics verified: `uv.lock` refreshed after bump + `uv sync --locked` clean; main confirmed ancestor before opening.

Post-merge: tag `v0.3.1` → GitHub Release → GHCR publish → back-merge → Pi upgrade. Owner pre-approved this train ("Yes, do the v0.3.1 cut release and load on to the RPi").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTAJUucu2ZPAD235B3GQeZ