### PR TITLE
chore: back-merge v0.3.1 release into dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ follows [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/) (`0.x.y` during pre-1.0 development).
 This file is updated only on release branches (see `docs/RELEASE.md`).
 
+## [0.3.1] — 2026-09-02
+
+A same-day patch for two owner-reported live-map irritations.
+
+### Fixed
+- **Aircraft labels no longer blink**: the density-driven label tier latches
+  through a hysteresis band (callsign-only above 60 visible aircraft,
+  full stack again below 50) instead of flapping on a single threshold, and
+  a colliding label now tries the other sides of its aircraft
+  (`text-variable-anchor`, per-anchor justification) before MapLibre hides
+  it; the selected aircraft's label remains always visible (#143)
+- **Aircraft markers no longer oscillate forward and back**: position fixes
+  are dated by the decoder's own `seen_pos` age instead of their arrival
+  time, so dead reckoning projects from the moment the fix was actually
+  measured and consecutive projections hand over continuously — the
+  per-decode backwards step (fix age × ground speed, ~0.1–0.3 nm at jet
+  speeds) is gone (#144)
+
 ## [0.3.0] — 2026-09-02
 
 A fresh-install polish and live-picture correctness release, driven by the

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flightsite"
-version = "0.3.0"
+version = "0.3.1"
 description = "FlightSite backend: self-hosted ADS-B observatory API and ingestion service."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "flightsite"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flightsite-frontend",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flightsite-frontend",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@radix-ui/react-separator": "^1.1.15",
         "@radix-ui/react-slot": "^1.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flightsite-frontend",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -79,6 +79,10 @@ releases:
       real deployment: first-run ingestion hot-start, activity WS batching,
       quick-wins bundle, OpenSky metadata source, Pi 4 baseline, selected-track
       backfill, live-set ghost expiry (slices 056-062). Recorded 2026-09-02."
+  - version: "v0.3.1"
+    after_phase: 8
+    theme: "Same-day patch: aircraft label stability (hysteresis + relocate-before-hide)
+      and the honest position-fix anchor (slices 063-064). Recorded 2026-09-02."
   - version: "v1.0.0"
     after_phase: 8
     theme: "Qualified stable release per SPEC.md §114 definition of done."


### PR DESCRIPTION
Brings the v0.3.1 release commit and main's release merge commit back into dev, keeping main an ancestor of dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTAJUucu2ZPAD235B3GQeZ