### PR TITLE
fix(filters): un-gate the Military quick-filter chip on real metadata availability (slice 066)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -145,6 +145,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 062 | Live-set ghost expiry | 007, 008, 009 | opus | medium | Age live records by the decoder's own "last heard" report so dump1090's ~5-minute retention window stops inflating the live count and the 15 s / 60 s thresholds fire on time (issue #134) |
 | 063 | Aircraft label stability | 014, 015 | opus | low | Stop aircraft labels blinking: a hysteresis band on the density tier, and variable anchoring so a colliding label relocates before it hides (issue #143) |
 | 064 | Honest position-fix anchor | 054 | opus | low | Date each position fix by the decode age the frame reports rather than by its arrival, so dead reckoning hands over between fixes without the periodic backwards step (issue #144) |
+| 066 | Military chip metadata gate | 017, 025 | opus | low | Gate the live map's Military quick-filter chip on whether this install has imported aircraft metadata instead of on the long-lifted slice-017 gate, and refresh the drawer's stale metadata notes (issue #151) |
 
 ## Parallelization Guide
 

--- a/frontend/src/features/filters/components/FilterDrawer.test.tsx
+++ b/frontend/src/features/filters/components/FilterDrawer.test.tsx
@@ -157,18 +157,29 @@ describe("FilterDrawer", () => {
     ).toHaveTextContent(/matches nothing until an aircraft-metadata import/i);
   });
 
-  it("notes the missing import on every metadata-backed section when nothing is imported", async () => {
+  it("notes the missing import on exactly the two import-only sections", async () => {
     renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
 
-    // Category/operator, classification, and mission category.
+    // Category/operator and classification — and those two only. Mission is
+    // not among them: the classification engine infers it from the
+    // callsign's airline designator with no import at all.
     const notes = await screen.findAllByText(
       /matches nothing until an aircraft-metadata import runs \(settings → metadata\)/i,
     );
-    expect(notes).toHaveLength(3);
+    expect(notes).toHaveLength(2);
   });
 
-  it("drops the metadata-import notes once metadata is imported", async () => {
+  it("tells the truth about mission category, which callsign inference already fills", async () => {
+    renderDrawer();
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }));
+
+    const note = screen.getByText(/inferred from the callsign/i);
+    expect(note).toHaveTextContent(/widens coverage by adding type-based/i);
+    expect(note).not.toHaveTextContent(/matches nothing until/i);
+  });
+
+  it("keeps the mission-category note and drops the import notes once metadata is imported", async () => {
     installMetadataApiMock({ statusSequence: [IMPORTED] });
     renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
@@ -180,7 +191,10 @@ describe("FilterDrawer", () => {
         ),
       ).not.toBeInTheDocument(),
     );
-    // The filters themselves are untouched — only the caveat goes away.
+    // The mission note is unconditional — it describes how mission is
+    // derived, not a prerequisite.
+    expect(screen.getByText(/inferred from the callsign/i)).toBeInTheDocument();
+    // The filters themselves are untouched — only the caveats go away.
     expect(screen.getByRole("checkbox", { name: "Military" })).toBeEnabled();
     expect(screen.getByLabelText(/aircraft type/i)).toBeEnabled();
   });

--- a/frontend/src/features/filters/components/FilterDrawer.test.tsx
+++ b/frontend/src/features/filters/components/FilterDrawer.test.tsx
@@ -1,18 +1,54 @@
-import { render, screen, within } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FilterDrawer } from "@/features/filters/components/FilterDrawer";
 import { useFilterStore } from "@/features/filters/store/useFilterStore";
 import { DEFAULT_FILTERS } from "@/features/filters/types";
+import type { MetadataStatusResponse } from "@/lib/api/metadata";
+import { installMetadataApiMock, metadataSource } from "@/test/metadataApiMock";
+import { renderWithProviders } from "@/test/test-utils";
+
+/** One source with a dataset installed — the case where the drawer's
+ * metadata-backed filters genuinely filter. */
+const IMPORTED: MetadataStatusResponse = {
+  sources: [
+    metadataSource({
+      name: "mictronics",
+      status: "ok",
+      row_count: 412_003,
+      last_success_ms: 1_756_600_000_000,
+      dataset_version: "2026-08-01",
+    }),
+  ],
+};
 
 beforeEach(() => {
   useFilterStore.setState({ filters: DEFAULT_FILTERS });
+  // Default: a stock install with nothing imported, so the metadata-import
+  // notes are present unless a test says otherwise.
+  installMetadataApiMock({
+    statusSequence: [
+      {
+        sources: [metadataSource({ name: "mictronics", status: "never-run" })],
+      },
+    ],
+  });
 });
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** The drawer reads metadata status through TanStack Query, so every render
+ * needs a `QueryClientProvider` (roadmap slice 066). */
+function renderDrawer() {
+  return renderWithProviders(<FilterDrawer />);
+}
 
 describe("FilterDrawer", () => {
   it("starts closed and opens on toggle", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     expect(screen.queryByTestId("filter-drawer")).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
@@ -23,7 +59,7 @@ describe("FilterDrawer", () => {
   });
 
   it("closes on Escape", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     expect(screen.getByTestId("filter-drawer")).toBeInTheDocument();
 
@@ -32,7 +68,7 @@ describe("FilterDrawer", () => {
   });
 
   it("closes on the close button", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.click(
       screen.getByRole("button", { name: /close filters/i }),
@@ -41,12 +77,12 @@ describe("FilterDrawer", () => {
   });
 
   it("shows no active-count badge with the defaults", () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     expect(screen.queryByTestId("filter-active-count")).not.toBeInTheDocument();
   });
 
   it("updates the active-count badge as filters change and clears via Clear all", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
 
     await userEvent.type(
@@ -62,7 +98,7 @@ describe("FilterDrawer", () => {
   });
 
   it("edits the altitude range", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.type(screen.getByLabelText(/minimum altitude/i), "1000");
     expect(useFilterStore.getState().filters.altitudeMinFt).toBe(1000);
@@ -75,14 +111,14 @@ describe("FilterDrawer", () => {
   });
 
   it("edits the distance override", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.type(screen.getByLabelText(/maximum distance/i), "75");
     expect(useFilterStore.getState().filters.maxDistanceNm).toBe(75);
   });
 
   it("edits the category, operator, and operator-group text filters", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.type(screen.getByLabelText(/aircraft type/i), "737");
     await userEvent.type(screen.getByLabelText(/^operator$/i), "BAW");
@@ -95,7 +131,7 @@ describe("FilterDrawer", () => {
   });
 
   it("toggles emergency-only and interesting-only", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.click(
       screen.getByRole("checkbox", { name: /emergency squawk only/i }),
@@ -109,20 +145,48 @@ describe("FilterDrawer", () => {
     });
   });
 
-  it("toggles a classification checkbox and explains the today-selects-nothing behavior", async () => {
-    render(<FilterDrawer />);
+  it("toggles a classification checkbox and explains that it needs a metadata import", async () => {
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.click(screen.getByRole("checkbox", { name: "Military" }));
     expect(useFilterStore.getState().filters.classifications).toEqual([
       "military",
     ]);
     expect(
-      screen.getByText(/selects nothing until aircraft metadata/i),
-    ).toBeInTheDocument();
+      screen.getByText(/never guesses a classification/i),
+    ).toHaveTextContent(/matches nothing until an aircraft-metadata import/i);
+  });
+
+  it("notes the missing import on every metadata-backed section when nothing is imported", async () => {
+    renderDrawer();
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }));
+
+    // Category/operator, classification, and mission category.
+    const notes = await screen.findAllByText(
+      /matches nothing until an aircraft-metadata import runs \(settings → metadata\)/i,
+    );
+    expect(notes).toHaveLength(3);
+  });
+
+  it("drops the metadata-import notes once metadata is imported", async () => {
+    installMetadataApiMock({ statusSequence: [IMPORTED] });
+    renderDrawer();
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(
+          /matches nothing until an aircraft-metadata import/i,
+        ),
+      ).not.toBeInTheDocument(),
+    );
+    // The filters themselves are untouched — only the caveat goes away.
+    expect(screen.getByRole("checkbox", { name: "Military" })).toBeEnabled();
+    expect(screen.getByLabelText(/aircraft type/i)).toBeEnabled();
   });
 
   it("adds and removes a mission category chip", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     const input = screen.getByLabelText(/add mission category/i);
     await userEvent.type(input, "medevac{enter}");
@@ -135,7 +199,7 @@ describe("FilterDrawer", () => {
   });
 
   it("selects a ground-traffic mode from the segmented control", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     const group = screen.getByRole("radiogroup", { name: /ground traffic/i });
     await userEvent.click(within(group).getByRole("radio", { name: "Dim" }));
@@ -143,7 +207,7 @@ describe("FilterDrawer", () => {
   });
 
   it("toggles hide-stale and hide-non-positioned checkboxes", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.click(
       screen.getByRole("checkbox", { name: /hide stale aircraft/i }),

--- a/frontend/src/features/filters/components/FilterDrawer.tsx
+++ b/frontend/src/features/filters/components/FilterDrawer.tsx
@@ -7,14 +7,24 @@
  * filter state of its own and can never drift from what the map is
  * actually drawing.
  *
- * Fields that match aircraft metadata (type/operator/operator group,
- * classification, mission) stay fully interactive rather than disabled, but
- * carry an inline note whenever this install has not imported metadata yet —
- * without it those filters match nothing, and the note says where to fix
- * that. Once an import has landed (`useMetadataAvailable`, slice 066) the
- * notes disappear, because the filters genuinely filter. "Interesting only"
- * was gated the same way until slice 038 started populating `interesting`
- * and slice 039 surfaced it.
+ * Fields that can only match imported aircraft metadata — type, operator,
+ * operator group, and the classification flags — stay fully interactive
+ * rather than disabled, but carry an inline note whenever this install has
+ * not imported any, because without it they match nothing. Once an import
+ * has landed (`useMetadataAvailable`, slice 066) those notes disappear,
+ * because the filters genuinely filter.
+ *
+ * Mission category is deliberately *not* in that set. The classification
+ * engine infers a mission from the callsign's airline designator against a
+ * bundled operator directory (`classification/engine.py`, `operators.py`),
+ * so airline traffic carries a mission on a metadata-less install; metadata
+ * only widens the coverage by adding type-code inference. Its note says
+ * that, unconditionally, rather than claiming a prerequisite it does not
+ * have. Classification flags are the opposite case and the note is right
+ * there: "a callsign never sets a flag" is that engine's own rule.
+ *
+ * "Interesting only" was gated the same way until slice 038 started
+ * populating `interesting` and slice 039 surfaced it.
  */
 
 import { Filter, X } from "lucide-react";
@@ -379,7 +389,10 @@ export function FilterDrawer() {
                   ))}
                 </ul>
               )}
-              {!metadataAvailable && <MetadataImportNote />}
+              <PlumbingNote>
+                Inferred from the callsign&apos;s airline designator; aircraft
+                metadata widens coverage by adding type-based missions.
+              </PlumbingNote>
             </FilterSection>
 
             <FilterSection title="Status">

--- a/frontend/src/features/filters/components/FilterDrawer.tsx
+++ b/frontend/src/features/filters/components/FilterDrawer.tsx
@@ -7,13 +7,14 @@
  * filter state of its own and can never drift from what the map is
  * actually drawing.
  *
- * Fields that target metadata the decoder does not populate until a later
- * slice (aircraft type/operator/operator group, classification, mission —
- * see `types.ts`'s doc comment) stay fully interactive rather than disabled,
- * but carry an inline note explaining why they will not change what's on the
- * map yet. "Interesting only" was one of those until slice 038 started
- * populating `interesting` and slice 039 surfaced it; its note is gone
- * because the filter now genuinely filters.
+ * Fields that match aircraft metadata (type/operator/operator group,
+ * classification, mission) stay fully interactive rather than disabled, but
+ * carry an inline note whenever this install has not imported metadata yet —
+ * without it those filters match nothing, and the note says where to fix
+ * that. Once an import has landed (`useMetadataAvailable`, slice 066) the
+ * notes disappear, because the filters genuinely filter. "Interesting only"
+ * was gated the same way until slice 038 started populating `interesting`
+ * and slice 039 surfaced it.
  */
 
 import { Filter, X } from "lucide-react";
@@ -30,6 +31,7 @@ import type {
 } from "@/features/filters/types";
 import { useDialogFocus } from "@/lib/a11y/useDialogFocus";
 import { useRovingFocus } from "@/lib/a11y/useRovingFocus";
+import { useMetadataAvailable } from "@/lib/api/metadata";
 import { cn } from "@/lib/utils";
 
 const CLASSIFICATION_OPTIONS: { value: ClassificationFlag; label: string }[] = [
@@ -44,10 +46,24 @@ const GROUND_OPTIONS: { value: GroundTrafficMode; label: string }[] = [
   { value: "hide", label: "Hide" },
 ];
 
-/** A metadata-gated field's explanation, reused wherever slice 024/038
- * data is what the filter actually needs. */
+/** A short explanation under a field — what it does, or what it still
+ * needs. The metadata-gated sections render one only while the install has
+ * no metadata (see `MetadataImportNote`); the rest are unconditional. */
 function PlumbingNote({ children }: { children: ReactNode }) {
   return <p className="text-[11px] text-muted-foreground">{children}</p>;
+}
+
+/** The one wording for "this filter has no data to match against yet",
+ * rendered only when it is true. `children` adds any section-specific
+ * caveat after the shared sentence. */
+function MetadataImportNote({ children }: { children?: ReactNode }) {
+  return (
+    <PlumbingNote>
+      Matches nothing until an aircraft-metadata import runs (Settings →
+      Metadata).
+      {children}
+    </PlumbingNote>
+  );
 }
 
 function FilterSection({
@@ -77,6 +93,7 @@ function numberOrNull(value: string): number | null {
 
 export function FilterDrawer() {
   const [isOpen, setIsOpen] = useState(false);
+  const metadataAvailable = useMetadataAvailable();
   const filters = useFilterStore((state) => state.filters);
   const setAltitudeRange = useFilterStore((state) => state.setAltitudeRange);
   const setMaxDistanceNm = useFilterStore((state) => state.setMaxDistanceNm);
@@ -301,10 +318,7 @@ export function FilterDrawer() {
                   />
                 </div>
               </div>
-              <PlumbingNote>
-                Activates once aircraft metadata populates these fields (roadmap
-                slice 024).
-              </PlumbingNote>
+              {!metadataAvailable && <MetadataImportNote />}
             </FilterSection>
 
             <FilterSection title="Classification">
@@ -323,11 +337,13 @@ export function FilterDrawer() {
                   </label>
                 ))}
               </div>
-              <PlumbingNote>
-                Selects nothing until aircraft metadata (slice 024) arrives —
-                FlightSite never guesses a classification it hasn&apos;t
-                confirmed.
-              </PlumbingNote>
+              {!metadataAvailable && (
+                <MetadataImportNote>
+                  {" "}
+                  FlightSite never guesses a classification it hasn&apos;t
+                  confirmed.
+                </MetadataImportNote>
+              )}
             </FilterSection>
 
             <FilterSection title="Mission category">
@@ -363,9 +379,7 @@ export function FilterDrawer() {
                   ))}
                 </ul>
               )}
-              <PlumbingNote>
-                Same as classification: selects nothing until slice 024.
-              </PlumbingNote>
+              {!metadataAvailable && <MetadataImportNote />}
             </FilterSection>
 
             <FilterSection title="Status">

--- a/frontend/src/features/filters/components/QuickFilterChips.test.tsx
+++ b/frontend/src/features/filters/components/QuickFilterChips.test.tsx
@@ -59,6 +59,27 @@ describe("QuickFilterChips", () => {
     expect(militaryChip()).toBeDisabled();
   });
 
+  it("leaves an already-active military filter releasable with no metadata imported", async () => {
+    useFilterStore.getState().toggleClassification("military");
+    renderWithProviders(<QuickFilterChips />);
+
+    // Active, so clickable — the alternative is a filter you can see but
+    // cannot turn off from where it is shown.
+    expect(militaryChip()).toBeEnabled();
+    expect(militaryChip()).toHaveAttribute("aria-pressed", "true");
+
+    await userEvent.hover(screen.getByTestId("military-chip-trigger"));
+    const tooltip = await screen.findAllByText(
+      /filter active, but no aircraft metadata/i,
+    );
+    expect(tooltip.length).toBeGreaterThan(0);
+
+    await userEvent.click(militaryChip());
+    expect(useFilterStore.getState().filters.classifications).toEqual([]);
+    // Released, and now correctly back to disabled.
+    expect(militaryChip()).toBeDisabled();
+  });
+
   it("enables the Military chip and toggles the military classification once metadata is imported", async () => {
     installMetadataApiMock({ statusSequence: [IMPORTED] });
     renderWithProviders(<QuickFilterChips />);

--- a/frontend/src/features/filters/components/QuickFilterChips.test.tsx
+++ b/frontend/src/features/filters/components/QuickFilterChips.test.tsx
@@ -1,28 +1,134 @@
-import { render, screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { FilterDrawer } from "@/features/filters/components/FilterDrawer";
 import { QuickFilterChips } from "@/features/filters/components/QuickFilterChips";
 import { useFilterStore } from "@/features/filters/store/useFilterStore";
 import { DEFAULT_FILTERS } from "@/features/filters/types";
+import type { MetadataStatusResponse } from "@/lib/api/metadata";
+import { installMetadataApiMock, metadataSource } from "@/test/metadataApiMock";
+import { renderWithProviders } from "@/test/test-utils";
+
+/** A status document reporting one source with a dataset installed — the
+ * "metadata available" case the Military chip is gated on. */
+const IMPORTED: MetadataStatusResponse = {
+  sources: [
+    metadataSource({
+      name: "mictronics",
+      status: "ok",
+      row_count: 412_003,
+      last_success_ms: 1_756_600_000_000,
+      dataset_version: "2026-08-01",
+    }),
+  ],
+};
+
+/** A stock install: the source is registered, but nothing has been imported. */
+const NOT_IMPORTED: MetadataStatusResponse = {
+  sources: [metadataSource({ name: "mictronics", status: "never-run" })],
+};
 
 beforeEach(() => {
   useFilterStore.setState({ filters: DEFAULT_FILTERS });
+  installMetadataApiMock({ statusSequence: [NOT_IMPORTED] });
 });
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function militaryChip() {
+  return screen.getByRole("button", { name: "Military" });
+}
+
 describe("QuickFilterChips", () => {
-  it("renders the Military chip disabled with an explanatory tooltip", async () => {
-    render(<QuickFilterChips />);
-    expect(screen.getByRole("button", { name: "Military" })).toBeDisabled();
+  it("keeps the Military chip disabled with a tooltip pointing at Settings when no metadata is imported", async () => {
+    renderWithProviders(<QuickFilterChips />);
+    expect(militaryChip()).toBeDisabled();
 
     await userEvent.hover(screen.getByTestId("military-chip-trigger"));
-    expect(
-      await screen.findByText(/activates with aircraft metadata/i),
-    ).toBeInTheDocument();
+    // Radix renders the content plus a visually-hidden copy for assistive
+    // tech, so both carry the wording — assert on the set, not on one node.
+    const tooltip = await screen.findAllByText(
+      /no aircraft metadata imported yet/i,
+    );
+    expect(tooltip.length).toBeGreaterThan(0);
+    expect(tooltip[0]).toHaveTextContent(/settings → metadata/i);
+    // Still disabled after the status has settled — no enable-then-disable.
+    expect(militaryChip()).toBeDisabled();
+  });
+
+  it("enables the Military chip and toggles the military classification once metadata is imported", async () => {
+    installMetadataApiMock({ statusSequence: [IMPORTED] });
+    renderWithProviders(<QuickFilterChips />);
+
+    await waitFor(() => expect(militaryChip()).toBeEnabled());
+    expect(militaryChip()).toHaveAttribute("aria-pressed", "false");
+
+    await userEvent.click(militaryChip());
+    expect(useFilterStore.getState().filters.classifications).toEqual([
+      "military",
+    ]);
+    expect(militaryChip()).toHaveAttribute("aria-pressed", "true");
+
+    await userEvent.click(militaryChip());
+    expect(useFilterStore.getState().filters.classifications).toEqual([]);
+    expect(militaryChip()).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("reflects an externally-set military classification as active", async () => {
+    installMetadataApiMock({ statusSequence: [IMPORTED] });
+    useFilterStore.getState().toggleClassification("military");
+    renderWithProviders(<QuickFilterChips />);
+
+    await waitFor(() => expect(militaryChip()).toBeEnabled());
+    expect(militaryChip()).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("mirrors the drawer's Military checkbox in both directions", async () => {
+    installMetadataApiMock({ statusSequence: [IMPORTED] });
+    renderWithProviders(
+      <>
+        <QuickFilterChips />
+        <FilterDrawer />
+      </>,
+    );
+    await waitFor(() => expect(militaryChip()).toBeEnabled());
+    await userEvent.click(screen.getByRole("button", { name: /^filters$/i }));
+
+    const checkbox = screen.getByRole("checkbox", { name: "Military" });
+    await userEvent.click(militaryChip());
+    expect(checkbox).toBeChecked();
+
+    await userEvent.click(checkbox);
+    expect(militaryChip()).toHaveAttribute("aria-pressed", "false");
+    expect(useFilterStore.getState().filters.classifications).toEqual([]);
+  });
+
+  it("keeps the Military chip disabled while the metadata status is still loading", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+    renderWithProviders(<QuickFilterChips />);
+    expect(militaryChip()).toBeDisabled();
+  });
+
+  it("keeps the Military chip disabled when the metadata status request fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("network down"))),
+    );
+    renderWithProviders(<QuickFilterChips />);
+
+    // Give the failed query a chance to settle: the safe state must survive it.
+    await waitFor(() => expect(militaryChip()).toBeDisabled());
+    expect(screen.getByTestId("military-chip-trigger")).toBeInTheDocument();
   });
 
   it("toggles emergency-only", async () => {
-    render(<QuickFilterChips />);
+    renderWithProviders(<QuickFilterChips />);
     const chip = screen.getByRole("button", { name: "Emergency" });
     expect(chip).toHaveAttribute("aria-pressed", "false");
 
@@ -35,7 +141,7 @@ describe("QuickFilterChips", () => {
   });
 
   it("toggles airborne-only via the ground-traffic filter", async () => {
-    render(<QuickFilterChips />);
+    renderWithProviders(<QuickFilterChips />);
     const chip = screen.getByRole("button", { name: "Airborne only" });
 
     await userEvent.click(chip);
@@ -48,7 +154,7 @@ describe("QuickFilterChips", () => {
 
   it("reflects an externally-set ground mode as active", () => {
     useFilterStore.getState().setGroundTraffic("hide");
-    render(<QuickFilterChips />);
+    renderWithProviders(<QuickFilterChips />);
     expect(
       screen.getByRole("button", { name: "Airborne only" }),
     ).toHaveAttribute("aria-pressed", "true");

--- a/frontend/src/features/filters/components/QuickFilterChips.tsx
+++ b/frontend/src/features/filters/components/QuickFilterChips.tsx
@@ -1,14 +1,18 @@
 /**
  * One-tap common filters, wired to the exact same `useFilterStore` the
  * drawer edits (roadmap slice 017) — a chip is a shortcut into the model,
- * never a second source of truth for it.
+ * never a second source of truth for it. "Military" and the drawer's
+ * Military checkbox are the same `classifications` entry seen twice.
  *
- * "Military" targets `classification.military`, which is `null` on every
- * live payload until slice 024 (see `types.ts`'s doc comment): toggling it
- * on today would silently empty the map with no way to tell why, so the
- * chip stays disabled with a tooltip instead of pretending to work.
- * "Emergency" (`emergency` squawk) and "Airborne only" (ground traffic) are
- * real decoder fields today and are fully live.
+ * "Military" targets `classification.military`, which only exists on live
+ * payloads once this install has imported aircraft metadata. The chip was
+ * hard-disabled from slice 017 until slice 066 because no metadata system
+ * existed at all; now that one does, the gate is on the *data*, not on
+ * history: `useMetadataAvailable` asks whether any source has rows
+ * installed, and the chip toggles for real when it does. With no import the
+ * chip stays disabled — turning it on would silently empty the map — and
+ * says where to fix that. "Emergency" (`emergency` squawk) and "Airborne
+ * only" (ground traffic) are decoder fields and are always live.
  */
 
 import {
@@ -18,6 +22,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useFilterStore } from "@/features/filters/store/useFilterStore";
+import { useMetadataAvailable } from "@/lib/api/metadata";
 import { cn } from "@/lib/utils";
 
 function Chip({
@@ -55,8 +60,17 @@ export function QuickFilterChips() {
   const filters = useFilterStore((state) => state.filters);
   const setEmergencyOnly = useFilterStore((state) => state.setEmergencyOnly);
   const setGroundTraffic = useFilterStore((state) => state.setGroundTraffic);
+  const toggleClassification = useFilterStore(
+    (state) => state.toggleClassification,
+  );
+  const metadataAvailable = useMetadataAvailable();
 
   const airborneOnly = filters.groundTraffic === "hide";
+  // Read from the store either way, disabled or not: the drawer's checkbox
+  // stays interactive without metadata, and a filter restored from the URL
+  // can arrive military-selected, so the chip reports the model rather than
+  // its own availability.
+  const militaryActive = filters.classifications.includes("military");
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -67,17 +81,28 @@ export function QuickFilterChips() {
         // map controls never overlap.
         className="absolute left-3 top-12 z-10 flex flex-wrap gap-1.5"
       >
-        <Tooltip>
-          <TooltipTrigger asChild>
-            {/* A disabled button suppresses its own pointer events in most
-             * browsers, so the hover target — and the tooltip trigger — is
-             * this wrapping span, not the button itself. */}
-            <span data-testid="military-chip-trigger">
-              <Chip label="Military" active={false} disabled />
-            </span>
-          </TooltipTrigger>
-          <TooltipContent>Activates with aircraft metadata</TooltipContent>
-        </Tooltip>
+        {metadataAvailable ? (
+          <Chip
+            label="Military"
+            active={militaryActive}
+            onClick={() => toggleClassification("military")}
+          />
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {/* A disabled button suppresses its own pointer events in most
+               * browsers, so the hover target — and the tooltip trigger — is
+               * this wrapping span, not the button itself. */}
+              <span data-testid="military-chip-trigger">
+                <Chip label="Military" active={militaryActive} disabled />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              No aircraft metadata imported yet — run Settings → Metadata →
+              Update Aircraft Metadata
+            </TooltipContent>
+          </Tooltip>
+        )}
 
         <Chip
           label="Emergency"

--- a/frontend/src/features/filters/components/QuickFilterChips.tsx
+++ b/frontend/src/features/filters/components/QuickFilterChips.tsx
@@ -8,11 +8,14 @@
  * payloads once this install has imported aircraft metadata. The chip was
  * hard-disabled from slice 017 until slice 066 because no metadata system
  * existed at all; now that one does, the gate is on the *data*, not on
- * history: `useMetadataAvailable` asks whether any source has rows
- * installed, and the chip toggles for real when it does. With no import the
- * chip stays disabled — turning it on would silently empty the map — and
- * says where to fix that. "Emergency" (`emergency` squawk) and "Airborne
- * only" (ground traffic) are decoder fields and are always live.
+ * history: `useMetadataAvailable` asks whether any airframe source has rows
+ * installed, and the chip toggles for real when it does. With no import,
+ * turning the filter *on* would silently empty the map, so the chip is
+ * disabled and says where to fix that — but a filter already on (restored
+ * from the URL, or set in the drawer) leaves the chip enabled, because an
+ * active filter must always be releasable from where its state is shown.
+ * "Emergency" (`emergency` squawk) and "Airborne only" (ground traffic) are
+ * decoder fields and are always live.
  */
 
 import {
@@ -71,6 +74,20 @@ export function QuickFilterChips() {
   // can arrive military-selected, so the chip reports the model rather than
   // its own availability.
   const militaryActive = filters.classifications.includes("military");
+  // Disabled only where clicking would *start* a filter that matches
+  // nothing. An already-active filter stays clickable however unavailable
+  // the metadata is — otherwise the one control showing "military only" is
+  // the one control that cannot turn it off again.
+  const militaryDisabled = !metadataAvailable && !militaryActive;
+
+  const militaryChip = (
+    <Chip
+      label="Military"
+      active={militaryActive}
+      disabled={militaryDisabled}
+      onClick={() => toggleClassification("military")}
+    />
+  );
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -82,24 +99,19 @@ export function QuickFilterChips() {
         className="absolute left-3 top-12 z-10 flex flex-wrap gap-1.5"
       >
         {metadataAvailable ? (
-          <Chip
-            label="Military"
-            active={militaryActive}
-            onClick={() => toggleClassification("military")}
-          />
+          militaryChip
         ) : (
           <Tooltip>
             <TooltipTrigger asChild>
               {/* A disabled button suppresses its own pointer events in most
                * browsers, so the hover target — and the tooltip trigger — is
                * this wrapping span, not the button itself. */}
-              <span data-testid="military-chip-trigger">
-                <Chip label="Military" active={militaryActive} disabled />
-              </span>
+              <span data-testid="military-chip-trigger">{militaryChip}</span>
             </TooltipTrigger>
             <TooltipContent>
-              No aircraft metadata imported yet — run Settings → Metadata →
-              Update Aircraft Metadata
+              {militaryActive
+                ? "Filter active, but no aircraft metadata is imported — it matches nothing until one runs"
+                : "No aircraft metadata imported yet — run Settings → Metadata → Update Aircraft Metadata"}
             </TooltipContent>
           </Tooltip>
         )}

--- a/frontend/src/lib/api/metadata.test.ts
+++ b/frontend/src/lib/api/metadata.test.ts
@@ -128,7 +128,7 @@ describe("hasImportedMetadata", () => {
     ).toBe(false);
   });
 
-  it("is true when any one source has rows installed", () => {
+  it("is true when any one airframe source has rows installed", () => {
     expect(
       hasImportedMetadata({
         sources: [
@@ -142,6 +142,70 @@ describe("hasImportedMetadata", () => {
         ],
       }),
     ).toBe(true);
+  });
+
+  it("ignores the airports source, whose rows are airports rather than airframes", () => {
+    // SPEC §27 keeps every source's outcome independent, so this — airports
+    // imported, both airframe sources failed — is an ordinary state, and it
+    // must not read as "this install has aircraft metadata".
+    expect(
+      hasImportedMetadata({
+        sources: [
+          metadataSource({
+            name: "airports",
+            status: "ok",
+            row_count: 80_412,
+            last_success_ms: 1_756_600_000_000,
+          }),
+          metadataSource({
+            name: "mictronics",
+            status: "failed",
+            last_error: "download failed",
+          }),
+          metadataSource({
+            name: "faa",
+            status: "failed",
+            last_error: "download failed",
+          }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("is true for airports alongside an airframe source with rows", () => {
+    expect(
+      hasImportedMetadata({
+        sources: [
+          metadataSource({
+            name: "airports",
+            status: "ok",
+            row_count: 80_412,
+            last_success_ms: 1_756_600_000_000,
+          }),
+          metadataSource({
+            name: "opensky",
+            status: "ok",
+            row_count: 512_000,
+            last_success_ms: 1_756_600_000_000,
+          }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores an unrecognized source name — a new airframe source lands with the code that names it", () => {
+    expect(
+      hasImportedMetadata({
+        sources: [
+          metadataSource({
+            name: "some-future-source",
+            status: "ok",
+            row_count: 1_000,
+            last_success_ms: 1_756_600_000_000,
+          }),
+        ],
+      }),
+    ).toBe(false);
   });
 
   it("stays true while a later run is in flight or has failed — the installed dataset is still there", () => {

--- a/frontend/src/lib/api/metadata.test.ts
+++ b/frontend/src/lib/api/metadata.test.ts
@@ -3,7 +3,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   getMetadataStatus,
+  hasImportedMetadata,
   triggerMetadataUpdate,
+  useMetadataAvailable,
   useMetadataStatusQuery,
   useTriggerMetadataUpdateMutation,
 } from "@/lib/api/metadata";
@@ -91,6 +93,141 @@ describe("useMetadataStatusQuery", () => {
       () => expect(result.current.data?.sources[0]?.status).toBe("ok"),
       { timeout: 4000 },
     );
+  });
+});
+
+describe("hasImportedMetadata", () => {
+  it("is false with no status document at all", () => {
+    expect(hasImportedMetadata(undefined)).toBe(false);
+  });
+
+  it("is false for a stock install with no registered sources", () => {
+    expect(hasImportedMetadata({ sources: [] })).toBe(false);
+  });
+
+  it("is false for a registered source that has never run", () => {
+    expect(
+      hasImportedMetadata({
+        sources: [metadataSource({ name: "mictronics", status: "never-run" })],
+      }),
+    ).toBe(false);
+  });
+
+  it("is false for a source reporting zero rows", () => {
+    expect(
+      hasImportedMetadata({
+        sources: [
+          metadataSource({
+            name: "mictronics",
+            status: "ok",
+            row_count: 0,
+            last_success_ms: 1_756_600_000_000,
+          }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("is true when any one source has rows installed", () => {
+    expect(
+      hasImportedMetadata({
+        sources: [
+          metadataSource({ name: "mictronics", status: "never-run" }),
+          metadataSource({
+            name: "faa",
+            status: "ok",
+            row_count: 412_003,
+            last_success_ms: 1_756_600_000_000,
+          }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("stays true while a later run is in flight or has failed — the installed dataset is still there", () => {
+    const installed = {
+      row_count: 412_003,
+      last_success_ms: 1_756_600_000_000,
+      dataset_version: "2026-08-01",
+    };
+    expect(
+      hasImportedMetadata({
+        sources: [
+          metadataSource({ name: "faa", status: "running", ...installed }),
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      hasImportedMetadata({
+        sources: [
+          metadataSource({
+            name: "faa",
+            status: "failed",
+            last_error: "download failed",
+            ...installed,
+          }),
+        ],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("useMetadataAvailable", () => {
+  it("reports availability once the status document lands", async () => {
+    installMetadataApiMock({
+      statusSequence: [
+        {
+          sources: [
+            metadataSource({
+              name: "mictronics",
+              status: "ok",
+              row_count: 412_003,
+              last_success_ms: 1_756_600_000_000,
+            }),
+          ],
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useMetadataAvailable(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    // Never the other way round: unavailable until the data says otherwise.
+    expect(result.current).toBe(false);
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it("stays unavailable while the status request is still in flight", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+
+    const { result } = renderHook(() => useMetadataAvailable(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await Promise.resolve();
+    expect(result.current).toBe(false);
+  });
+
+  it("stays unavailable when the status request fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("network down"))),
+    );
+
+    const { result } = renderHook(
+      () => ({
+        available: useMetadataAvailable(),
+        query: useMetadataStatusQuery(),
+      }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.query.isError).toBe(true));
+    expect(result.current.available).toBe(false);
   });
 });
 

--- a/frontend/src/lib/api/metadata.ts
+++ b/frontend/src/lib/api/metadata.ts
@@ -86,7 +86,32 @@ export function useMetadataStatusQuery(): UseQueryResult<MetadataStatusResponse>
   });
 }
 
-/** True when this source row proves a dataset is actually installed.
+/** The registered sources whose rows are *airframes*.
+ *
+ * The status endpoint reports every registered source and carries no field
+ * saying what kind of rows a source installs, so the distinction has to be
+ * drawn by name. `airports` (slice 027) is a metadata source in every
+ * mechanical sense — its own status row, its own `row_count` in the tens of
+ * thousands — but, as `backend/src/flightsite/metadata/registry.py`'s module
+ * docstring puts it, its "rows are airports rather than airframes". SPEC §27
+ * makes each source's outcome independent, so "airports ok, mictronics and
+ * faa failed" is an ordinary state; counting airports there would report
+ * metadata as available over an empty `aircraft_metadata` table — exactly
+ * the silently-empty-map hazard the original chip gate existed to prevent.
+ *
+ * The frontend already draws this line in `MetadataSection`'s
+ * `SOURCE_LABELS`, which names these three and lets `airports` fall through
+ * to the generic label. An unrecognized name is treated as
+ * not-an-airframe-source: a new aircraft source arrives together with the
+ * frontend change that names it, and failing closed until then only leaves a
+ * filter unavailable, where failing open would leave it lying. */
+const AIRCRAFT_METADATA_SOURCES: ReadonlySet<string> = new Set([
+  "mictronics",
+  "faa",
+  "opensky",
+]);
+
+/** True when this source row proves an *airframe* dataset is installed.
  *
  * `row_count` is written only by a successful promotion and cleared only by
  * a metadata reset, so a positive count is the single field that separates
@@ -97,13 +122,17 @@ export function useMetadataStatusQuery(): UseQueryResult<MetadataStatusResponse>
  * the previous dataset intact) — neither of those takes the data away, so
  * neither should take the metadata-backed filters away. */
 function sourceHasRows(source: MetadataSourceStatusEntry): boolean {
-  return source.row_count !== null && source.row_count > 0;
+  return (
+    AIRCRAFT_METADATA_SOURCES.has(source.name) &&
+    source.row_count !== null &&
+    source.row_count > 0
+  );
 }
 
-/** Whether a status document reports any source with rows installed.
- * `undefined` — status not loaded yet, or the request failed — reads as
- * "no metadata", the safe answer: a filter that would silently match
- * nothing stays visibly unavailable until we know better. */
+/** Whether a status document reports any airframe source with rows
+ * installed. `undefined` — status not loaded yet, or the request failed —
+ * reads as "no metadata", the safe answer: a filter that would silently
+ * match nothing stays visibly unavailable until we know better. */
 export function hasImportedMetadata(
   status: MetadataStatusResponse | undefined,
 ): boolean {

--- a/frontend/src/lib/api/metadata.ts
+++ b/frontend/src/lib/api/metadata.ts
@@ -86,6 +86,43 @@ export function useMetadataStatusQuery(): UseQueryResult<MetadataStatusResponse>
   });
 }
 
+/** True when this source row proves a dataset is actually installed.
+ *
+ * `row_count` is written only by a successful promotion and cleared only by
+ * a metadata reset, so a positive count is the single field that separates
+ * "an import ran and installed rows" from "registered but never run", "still
+ * downloading its first dataset", and "failed with nothing to show". It
+ * deliberately keeps describing the installed dataset while a later run is
+ * `"running"` or after one has `"failed"` (SPEC §27: a failed import leaves
+ * the previous dataset intact) — neither of those takes the data away, so
+ * neither should take the metadata-backed filters away. */
+function sourceHasRows(source: MetadataSourceStatusEntry): boolean {
+  return source.row_count !== null && source.row_count > 0;
+}
+
+/** Whether a status document reports any source with rows installed.
+ * `undefined` — status not loaded yet, or the request failed — reads as
+ * "no metadata", the safe answer: a filter that would silently match
+ * nothing stays visibly unavailable until we know better. */
+export function hasImportedMetadata(
+  status: MetadataStatusResponse | undefined,
+): boolean {
+  return status?.sources.some(sourceHasRows) ?? false;
+}
+
+/** Does this install have aircraft metadata for the metadata-backed filters
+ * (classification, mission, type/operator) to match against?
+ *
+ * Reads {@link useMetadataStatusQuery} rather than fetching the status
+ * document a second time: one query key with one set of options, however
+ * many components ask. While the status is loading or errored this answers
+ * `false`, so a gated control opens up only on positive evidence and never
+ * flashes enabled before turning itself off again. */
+export function useMetadataAvailable(): boolean {
+  const { data } = useMetadataStatusQuery();
+  return hasImportedMetadata(data);
+}
+
 /** Triggers an update and refreshes {@link useMetadataStatusQuery} with an
  * immediate refetch, so the "running" state (and the polling it drives)
  * shows up as soon as the backend has scheduled the run rather than waiting

--- a/frontend/src/test/overlaysApiMock.ts
+++ b/frontend/src/test/overlaysApiMock.ts
@@ -55,9 +55,10 @@ const EMPTY_SIGHTING_LIST: SightingListResponse = {
  * and `GET /api/v1/sightings/{id}`, which back the track backfill (roadmap
  * slice 061) — and `GET /api/internal/metadata/status`, which the filter
  * chips and drawer read to decide whether the metadata-backed filters have
- * anything to match (roadmap slice 066), so map tests can exercise the real API clients and TanStack
- * Query hooks without a running backend. Any other URL throws, surfacing an
- * un-mocked request as a test failure instead of a silent network error. */
+ * anything to match (roadmap slice 066). So map tests can exercise the real
+ * API clients and TanStack Query hooks without a running backend. Any other
+ * URL throws, surfacing an un-mocked request as a test failure instead of a
+ * silent network error. */
 export function installOverlaysApiMock(options: MockOverlaysApiOptions = {}) {
   const fetchMock = vi.fn(
     async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/frontend/src/test/overlaysApiMock.ts
+++ b/frontend/src/test/overlaysApiMock.ts
@@ -1,6 +1,7 @@
 import type { FeatureCollection } from "geojson";
 import { vi } from "vitest";
 
+import type { MetadataStatusResponse } from "@/lib/api/metadata";
 import type { SightingDetail, SightingListResponse } from "@/lib/api/sightings";
 
 /** An empty `FeatureCollection` — the default response for both endpoints,
@@ -33,6 +34,11 @@ export interface MockOverlaysApiOptions {
   /** `id -> SightingDetail` for `GET /api/v1/sightings/{id}`; an id with no
    * entry 404s. */
   sightingDetail?: Record<number, SightingDetail>;
+  /** Response `GET /api/internal/metadata/status` returns — the filter
+   * chips and drawer read it to decide whether the metadata-backed filters
+   * have anything to match (roadmap slice 066). Defaults to no registered
+   * sources, i.e. a stock install with no import behind it. */
+  metadataStatus?: MetadataStatusResponse;
 }
 
 /** The `GET /api/v1/sightings` default: no open sighting for anything. */
@@ -47,7 +53,9 @@ const EMPTY_SIGHTING_LIST: SightingListResponse = {
  * `GET /api/v1/airspace` (roadmap slice 028), plus the two sightings reads the
  * Live Map itself makes when an aircraft is selected — `GET /api/v1/sightings`
  * and `GET /api/v1/sightings/{id}`, which back the track backfill (roadmap
- * slice 061) — so map tests can exercise the real API clients and TanStack
+ * slice 061) — and `GET /api/internal/metadata/status`, which the filter
+ * chips and drawer read to decide whether the metadata-backed filters have
+ * anything to match (roadmap slice 066), so map tests can exercise the real API clients and TanStack
  * Query hooks without a running backend. Any other URL throws, surfacing an
  * un-mocked request as a test failure instead of a silent network error. */
 export function installOverlaysApiMock(options: MockOverlaysApiOptions = {}) {
@@ -95,6 +103,13 @@ export function installOverlaysApiMock(options: MockOverlaysApiOptions = {}) {
           );
         }
         return jsonResponse(detail);
+      }
+
+      if (
+        url.pathname === "/api/internal/metadata/status" &&
+        method === "GET"
+      ) {
+        return jsonResponse(options.metadataStatus ?? { sources: [] });
       }
 
       throw new Error(`Unhandled fetch in test: ${method} ${raw}`);

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1712,12 +1712,15 @@ slices:
     depends_on: ["017", "025"]
     objective: "Lift the slice-017 gate that left the live map's Military quick-filter chip permanently disabled, and gate it on the install's actual metadata instead of on roadmap history — so the chip toggles for real once an import has landed, and says where to run one when it has not (issue #151)."
     scope:
-      - "`lib/api/metadata.ts` gains `hasImportedMetadata(status)` and the `useMetadataAvailable()` hook, both deriving availability from `row_count > 0` on any source - the one field written only by a successful promotion, so it separates an installed dataset from never-run, first-run-in-flight and failed"
+      - "`lib/api/metadata.ts` gains `hasImportedMetadata(status)` and the `useMetadataAvailable()` hook, deriving availability from `row_count > 0` on an *airframe* source - the one field written only by a successful promotion, so it separates an installed dataset from never-run, first-run-in-flight and failed"
+      - "the airframe sources are named explicitly (mictronics, faa, opensky) because the status payload carries no kind discriminator: slice 027's `airports` source reports its own five-figure `row_count` while installing no airframes at all (registry.py: \"rows are airports rather than airframes\"), and SPEC §27's per-source independence makes airports-ok-airframes-failed an ordinary state that must not read as \"this install has aircraft metadata\""
       - "`useMetadataAvailable` reads the existing `useMetadataStatusQuery` rather than fetching `/api/internal/metadata/status` a second time: one key, one set of options, however many components ask (the slice-061 lesson about divergent observers of one key)"
       - "unknown status - loading or errored - answers `false`, so a gated control opens only on positive evidence and never flashes enabled before disabling itself"
-      - "`QuickFilterChips` renders Military as a real toggle when metadata is available, wired to `toggleClassification(\"military\")` with `aria-pressed` read from `filters.classifications`; when it is not, the chip stays disabled and its tooltip points at Settings -> Metadata instead of at a future slice"
+      - "`QuickFilterChips` renders Military as a real toggle when metadata is available, wired to `toggleClassification(\"military\")` with `aria-pressed` read from `filters.classifications`; when it is not, the chip is disabled and its tooltip points at Settings -> Metadata instead of at a future slice"
+      - "an already-active military filter keeps the chip enabled even with no metadata, so a selection restored from the URL or set in the drawer stays releasable from where its state is shown; that case gets its own tooltip saying the filter is on and matching nothing"
       - "the chip reports the store's military selection whether enabled or disabled, so it can never disagree with the drawer checkbox it mirrors"
-      - "`FilterDrawer` replaces the three stale slice-024 plumbing notes (category/operator, classification, mission category) with one `MetadataImportNote` wording, rendered only while metadata is absent and gone once an import has landed"
+      - "`FilterDrawer` replaces the stale slice-024 plumbing notes on the two import-only sections (category/operator, classification) with one `MetadataImportNote` wording, rendered only while metadata is absent"
+      - "mission category gets an unconditional honest note instead of an import note: the classification engine infers a mission from the callsign's airline designator against a bundled operator directory, so mission is populated with no import at all and metadata only widens coverage by adding type-code inference"
       - "`test/overlaysApiMock.ts` serves the metadata-status read the live map now makes, with a `metadataStatus` option"
     out_of_scope:
       - "the drawer's metadata-backed inputs themselves, which stay fully interactive with or without metadata - a note, never a disabled field"
@@ -1726,18 +1729,23 @@ slices:
       - "`features/filters/types.ts`'s module docstring, which still describes the metadata fields as slice-024-pending - a separate documentation-only cleanup"
       - "any new metadata source, import trigger, or Settings-page change"
     acceptance_criteria:
-      - "with a source reporting rows installed, the Military chip is enabled, toggles `classifications` military on and off, and carries the matching `aria-pressed`"
+      - "with an airframe source reporting rows installed, the Military chip is enabled, toggles `classifications` military on and off, and carries the matching `aria-pressed`"
+      - "an airports-only import - airports ok, airframe sources failed or never run - leaves the chip disabled and the drawer notes in place"
       - "with no import, the chip is disabled and its tooltip names the prerequisite and where to fulfil it"
+      - "with no import but the filter already active, the chip is enabled, says so, and one click clears the filter"
       - "toggling the chip checks the drawer's Military checkbox and vice versa - one store, two views"
       - "while the status is loading or after it fails, the chip is disabled; it never renders enabled first"
-      - "the drawer shows one import note per metadata-backed section without metadata, and none with it"
+      - "the drawer shows an import note on exactly the two import-only sections without metadata, and none with it"
+      - "the mission-category note describes callsign inference and claims no import prerequisite, with or without metadata"
       - "no drawer or chip copy references an unlanded slice"
     required_tests:
       - predicate unit tests over undefined/empty/never-run/zero-row/populated documents and the running-and-failed cases that must stay available
+      - predicate unit tests for the airports source alone (false), airports beside an airframe source (true), and an unrecognized source name (false)
       - hook tests for the false-until-proven default, the in-flight case, and the errored case
       - chip tests for the disabled tooltip, the enabled toggle, external selection, loading and error safe states
+      - a chip test for the active-but-unavailable case: enabled, its own tooltip, and clearable in one click
       - a mirror test rendering chips and drawer together and driving each from the other
-      - drawer tests for the note count without metadata and their absence with it
+      - drawer tests for the import-note count without metadata, their absence with it, and the mission note's presence in both
     expected_artifacts:
       - frontend/src/lib/api/metadata.ts
       - frontend/src/features/filters/components/QuickFilterChips.tsx

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1704,6 +1704,51 @@ slices:
     preferred_agent: opus
     risk_level: low
     notes: "Owner reported markers still oscillating on the Pi at v0.3.0. Fixes GitHub issue #144, the residual systematic term slice 054's no-correction-blend rationale underestimated. Frontend-only, client-side mirror of slice 062's server-side ageing. Added by Fable outside the phase plan."
+  - id: "066"
+    title: "Military chip metadata gate"
+    phase: 8
+    branch: "066-military-chip"
+    status: merged
+    depends_on: ["017", "025"]
+    objective: "Lift the slice-017 gate that left the live map's Military quick-filter chip permanently disabled, and gate it on the install's actual metadata instead of on roadmap history — so the chip toggles for real once an import has landed, and says where to run one when it has not (issue #151)."
+    scope:
+      - "`lib/api/metadata.ts` gains `hasImportedMetadata(status)` and the `useMetadataAvailable()` hook, both deriving availability from `row_count > 0` on any source - the one field written only by a successful promotion, so it separates an installed dataset from never-run, first-run-in-flight and failed"
+      - "`useMetadataAvailable` reads the existing `useMetadataStatusQuery` rather than fetching `/api/internal/metadata/status` a second time: one key, one set of options, however many components ask (the slice-061 lesson about divergent observers of one key)"
+      - "unknown status - loading or errored - answers `false`, so a gated control opens only on positive evidence and never flashes enabled before disabling itself"
+      - "`QuickFilterChips` renders Military as a real toggle when metadata is available, wired to `toggleClassification(\"military\")` with `aria-pressed` read from `filters.classifications`; when it is not, the chip stays disabled and its tooltip points at Settings -> Metadata instead of at a future slice"
+      - "the chip reports the store's military selection whether enabled or disabled, so it can never disagree with the drawer checkbox it mirrors"
+      - "`FilterDrawer` replaces the three stale slice-024 plumbing notes (category/operator, classification, mission category) with one `MetadataImportNote` wording, rendered only while metadata is absent and gone once an import has landed"
+      - "`test/overlaysApiMock.ts` serves the metadata-status read the live map now makes, with a `metadataStatus` option"
+    out_of_scope:
+      - "the drawer's metadata-backed inputs themselves, which stay fully interactive with or without metadata - a note, never a disabled field"
+      - "`applyFilters` and its null-excludes semantics, unchanged: this slice changes what the UI says and enables, not what a selection matches"
+      - "backend changes; `/api/internal/metadata/status` already carries everything the predicate needs"
+      - "`features/filters/types.ts`'s module docstring, which still describes the metadata fields as slice-024-pending - a separate documentation-only cleanup"
+      - "any new metadata source, import trigger, or Settings-page change"
+    acceptance_criteria:
+      - "with a source reporting rows installed, the Military chip is enabled, toggles `classifications` military on and off, and carries the matching `aria-pressed`"
+      - "with no import, the chip is disabled and its tooltip names the prerequisite and where to fulfil it"
+      - "toggling the chip checks the drawer's Military checkbox and vice versa - one store, two views"
+      - "while the status is loading or after it fails, the chip is disabled; it never renders enabled first"
+      - "the drawer shows one import note per metadata-backed section without metadata, and none with it"
+      - "no drawer or chip copy references an unlanded slice"
+    required_tests:
+      - predicate unit tests over undefined/empty/never-run/zero-row/populated documents and the running-and-failed cases that must stay available
+      - hook tests for the false-until-proven default, the in-flight case, and the errored case
+      - chip tests for the disabled tooltip, the enabled toggle, external selection, loading and error safe states
+      - a mirror test rendering chips and drawer together and driving each from the other
+      - drawer tests for the note count without metadata and their absence with it
+    expected_artifacts:
+      - frontend/src/lib/api/metadata.ts
+      - frontend/src/features/filters/components/QuickFilterChips.tsx
+      - frontend/src/features/filters/components/FilterDrawer.tsx
+      - frontend/src/lib/api/metadata.test.ts
+      - frontend/src/features/filters/components/QuickFilterChips.test.tsx
+      - frontend/src/features/filters/components/FilterDrawer.test.tsx
+      - frontend/src/test/overlaysApiMock.ts
+    preferred_agent: opus
+    risk_level: low
+    notes: "Owner-reported at v0.3.1: the chip had been disabled since slice 017, when no metadata system existed; slices 022-025 landed one and nobody lifted the gate. Fixes GitHub issue #151. Frontend-only. Added by Fable outside the phase plan."
 
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,


### PR DESCRIPTION
Slice 066 — closes #151.

The Military chip has been hard-disabled since slice 017, when no metadata system existed. The gate now reads data instead of history:

- `hasImportedMetadata` derives availability from the metadata status the Settings page already fetches (same query, one observer), restricted to the sources that actually write aircraft metadata ({mictronics, faa, opensky} — the airports catalog is excluded, so an airports-only import can no longer enable classification filtering into a silently empty map; fail-closed for unrecognized sources).
- With metadata: the chip is a real toggle mirroring the drawer's Military checkbox through the one store. Without: disabled with an actionable tooltip (Settings → Metadata) — except an already-active filter (e.g. URL-restored) stays releasable.
- The drawer's three stale "slice 024" notes are replaced: two honest import-prerequisite notes, and a truthful mission note (callsign inference already fills missions; metadata widens coverage).

Adversarial review: initial FIX FIRST caught the airports-source hole and a false mission claim; verification of the fixes returned MERGE with the allowlist checked against backend registrations.

21 new/changed tests (1705 total green); lint/typecheck/format:check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTAJUucu2ZPAD235B3GQeZ