### PR TITLE
feat(perf): record the clean Raspberry Pi 5 baseline and promote five budgets to hard gates (slice 065)

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -18,10 +18,15 @@ name: perf
 # This job is deliberately NOT a required status check. Its budgets are stated
 # for the reference hardware (Raspberry Pi 4) and a shared GitHub runner is
 # neither that hardware nor a quiet one; treating a noisy trend signal as a
-# merge blocker would train people to re-run it until it passed. The Pi 4
-# qualification procedure in docs/PERFORMANCE.md is what converts these
-# reference budgets into hard gates, and that is a release activity run on real
-# hardware.
+# merge blocker would train people to re-run it until it passed.
+#
+# Note that "trend signal" no longer describes most of the table. Slice 065
+# promoted five reference budgets to hard gates on the on-hardware baselines in
+# docs/PERFORMANCE.md §5.4 and §5.5, so this run now asserts eleven of the
+# twelve; db_write_cycle_ms is the one still trend-tracked, awaiting a clean
+# Pi 4 run on non-SD storage (issue #153). Promotion happens in §5.3's
+# procedure, on real hardware at release time — never here, and never because a
+# runner happened to be fast.
 
 on:
   schedule:

--- a/backend/src/flightsite/perf/budgets.py
+++ b/backend/src/flightsite/perf/budgets.py
@@ -56,8 +56,9 @@ matters more than the shared constant: startup measured 0.547 s on a contended
 Pi 4 and 0.112 s on a Pi 5, while recovery measured **9.3 s** on that Pi 4's SD
 card against 0.0755 s on the Pi 5. Recovery therefore sits 3.2x inside its
 ceiling on the reference hardware, on a path already reported as load-sensitive
-(issue #100) — the tightest gate in this table, and the one to read first if a
-run on slow storage goes red.
+(issue #100) — the tightest of the five gates §5.5 promotes. On slow storage the
+rows that actually go red first are ingest_duty_cycle and db_write_cycle_ms
+(issues #132/#153); recovery_s is the promoted gate worth watching beside them.
 """
 
 from __future__ import annotations
@@ -343,7 +344,7 @@ BUDGETS: Final[tuple[Budget, ...]] = (
             "Repairing every sighting left open by a power cut, from checkpoint rows "
             "(slice 053). Bounded by the open-sighting count, which the harness records, and "
             "by the storage device. Promoted on the baselines in docs/PERFORMANCE.md §5.5 and "
-            "kept at NO_HEADROOM, which leaves the narrowest margin of any gate here: 539 open "
+            "kept at NO_HEADROOM, the narrowest margin among the five §5.5 promotions: 539 open "
             "sightings were repaired in 9.3 s on a contended Pi 4 SD card — 3.2x inside the "
             "30 s ceiling — against 0.0755 s on a Pi 5, and the path is already reported as "
             "load-sensitive (issue #100). Promoted knowingly on that figure: the budget bounds "

--- a/backend/src/flightsite/perf/budgets.py
+++ b/backend/src/flightsite/perf/budgets.py
@@ -23,7 +23,14 @@ metrics initially; convert to hard gates once real Pi 4 baselines exist."* They
 are stated against the reference hardware (Raspberry Pi 4), and a dev machine
 beating them by an order of magnitude proves nothing about the Pi. Promoting
 one to :attr:`GateKind.HARD` is a deliberate edit here once
-``docs/PERFORMANCE.md`` carries a recorded Pi 4 baseline for it.
+``docs/PERFORMANCE.md`` carries a recorded Pi baseline for it.
+
+Five of the original six were promoted on the two on-hardware baselines in
+``docs/PERFORMANCE.md`` §5.4 (Pi 4, SD card, contended) and §5.5 (Pi 5, NVMe,
+all twelve gates passed): each was inside its budget on both, and a figure that
+*met* its budget on a contended machine met it with the worst case included.
+``db_write_cycle_ms`` is the one that remains, because those two runs disagree
+about it by an order of magnitude — the storage device sets it (issue #132).
 
 CI headroom
 -----------
@@ -39,6 +46,12 @@ Budgets that measure a *quantity* rather than a duration get
 :data:`NO_HEADROOM`. A 1 GB memory ceiling relaxed five-fold is not a gate, and
 the live population a deterministic scenario produces does not vary with how
 loaded the machine is.
+
+``startup_s`` and ``recovery_s`` are durations that also carry
+:data:`NO_HEADROOM`, for an arithmetic reason rather than a principled one:
+they are budgeted at 30 s against measurements of a tenth of a second, so a
+five-fold allowance would assert a bound nothing could fail. They were promoted
+in slice 065 at their stated 30 s.
 """
 
 from __future__ import annotations
@@ -131,7 +144,8 @@ class Budget:
 
 
 #: The table. Ordered as ``docs/PERFORMANCE.md`` presents it: the hard gates
-#: SPEC §85 names, then the reference budgets awaiting Pi 4 baselines.
+#: SPEC §85 names, then the rows promoted to hard gates on the §5.4/§5.5
+#: baselines, then what remains trend-tracked.
 BUDGETS: Final[tuple[Budget, ...]] = (
     Budget(
         metric="live_population",
@@ -243,29 +257,13 @@ BUDGETS: Final[tuple[Budget, ...]] = (
         value=100.0,
         statistic=Statistic.P95,
         direction=Direction.CEILING,
-        gate=GateKind.REFERENCE,
+        gate=GateKind.HARD,
         ci_headroom=CI_HEADROOM,
         rationale=(
             "One delta built and delivered to every connected client, once per ~1 Hz tick "
-            "(docs/API.md §4.3). Reference until a Pi 4 baseline exists: fan-out cost is "
-            "serialization-bound and scales with client count, which the harness records "
-            "alongside the figure."
-        ),
-    ),
-    Budget(
-        metric="db_write_cycle_ms",
-        title="SQLite write latency (persistence cycle)",
-        spec_metric="SQLite write latency",
-        unit="ms",
-        value=250.0,
-        statistic=Statistic.P95,
-        direction=Direction.CEILING,
-        gate=GateKind.REFERENCE,
-        ci_headroom=CI_HEADROOM,
-        rationale=(
-            "One write-behind cycle committing a tick's accumulated sighting work. It is off "
-            "the hot path by construction (ADR-0008), so this is a health figure rather than a "
-            "correctness limit — reference until Pi 4 SD-card I/O sets the real number."
+            "(docs/API.md §4.3). Promoted from a reference budget on the on-hardware baselines "
+            "in docs/PERFORMANCE.md §5.5: 68.1 ms p95 on a contended Pi 4 and 28.2 ms on a "
+            "Pi 5, both inside the 100 ms budget."
         ),
     ),
     Budget(
@@ -276,12 +274,13 @@ BUDGETS: Final[tuple[Budget, ...]] = (
         value=500.0,
         statistic=Statistic.P95,
         direction=Direction.CEILING,
-        gate=GateKind.REFERENCE,
+        gate=GateKind.HARD,
         ci_headroom=CI_HEADROOM,
         rationale=(
             "History and sightings endpoints served while ingestion runs, i.e. a reader "
-            "competing with the single writer for the WAL. Reference until Pi 4 storage is "
-            "characterized; slice 050 qualifies it at multi-year scale."
+            "competing with the single writer for the WAL. Promoted on the baselines in "
+            "docs/PERFORMANCE.md §5.5: 26.2 ms p95 on a contended Pi 4 and 9.16 ms on a Pi 5, "
+            "against a 500 ms budget. Slice 050 qualifies it again at multi-year scale."
         ),
         also_enforced_by=(
             "tests/api/test_sightings_perf.py",
@@ -296,11 +295,13 @@ BUDGETS: Final[tuple[Budget, ...]] = (
         value=500.0,
         statistic=Statistic.P95,
         direction=Direction.CEILING,
-        gate=GateKind.REFERENCE,
+        gate=GateKind.HARD,
         ci_headroom=CI_HEADROOM,
         rationale=(
             "Roadmap slice 031's stated budget, restated here under concurrent ingestion "
-            "rather than on an idle process. Slice 050 qualifies it on a multi-year dataset."
+            "rather than on an idle process. Promoted on the baselines in "
+            "docs/PERFORMANCE.md §5.5: 48.2 ms p95 on a contended Pi 4 and 13.8 ms on a Pi 5, "
+            "against a 500 ms budget. Slice 050 qualifies it on a multi-year dataset."
         ),
         also_enforced_by=("tests/analytics/test_perf.py",),
     ),
@@ -312,12 +313,14 @@ BUDGETS: Final[tuple[Budget, ...]] = (
         value=30.0,
         statistic=Statistic.MAX,
         direction=Direction.CEILING,
-        gate=GateKind.REFERENCE,
+        gate=GateKind.HARD,
         ci_headroom=NO_HEADROOM,
         rationale=(
-            "Migrations, wiring and the first ready report. Dominated by disk on a Pi 4, so the "
-            "budget is stated for that hardware and carries no CI headroom — a dev machine "
-            "should be nowhere near it."
+            "Migrations, wiring and the first ready report. Dominated by disk on a Pi, so the "
+            "budget is stated for that hardware. Promoted on the baselines in "
+            "docs/PERFORMANCE.md §5.5 — 0.547 s on a contended Pi 4, 0.112 s on a Pi 5 — and "
+            "kept at NO_HEADROOM: multiplying a 30 s ceiling by five would assert a bound no "
+            "machine could fail, and a promotion that loosens its own bound is not one."
         ),
     ),
     Budget(
@@ -328,14 +331,34 @@ BUDGETS: Final[tuple[Budget, ...]] = (
         value=30.0,
         statistic=Statistic.MAX,
         direction=Direction.CEILING,
-        gate=GateKind.REFERENCE,
+        gate=GateKind.HARD,
         ci_headroom=NO_HEADROOM,
         rationale=(
             "Repairing every sighting left open by a power cut, from checkpoint rows "
-            "(slice 053). Bounded by the open-sighting count, which the harness records; "
-            "reference until Pi 4 SD-card I/O sets the real number."
+            "(slice 053). Bounded by the open-sighting count, which the harness records. "
+            "Promoted on the baselines in docs/PERFORMANCE.md §5.5 — 539 open sightings "
+            "repaired in 9.3 s on a contended Pi 4 SD card and 0.0755 s on a Pi 5 — and kept "
+            "at NO_HEADROOM for the same reason as startup."
         ),
         also_enforced_by=("tests/sightings/test_kill_drill.py",),
+    ),
+    Budget(
+        metric="db_write_cycle_ms",
+        title="SQLite write latency (persistence cycle)",
+        spec_metric="SQLite write latency",
+        unit="ms",
+        value=250.0,
+        statistic=Statistic.P95,
+        direction=Direction.CEILING,
+        gate=GateKind.REFERENCE,
+        ci_headroom=CI_HEADROOM,
+        rationale=(
+            "One write-behind cycle committing a tick's accumulated sighting work. It is off "
+            "the hot path by construction (ADR-0008), so this is a health figure rather than a "
+            "correctness limit. The one row the two on-hardware baselines disagree about — "
+            "678 ms p95 on a Pi 4 SD card against 57.7 ms on a Pi 5 NVMe (issue #132) — so it "
+            "stays a reference budget: the storage device, not the code, sets it."
+        ),
     ),
 )
 

--- a/backend/src/flightsite/perf/budgets.py
+++ b/backend/src/flightsite/perf/budgets.py
@@ -30,7 +30,8 @@ Five of the original six were promoted on the two on-hardware baselines in
 all twelve gates passed): each was inside its budget on both, and a figure that
 *met* its budget on a contended machine met it with the worst case included.
 ``db_write_cycle_ms`` is the one that remains, because those two runs disagree
-about it by an order of magnitude — the storage device sets it (issue #132).
+about it by an order of magnitude — the storage device sets it, and the clean
+Pi 4 run on non-SD storage that would calibrate it is issue #153.
 
 CI headroom
 -----------
@@ -48,10 +49,15 @@ the live population a deterministic scenario produces does not vary with how
 loaded the machine is.
 
 ``startup_s`` and ``recovery_s`` are durations that also carry
-:data:`NO_HEADROOM`, for an arithmetic reason rather than a principled one:
-they are budgeted at 30 s against measurements of a tenth of a second, so a
-five-fold allowance would assert a bound nothing could fail. They were promoted
-in slice 065 at their stated 30 s.
+:data:`NO_HEADROOM`. Slice 065 promoted both at their stated 30 s rather than
+relaxing them to 150 s on promotion, because a promotion that loosens the bound
+it enforces is not one. Their margins are not alike, though, and the difference
+matters more than the shared constant: startup measured 0.547 s on a contended
+Pi 4 and 0.112 s on a Pi 5, while recovery measured **9.3 s** on that Pi 4's SD
+card against 0.0755 s on the Pi 5. Recovery therefore sits 3.2x inside its
+ceiling on the reference hardware, on a path already reported as load-sensitive
+(issue #100) — the tightest gate in this table, and the one to read first if a
+run on slow storage goes red.
 """
 
 from __future__ import annotations
@@ -335,10 +341,13 @@ BUDGETS: Final[tuple[Budget, ...]] = (
         ci_headroom=NO_HEADROOM,
         rationale=(
             "Repairing every sighting left open by a power cut, from checkpoint rows "
-            "(slice 053). Bounded by the open-sighting count, which the harness records. "
-            "Promoted on the baselines in docs/PERFORMANCE.md §5.5 — 539 open sightings "
-            "repaired in 9.3 s on a contended Pi 4 SD card and 0.0755 s on a Pi 5 — and kept "
-            "at NO_HEADROOM for the same reason as startup."
+            "(slice 053). Bounded by the open-sighting count, which the harness records, and "
+            "by the storage device. Promoted on the baselines in docs/PERFORMANCE.md §5.5 and "
+            "kept at NO_HEADROOM, which leaves the narrowest margin of any gate here: 539 open "
+            "sightings were repaired in 9.3 s on a contended Pi 4 SD card — 3.2x inside the "
+            "30 s ceiling — against 0.0755 s on a Pi 5, and the path is already reported as "
+            "load-sensitive (issue #100). Promoted knowingly on that figure: the budget bounds "
+            "exactly the disk cost that consumed it."
         ),
         also_enforced_by=("tests/sightings/test_kill_drill.py",),
     ),
@@ -356,8 +365,9 @@ BUDGETS: Final[tuple[Budget, ...]] = (
             "One write-behind cycle committing a tick's accumulated sighting work. It is off "
             "the hot path by construction (ADR-0008), so this is a health figure rather than a "
             "correctness limit. The one row the two on-hardware baselines disagree about — "
-            "678 ms p95 on a Pi 4 SD card against 57.7 ms on a Pi 5 NVMe (issue #132) — so it "
-            "stays a reference budget: the storage device, not the code, sets it."
+            "678 ms p95 on a Pi 4 SD card against 57.7 ms on a Pi 5 NVMe — so it stays a "
+            "reference budget: the storage device, not the code, sets it, and the clean Pi 4 "
+            "run on non-SD storage that would calibrate it is issue #153."
         ),
     ),
 )

--- a/backend/tests/perf/test_budgets.py
+++ b/backend/tests/perf/test_budgets.py
@@ -81,6 +81,46 @@ def test_the_reference_budgets_are_the_ones_spec_85_lets_be_trended() -> None:
     assert not (trended & SPEC_85_HARD_GATES)
 
 
+def test_the_hard_gates_are_the_eleven_documented_ones() -> None:
+    """The exact hard set, pinned as ``tests/perf/storage`` pins its three.
+
+    The two checks above are supersets: they catch a SPEC §85 gate being
+    demoted, but say nothing about the five rows ``docs/PERFORMANCE.md`` §5.5
+    promoted on the recorded Pi baselines. Demoting one of those would restore
+    the pre-promotion behaviour — measured, reported, never failing a run — and
+    every other test in this module would still pass. Promotion was a decision
+    somebody made and wrote down; reversing it has to be one too.
+    """
+    assert {budget.metric for budget in hard_budgets()} == {
+        # SPEC §85's own hard-gate list.
+        "live_population",
+        "ingest_apply_ms",
+        "ingest_duty_cycle",
+        "live_sweep_ms",
+        "api_live_ms",
+        "memory_rss_mib",
+        # Promoted in docs/PERFORMANCE.md §5.5, on the §5.4 and §5.5 baselines.
+        "ws_fanout_ms",
+        "db_read_ms",
+        "analytics_query_ms",
+        "startup_s",
+        "recovery_s",
+    }
+
+
+def test_the_write_cycle_is_the_only_budget_still_trend_tracked() -> None:
+    """§5.5 promoted five of the six, and recorded why the sixth was not.
+
+    ``db_write_cycle_ms`` measured 678 ms on a Pi 4 SD card and 57.7 ms on a
+    Pi 5 NVMe against a 250 ms budget, so neither reading calibrates it and
+    promoting it on the faster one would fail the reference hardware for the
+    storage most Pi 4 installs use. Issue #153 is the run that would settle it.
+    Pinned in both directions, so neither promoting this row nor quietly adding
+    another one beside it happens without a documented decision.
+    """
+    assert {budget.metric for budget in reference_budgets()} == {"db_write_cycle_ms"}
+
+
 def test_the_live_population_floor_is_the_spec_5_envelope() -> None:
     budget = budget_for("live_population")
     assert budget.value == float(TARGET_AIRCRAFT)

--- a/backend/tests/perf/test_docs.py
+++ b/backend/tests/perf/test_docs.py
@@ -18,7 +18,13 @@ from pathlib import Path
 
 import pytest
 
-from flightsite.perf.budgets import BUDGETS, TARGET_AIRCRAFT, Budget, GateKind
+from flightsite.perf.budgets import (
+    BUDGETS,
+    TARGET_AIRCRAFT,
+    Budget,
+    GateKind,
+    reference_budgets,
+)
 
 #: backend/tests/perf/test_docs.py -> repo root.
 DOC = Path(__file__).resolve().parents[3] / "docs" / "PERFORMANCE.md"
@@ -27,8 +33,11 @@ HARD_HEADING = "### 2.1 Hard gates"
 REFERENCE_HEADING = "### 2.2 Reference budgets"
 END_HEADING = "### 2.3"
 
-BASELINE_HEADING = "### 5.4 Recorded baselines"
+BASELINE_HEADING = "### 5.4 Raspberry Pi 4 baseline"
 BASELINE_END_HEADING = "### 5.5"
+
+CLEAN_BASELINE_HEADING = "### 5.5 Raspberry Pi 5 baseline"
+CLEAN_BASELINE_END_HEADING = "### 5.6"
 
 
 @pytest.fixture(scope="module")
@@ -39,13 +48,20 @@ def document() -> str:
 
 @pytest.fixture(scope="module")
 def baseline(document: str) -> str:
-    """§5.4 alone.
+    """§5.4 alone — the contended Pi 4 run.
 
-    Scoped deliberately: §5.5's development-machine table and §7.6's storage
-    section carry their own figures and their own disclaimer, and a check on
-    the whole document would be satisfied — or defeated — by either of them.
+    Scoped deliberately: §5.5's Pi 5 run, §5.6's development-machine table and
+    §7.6's storage section carry their own figures and their own caveats, and a
+    check on the whole document would be satisfied — or defeated — by any of
+    them.
     """
     return section(document, BASELINE_HEADING, BASELINE_END_HEADING)
+
+
+@pytest.fixture(scope="module")
+def clean_baseline(document: str) -> str:
+    """§5.5 alone — the fully-passing Pi 5 run, scoped for the same reason."""
+    return section(document, CLEAN_BASELINE_HEADING, CLEAN_BASELINE_END_HEADING)
 
 
 def section(document: str, start: str, end: str) -> str:
@@ -129,6 +145,55 @@ def test_the_recorded_baseline_reports_every_budget(budget: Budget, baseline: st
     """
     assert budget.metric in baseline, (
         f"{budget.metric} is measured by the harness but absent from §5.4's recorded baseline"
+    )
+
+
+def test_the_document_records_the_clean_pi_baseline(clean_baseline: str) -> None:
+    """Slice 065's result: the first on-hardware run that passed every gate.
+
+    Held the same way §5.4 is held. §5.4 is an upper bound taken on a contended
+    machine and says so; a document that kept it and quietly lost the clean run
+    beside it would read as though qualification had never succeeded.
+    """
+    assert "Raspberry Pi 5" in clean_baseline, (
+        "docs/PERFORMANCE.md §5.5 records the clean on-hardware run; it must name "
+        "the machine it was taken on"
+    )
+    assert "not yet run" not in clean_baseline, (
+        "docs/PERFORMANCE.md §5.5 must not be an empty table"
+    )
+    assert "#132" in clean_baseline, (
+        "docs/PERFORMANCE.md §5.5 answers the finding §5.4 filed; the section has "
+        "to name the issue it closes, or the two readings read as unrelated runs"
+    )
+
+
+@pytest.mark.parametrize("budget", BUDGETS, ids=lambda budget: budget.metric)
+def test_the_clean_baseline_reports_every_budget(budget: Budget, clean_baseline: str) -> None:
+    """§5.3 step 1 again, for the second recorded run.
+
+    The same rule as §5.4's: a run that reports the comfortable rows and omits
+    the rest is not a baseline. It matters more here, because this is the run
+    §5.3 step 2's promotions were decided on.
+    """
+    assert budget.metric in clean_baseline, (
+        f"{budget.metric} is measured by the harness but absent from §5.5's recorded baseline"
+    )
+
+
+@pytest.mark.parametrize("budget", reference_budgets(), ids=lambda budget: budget.metric)
+def test_the_promotion_decision_accounts_for_what_stayed_trend_tracked(
+    budget: Budget, clean_baseline: str
+) -> None:
+    """§5.3 step 2 is a decision, and a decision nobody can read was not made.
+
+    §5.5 applied the promotion rule. A budget still trend-tracked after a run
+    that measured it is the case the rule has to justify explicitly, so the
+    section that promoted the others has to name it.
+    """
+    assert budget.metric in clean_baseline, (
+        f"{budget.metric} was left a reference budget by §5.3 step 2, but §5.5 — "
+        "where that decision was taken — does not mention it"
     )
 
 

--- a/backend/tests/perf/test_docs.py
+++ b/backend/tests/perf/test_docs.py
@@ -187,13 +187,29 @@ def test_the_promotion_decision_accounts_for_what_stayed_trend_tracked(
 ) -> None:
     """§5.3 step 2 is a decision, and a decision nobody can read was not made.
 
-    §5.5 applied the promotion rule. A budget still trend-tracked after a run
-    that measured it is the case the rule has to justify explicitly, so the
-    section that promoted the others has to name it.
+    Mere presence is not enough and is already covered above: a metric named
+    only in §5.5's results table would satisfy that test while leaving the
+    reader no idea why it alone stayed trend-tracked after a run that measured
+    it passing. So this asks for the decision itself — the metric named on a
+    line that says it was *not* promoted, or that it stays a reference budget.
+    Emphasis and code markers are stripped first, because whether the document
+    writes ``**not** promoted`` or ``not promoted`` is layout, and pinning
+    layout is how a documentation test earns its deletion.
     """
-    assert budget.metric in clean_baseline, (
+    decisions = ("not promoted", "stays a reference", "reference -> reference")
+    lines = [
+        line.replace("*", "").replace("`", "").replace("→", "->")
+        for line in clean_baseline.splitlines()
+        if budget.metric in line
+    ]
+    assert lines, (
         f"{budget.metric} was left a reference budget by §5.3 step 2, but §5.5 — "
         "where that decision was taken — does not mention it"
+    )
+    assert any(decision in line for line in lines for decision in decisions), (
+        f"§5.5 names {budget.metric} but never states the decision: the row that "
+        "survived the promotion has to be recorded as not promoted, not merely "
+        f"reported. Lines found: {lines}"
     )
 
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -61,13 +61,18 @@ population a deterministic scenario produces does not vary with how loaded the
 machine is.
 
 Two timing gates carry no headroom either, and the reason is arithmetic rather
-than principle. `startup_s` and `recovery_s` are budgeted at 30 seconds against
-measurements of a tenth of a second (§5.5); multiplying that ceiling by five
-would assert 150 s, which no machine this product runs on could fail. They were
-promoted at their stated 30 s in §5.5 because a promotion that loosens the
-bound it enforces is not a promotion, and the rule above exists to stop a busy
-runner failing a gate, not to inflate one that already clears its measurements
-by a factor of several hundred.
+than principle. `startup_s` and `recovery_s` are budgeted at 30 seconds;
+multiplying that by five would assert 150 s, and a promotion that loosens the
+bound it enforces is not a promotion, so §5.5 promoted both at their stated
+figure. What that leaves is a real bound rather than a formality, and the
+margins differ sharply between the two. Startup measured 0.112 s on a Pi 5 and
+0.547 s on a contended Pi 4 — three hundred times inside the ceiling either way.
+Recovery measured 0.0755 s on the Pi 5 but **9.3 s on the contended Pi 4's SD
+card**, which is only 3.2× inside it, and the repair path is already known to be
+load-sensitive (issue #100). That is the narrowest margin of any gate in the
+table; it is deliberate — recovery is bounded by the open-sighting count and the
+storage device, and both are exactly what the budget is there to bound — but it
+is the row to watch on a slow disk, not one to treat as unfailable.
 
 ---
 
@@ -107,7 +112,7 @@ crossing one now fails.
 | `db_read_ms` | SQLite read/query latency | ≤ 500 ms | p95 | ≤ 2500 ms | A reader competing with the single writer for the WAL. Promoted in §5.5: 26.2 ms on a contended Pi 4, 9.16 ms on a Pi 5. §7 qualifies it again at multi-year scale. |
 | `analytics_query_ms` | analytics query latency | ≤ 500 ms | p95 | ≤ 2500 ms | Slice 031's stated budget, restated under concurrent ingestion. Promoted in §5.5: 48.2 ms on a contended Pi 4, 13.8 ms on a Pi 5. |
 | `startup_s` | startup | ≤ 30 s | max | ≤ 30 s | Migrations, wiring and the first ready report; dominated by disk. Promoted in §5.5 at two orders of magnitude of margin, and with no CI headroom (§1 explains why multiplying it would be meaningless). |
-| `recovery_s` | unclean-shutdown recovery | ≤ 30 s | max | ≤ 30 s | Repair of the sightings a power cut left open (slice 053), bounded by the open-sighting count the harness records. Promoted in §5.5, likewise without headroom. |
+| `recovery_s` | unclean-shutdown recovery | ≤ 30 s | max | ≤ 30 s | Repair of the sightings a power cut left open (slice 053), bounded by the open-sighting count the harness records. Promoted in §5.5, likewise without headroom — and the tightest row in this table: 539 sightings took 9.3 s on the contended Pi 4's SD card against 0.0755 s on a Pi 5, so the margin on the reference hardware is 3.2× and the path is load-sensitive (issue #100). |
 
 ### 2.2 Reference budgets (trend-tracked)
 
@@ -124,7 +129,7 @@ the table for.
 
 | Metric | SPEC §85 item | Budget (Pi 4) | Statistic | Why not yet a hard gate |
 |---|---|---|---|---|
-| `db_write_cycle_ms` | SQLite write latency | ≤ 250 ms | p95 | Off the hot path by construction (ADR-0008), so this is a health figure rather than a correctness limit. Measured at 678 ms on a Pi 4 SD card and 57.7 ms on a Pi 5 NVMe: the storage substrate, not the code, sets it (§5.5, issue #132). |
+| `db_write_cycle_ms` | SQLite write latency | ≤ 250 ms | p95 | Off the hot path by construction (ADR-0008), so this is a health figure rather than a correctness limit. Measured at 678 ms on a Pi 4 SD card and 57.7 ms on a Pi 5 NVMe: the storage substrate, not the code, sets it (§5.5). The clean Pi 4 run on non-SD storage that would calibrate it is issue #153. |
 
 ### 2.3 Where else these are enforced
 
@@ -362,8 +367,11 @@ userland on an aarch64 kernel), Docker Compose · 500 aircraft, 600 ticks,
 > hardware's number.
 >
 > **The re-run landed: §5.5, on a Pi 5 with an NVMe SSD, passes all twelve
-> gates and closes issue #132.** This section stays exactly as recorded — it is
-> the Pi 4 reading, and a baseline that gets edited is not a baseline.
+> gates and explains the overrun below.** Issue #132 is closed on that
+> explanation; the reference-hardware question it leaves open — a clean Pi 4 on
+> non-SD storage — is tracked as **issue #153**. This section stays exactly as
+> recorded: it is the Pi 4 reading, and a baseline that gets edited is not a
+> baseline.
 
 Budgets below are the Pi 4 budgets from §2 at face value. `CI_HEADROOM` does
 not apply: it exists so that a shared CI runner cannot fail a gate, and this
@@ -471,10 +479,13 @@ Nginx Proxy Manager and MariaDB pair resident on the host. The harness runs
 in-process against its own temporary database, so what it measured was a second
 full pipeline standing up beside the first.
 
-That is a *lighter* load than §5.4's but it is not a quiet machine either, and
-the figures are stated as the upper bounds they are. It does not weaken the
-result: every gate passed, and a gate passed with neighbours on the machine is a
-gate passed with them included.
+The container inventory is *larger* than §5.4's, not smaller. What is lighter is
+the contention that mattered there: the neighbours' writes no longer queue
+behind one SD card, and the proxy and database pair were idle rather than
+serving. So this is not the quiet machine §5.2 describes either, and the figures
+are stated as the upper bounds they are. That does not weaken the result: every
+gate passed, and a gate passed with neighbours on the machine is a gate passed
+with them included.
 
 Budgets are the Pi 4 budgets from §2 at face value, as in §5.4 — the same
 comparison, so the two tables can be read against each other. The Gate column
@@ -532,15 +543,17 @@ product, or is it the SD card? The answer is legible in the write-cycle row.
 | `ingest_duty_cycle` p95 | 0.99 | **0.347** |
 | `ingest_duty_cycle` max | 5.29 | **1.31** |
 
-An 11.8× fall in write-cycle p95 is not a CPU result. The Pi 5's cores are
-roughly two to three times the Pi 4's, and every purely computational row here
-moved by about that much — `ingest_apply_ms` p95 from 81.2 to 30.5,
-`ws_fanout_ms` from 68.1 to 28.2, `analytics_query_ms` from 48.2 to 13.8. The
-write cycle moved by an order of magnitude more than the arithmetic did, and it
-is the one stage whose cost is dominated by the storage device. §5.4 predicted
+An 11.8× fall in write-cycle p95 is not a CPU result. The purely computational
+rows moved by between **2.4× and 3.5×** — `ingest_apply_ms` p95 81.2 → 30.5
+(2.7×), `ws_fanout_ms` 68.1 → 28.2 (2.4×), `analytics_query_ms` 48.2 → 13.8
+(3.5×) — which is the range a Pi 5's cores against a Pi 4's would predict. The
+write cycle moved three to five times further than any of them, and it is the
+one stage whose cost is dominated by the storage device. §5.4 predicted
 exactly this: *"an SD card that occasionally takes five seconds to commit a
 flush carries the duty cycle straight up with it."* It did, and on NVMe it does
-not. **#132 is closed on that finding**, and no budget was widened to close it.
+not. **#132 is closed on that explanation**, and no budget was widened to close
+it: the finding is understood rather than made to disappear, and what it leaves
+open on the reference hardware is tracked as **#153**.
 
 Two honest limits on the claim. Two variables changed at once — the SoC and the
 storage — so this run does not decompose the improvement to the last
@@ -582,7 +595,11 @@ field per row. `ws_fanout_ms`, `db_read_ms` and `analytics_query_ms` keep
 harness already reported. `startup_s` and `recovery_s` keep `NO_HEADROOM` and
 are therefore gated at their stated 30 s: giving them the fivefold allowance
 would have asserted 150 s, and a promotion that loosens the bound it enforces
-is not a promotion (§1).
+is not a promotion (§1). Read against the reference hardware rather than
+against this run, `recovery_s` is the tightest of the five — 9.3 s of the 30 on
+§5.4's SD card, on a path issue #100 already reports as load-sensitive. It is
+promoted on that figure knowingly: 3.2× is a margin, the budget bounds exactly
+the disk cost that consumed it, and a gate nothing can reach is not a gate.
 
 `db_write_cycle_ms` is **not** promoted, and this is the conservative half of
 the same argument. It is the one row the two runs disagree about — 678 ms on an
@@ -591,8 +608,9 @@ calibrates it. Promoting it on the Pi 5 figure would make the reference
 hardware fail its own gate on the storage most Pi 4 installs use; promoting it
 on the Pi 4 figure is impossible, because that figure missed. It stays a
 reference budget at 250 ms, unwidened, exactly as §5.3 rule 3 requires. What
-would settle it is a clean Pi 4 run on a USB SSD — the same product, the same
-poll, with only the card taken out of the picture.
+would settle it is a clean Pi 4 run on non-SD storage — the same product, the
+same poll, with only the card taken out of the picture. That run is **issue
+#153**, #132's successor and the row's outstanding calibration.
 
 ### 5.6 Development-machine baseline
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -66,8 +66,8 @@ measurements of a tenth of a second (§5.5); multiplying that ceiling by five
 would assert 150 s, which no machine this product runs on could fail. They were
 promoted at their stated 30 s in §5.5 because a promotion that loosens the
 bound it enforces is not a promotion, and the rule above exists to stop a busy
-runner failing a gate, not to inflate one that already has three orders of
-magnitude of room.
+runner failing a gate, not to inflate one that already clears its measurements
+by a factor of several hundred.
 
 ---
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -20,8 +20,10 @@ reason for that. Some limits are correctness-critical: cross one and the live
 picture becomes a backlog, or the process heads for the OOM killer. Others are
 questions of comfort whose real answer depends on the reference hardware — and
 a budget calibrated on a developer laptop tells you nothing about an SD card on
-a Pi. §5.4 now carries a first Pi 4 reading, taken on a contended machine; it
-informs the second kind of budget without yet being firm enough to fix one.
+a Pi. §5 now carries two on-hardware readings: a contended Pi 4 on an SD card
+(§5.4) and a fully-passing Pi 5 on NVMe (§5.5). Between them they were enough
+to fix five of the six budgets of the second kind, which became hard gates in
+§5.5. One did not, and §5.5 says why.
 
 So budgets come in two kinds, and every row of the table below is labelled.
 
@@ -29,14 +31,18 @@ So budgets come in two kinds, and every row of the table below is labelled.
 |---|---|---|
 | Enforced | Fails the test suite, on every PR | Measured, reported, trended; never fails a run |
 | Stated for | Any hardware the suite runs on | Raspberry Pi 4 |
-| Why | Correctness-critical: crossing it breaks the product | Comfort or headroom; the real limit needs Pi 4 data |
-| Becomes hard when | — | A Pi 4 baseline is recorded here (§5) and the row is promoted |
+| Why | Correctness-critical: crossing it breaks the product | Comfort or headroom; the real limit needs Pi data |
+| Becomes hard when | — | An on-hardware baseline in §5 backs it and the row is promoted (five were, in §5.5) |
 
 A reference budget is not a weaker budget. It is a budget that has not yet been
 calibrated against the hardware it is stated for, and reporting it as a hard
 gate on a developer machine would be dressing up a guess. A *contended* Pi 4 —
-which is what §5.4 records — does not lift that objection either; §5.4's
-closing note says why promotion waits for a clean re-run.
+which is what §5.4 records — does not lift that objection for a figure that
+*missed* its budget, because contention is then a live explanation for the
+miss. It does lift it for a figure that *met* one: neighbours competing for the
+machine can only have made a measurement worse, so a pass under contention is a
+pass with the worst case included. That asymmetry is the whole of §5.5's
+promotion argument.
 
 ### CI headroom
 
@@ -47,12 +53,21 @@ shared runner under coverage instrumentation is slow and noisy, and a bound
 five times the budget still catches every structural regression (a hot-path
 await, a per-aircraft query, a superlinear scan) while never failing on a busy
 machine. In practice the measured figures sit one to two orders of magnitude
-inside the asserted bound; see §5.5.
+inside the asserted bound; see §5.6.
 
 Budgets that measure a *quantity* rather than a duration get no headroom at
 all. A 1 GB memory ceiling relaxed fivefold is not a gate, and the live
 population a deterministic scenario produces does not vary with how loaded the
 machine is.
+
+Two timing gates carry no headroom either, and the reason is arithmetic rather
+than principle. `startup_s` and `recovery_s` are budgeted at 30 seconds against
+measurements of a tenth of a second (§5.5); multiplying that ceiling by five
+would assert 150 s, which no machine this product runs on could fail. They were
+promoted at their stated 30 s in §5.5 because a promotion that loosens the
+bound it enforces is not a promotion, and the rule above exists to stop a busy
+runner failing a gate, not to inflate one that already has three orders of
+magnitude of room.
 
 ---
 
@@ -64,11 +79,21 @@ and the harness judges every run against it. A budget that lives only in a
 document drifts from the test enforcing it; a budget that lives only in a test
 is invisible to whoever is deciding whether a Pi 4 is fast enough.
 
+Multi-year database behavior — the tenth item on SPEC §85's list — is roadmap
+slice 050's scope and is deliberately absent from both tables below. It has a
+table of its own in §7, which restates `db_read_ms` and `analytics_query_ms` at
+multi-year scale and adds the growth, retention, backup and restore budgets
+that only mean anything once a database has years in it.
+
 ### 2.1 Hard gates
 
-These are SPEC §85's own list: *ingestion keeps up; 500-aircraft workload
-remains functional; no live-state stalls; memory below agreed budget; core APIs
-responsive.*
+The first six are SPEC §85's own list: *ingestion keeps up; 500-aircraft
+workload remains functional; no live-state stalls; memory below agreed budget;
+core APIs responsive.* The last five were reference budgets until §5.5, and are
+here because SPEC §85 asks for exactly that — *convert to hard gates once real
+Pi baselines exist* — and two on-hardware runs now exist. Their budgets and
+their in-suite bounds are unchanged by the promotion; what changed is that
+crossing one now fails.
 
 | Metric | SPEC §85 item | Budget | Statistic | In-suite bound | What it protects |
 |---|---|---|---|---|---|
@@ -78,32 +103,28 @@ responsive.*
 | `live_sweep_ms` | live-state update latency | ≤ 100 ms | max | ≤ 500 ms | The lifecycle sweep runs every second over the whole live set, so it shares the apply budget. |
 | `api_live_ms` | core APIs responsive | ≤ 250 ms | p95 | ≤ 1250 ms | `/api/v1/aircraft/current` answers from memory, so under load this is serialization and nothing else. Past a quarter second the map feels stalled. |
 | `memory_rss_mib` | memory use | ≤ 1024 MiB | max | ≤ 1024 MiB | SPEC §5. An absolute ceiling on a 4 GB Pi shared with the frontend container and the decoder. |
+| `ws_fanout_ms` | WebSocket distribution | ≤ 100 ms | p95 | ≤ 500 ms | One delta built and delivered to every connected client per ~1 Hz tick (`docs/API.md` §4.3). Promoted in §5.5: measured at 68.1 ms on a contended Pi 4 and 28.2 ms on a Pi 5. |
+| `db_read_ms` | SQLite read/query latency | ≤ 500 ms | p95 | ≤ 2500 ms | A reader competing with the single writer for the WAL. Promoted in §5.5: 26.2 ms on a contended Pi 4, 9.16 ms on a Pi 5. §7 qualifies it again at multi-year scale. |
+| `analytics_query_ms` | analytics query latency | ≤ 500 ms | p95 | ≤ 2500 ms | Slice 031's stated budget, restated under concurrent ingestion. Promoted in §5.5: 48.2 ms on a contended Pi 4, 13.8 ms on a Pi 5. |
+| `startup_s` | startup | ≤ 30 s | max | ≤ 30 s | Migrations, wiring and the first ready report; dominated by disk. Promoted in §5.5 at two orders of magnitude of margin, and with no CI headroom (§1 explains why multiplying it would be meaningless). |
+| `recovery_s` | unclean-shutdown recovery | ≤ 30 s | max | ≤ 30 s | Repair of the sightings a power cut left open (slice 053), bounded by the open-sighting count the harness records. Promoted in §5.5, likewise without headroom. |
 
 ### 2.2 Reference budgets (trend-tracked)
 
 SPEC §85: *trend-track less critical metrics initially; convert to hard gates
 once real Pi 4 baselines exist.*
 
-A first Pi 4 baseline now exists (§5.4), so the per-row rationales below are no
-longer arguing from no data at all. None of these rows is promoted on it: that
-run was contended and its figures are upper bounds, so §5.3's promotion step is
-deferred to the clean re-run rather than applied to numbers that would set
-every threshold in the wrong place. §5.4 gives the argument in full.
+Five of the original six were converted in §5.5 and now sit in §2.1. One row
+remains, and it is the one the two recorded runs disagree about: the Pi 4's SD
+card missed it by a factor of nearly three (§5.4) while the Pi 5's NVMe met it
+with room to spare (§5.5). A budget whose measured value moves an order of
+magnitude with the storage device underneath it is not calibrated by either
+reading on its own, which is precisely the condition §1 reserves this half of
+the table for.
 
 | Metric | SPEC §85 item | Budget (Pi 4) | Statistic | Why not yet a hard gate |
 |---|---|---|---|---|
-| `ws_fanout_ms` | WebSocket distribution | ≤ 100 ms | p95 | Serialization-bound and scales with client count, which the harness records alongside the figure. |
-| `db_write_cycle_ms` | SQLite write latency | ≤ 250 ms | p95 | Off the hot path by construction (ADR-0008), so this is a health figure rather than a correctness limit. Pi 4 SD-card I/O sets the real number. |
-| `db_read_ms` | SQLite read/query latency | ≤ 500 ms | p95 | A reader competing with the single writer for the WAL. Pi 4 storage is uncharacterized; slice 050 qualifies it at multi-year scale. |
-| `analytics_query_ms` | analytics query latency | ≤ 500 ms | p95 | Slice 031's stated budget, restated under concurrent ingestion. Slice 050 qualifies it on a multi-year dataset. |
-| `startup_s` | startup | ≤ 30 s | max | Dominated by disk on a Pi 4. |
-| `recovery_s` | unclean-shutdown recovery | ≤ 30 s | max | Bounded by the open-sighting count, which the harness records. Pi 4 SD-card I/O sets the real number. |
-
-Multi-year database behavior — the tenth item on SPEC §85's list — is roadmap
-slice 050's scope and is deliberately absent from this table. It has a table of
-its own in §7, which restates `db_read_ms` and `analytics_query_ms` above at
-multi-year scale and adds the growth, retention, backup and restore budgets
-that only mean anything once a database has years in it.
+| `db_write_cycle_ms` | SQLite write latency | ≤ 250 ms | p95 | Off the hot path by construction (ADR-0008), so this is a health figure rather than a correctness limit. Measured at 678 ms on a Pi 4 SD card and 57.7 ms on a Pi 5 NVMe: the storage substrate, not the code, sets it (§5.5, issue #132). |
 
 ### 2.3 Where else these are enforced
 
@@ -265,15 +286,23 @@ the command drops straight into a release check.
 
 ---
 
-## 5. Raspberry Pi 4 qualification procedure
+## 5. Raspberry Pi qualification procedure
 
 Run this before a release (SPEC §107's release checklist names Pi 4 performance
 qualification), and whenever a change is expected to move any figure in §2.
 
+The reference hardware the budgets are stated for is still the Raspberry Pi 4;
+the procedure below is written for it and is unchanged. Two runs are recorded:
+a Pi 4 (§5.4) and a Pi 5 (§5.5). A newer Pi runs the same procedure and is
+recorded the same way — what a baseline has to state is the hardware it was
+taken on, not that the hardware was one particular model.
+
 ### 5.1 Prepare
 
 1. A Raspberry Pi 4 (4 GB or better) on Raspberry Pi OS 64-bit, with the
-   storage the install actually uses — SD card or USB SSD, not a tmpfs.
+   storage the install actually uses — SD card or USB SSD, not a tmpfs. A later
+   model runs the same procedure; record which, because the figures are only
+   readable against the machine that produced them.
 2. Deploy the release candidate with Docker Compose per `docs/DEVELOPMENT.md`.
 3. Stop anything else competing for the machine. A decoder feeding the Pi is
    fine and realistic; a desktop session is not.
@@ -294,17 +323,22 @@ table and the JSON off the Pi.
 
 ### 5.3 Record and promote
 
-1. Add a row set to §5.4 with the date, the release, the hardware and every
-   measured figure.
-2. For each **reference** budget now backed by a Pi 4 baseline, decide whether
-   to promote it to a hard gate: change its `gate` to `GateKind.HARD` in
+1. Add a subsection to §5 with the date, the release, the hardware and every
+   measured figure — one subsection per machine, so a later run adds a reading
+   rather than overwriting one.
+2. For each **reference** budget now backed by an on-hardware baseline, decide
+   whether to promote it to a hard gate. §1's asymmetry governs what a
+   *contended* run can back: a figure that met its budget under contention met
+   it with the worst case included, and a figure that missed one under
+   contention has not been measured at all. Promote by changing its `gate` to
+   `GateKind.HARD` in
    `backend/src/flightsite/perf/budgets.py`, set an appropriate `ci_headroom`,
    and update §2 above. `tests/perf/test_budgets.py` will hold the new
    invariant.
 3. If a measured figure exceeds its budget, that is a finding: file it as a
    roadmap entry or an issue rather than widening the budget to fit.
 
-### 5.4 Recorded baselines
+### 5.4 Raspberry Pi 4 baseline — SD card, contended
 
 **2026-09-01** · FlightSite **v0.2.0** · Raspberry Pi 4 Model B Rev 1.5, 4 GB
 RAM (3794 MB), SD-card root (`/dev/root`, 59 GB), Raspberry Pi OS (armhf
@@ -326,10 +360,17 @@ userland on an aarch64 kernel), Docker Compose · 500 aircraft, 600 ticks,
 > quiet-machine measurement §5.2 describes. **A clean re-run is pending**;
 > until it lands, read every figure here as an upper bound rather than as the
 > hardware's number.
+>
+> **The re-run landed: §5.5, on a Pi 5 with an NVMe SSD, passes all twelve
+> gates and closes issue #132.** This section stays exactly as recorded — it is
+> the Pi 4 reading, and a baseline that gets edited is not a baseline.
 
 Budgets below are the Pi 4 budgets from §2 at face value. `CI_HEADROOM` does
 not apply: it exists so that a shared CI runner cannot fail a gate, and this
-*is* the reference hardware the budgets are stated for.
+*is* the reference hardware the budgets are stated for. The Gate column is the
+gate each row carried **when this run was taken**; five of the six reference
+rows were promoted to hard gates in §5.5, on this run's evidence together with
+that one's.
 
 | Metric | Gate | median | p95 | max | Gated statistic | Pi 4 budget | Result |
 |---|---|---|---|---|---|---|---|
@@ -347,9 +388,9 @@ not apply: it exists so that a shared CI runner cannot fail a gate, and this
 | `recovery_s` | reference | — | — | — | max 9.3 | ≤ 30 | pass |
 
 The WebSocket run distributed 3,560 frames with **0 resync reconnects**, which
-is slice 057's batching fix (§5.5's closing note) confirmed on real hardware
+is slice 057's batching fix (§5.6's closing note) confirmed on real hardware
 rather than on the machine that wrote it. Recovery adopted **539 open
-sightings** in 9.3 s, the same open-sighting count as §5.5's development run
+sightings** in 9.3 s, the same open-sighting count as §5.6's development run
 and about four times its cost — the clearest single expression of what SD-card
 I/O does to this product. The JSON report is on that Pi at
 `/opt/flightsite/data/perf-baseline/report.json`; §5.2 asks for it to be copied
@@ -360,7 +401,7 @@ finding.** `ingest_duty_cycle` is a hard gate and its p95 of 0.99 is twice its
 budget: at that figure the per-tick hot path is consuming a whole 1 Hz poll,
 with no margin left. Its driver is visible one row down — `db_write_cycle_ms`
 p95 678 ms against a 250 ms budget, with a maximum of 5.18 s. The duty cycle
-sums the harness's stages serially (§5.5 explains why, and why the product does
+sums the harness's stages serially (§5.6 explains why, and why the product does
 not), so an SD card that occasionally takes five seconds to commit a flush
 carries the duty cycle straight up with it.
 
@@ -402,7 +443,158 @@ their budgets even under this load, and the sixth is the write-cycle row that
 #132 exists to explain. The clean re-run is the point at which §5.3 step 2 gets
 applied for real.
 
-### 5.5 Development-machine baseline
+*It was.* §5.5 records the re-run, and step 2 promoted exactly those five —
+the ones that held here under contention and again on a quiet-storage machine.
+The sixth, `db_write_cycle_ms`, is the one this run and that one disagree
+about, and it stays a reference budget for that reason.
+
+### 5.5 Raspberry Pi 5 baseline — NVMe, clean run
+
+**2026-09-02** · FlightSite **v0.3.1** · Raspberry Pi 5 Model B Rev 1.0, 8 GB
+RAM, NVMe SSD root (476.9 G), Debian 12 (bookworm) arm64, kernel 6.12.96,
+Docker CE 29.7, Python 3.12.14 · 500 aircraft, 600 ticks, 4 WebSocket clients,
+629 s wall
+
+```bash
+docker compose exec flightsite-backend \
+  flightsite-perf --realtime --ticks 600 \
+                  --data-dir /opt/flightsite/data/perf-baseline \
+                  --json /opt/flightsite/data/perf-baseline/report.json
+```
+
+Taken on the owner's live receiver, exactly as §5.2 prescribes. The machine was
+running its ordinary job
+throughout: an ultrafeeder decoder and the piaware, FlightRadar24 and OpenSky
+feeder containers — the "decoder feeding the Pi" §5.1 step 3 explicitly
+permits — plus the live FlightSite backend serving and ingesting, and an idle
+Nginx Proxy Manager and MariaDB pair resident on the host. The harness runs
+in-process against its own temporary database, so what it measured was a second
+full pipeline standing up beside the first.
+
+That is a *lighter* load than §5.4's but it is not a quiet machine either, and
+the figures are stated as the upper bounds they are. It does not weaken the
+result: every gate passed, and a gate passed with neighbours on the machine is a
+gate passed with them included.
+
+Budgets are the Pi 4 budgets from §2 at face value, as in §5.4 — the same
+comparison, so the two tables can be read against each other. The Gate column
+is the gate each row carried when the run was taken; the promotion below is
+what this run changed.
+
+| Metric | Gate | median | p95 | max | Gated statistic | Pi 4 budget | Result |
+|---|---|---|---|---|---|---|---|
+| `live_population` | hard | 600 | 631 | 778 | min 526 | ≥ 500 | pass |
+| `ingest_apply_ms` | hard | 20.5 | 30.5 | 368 | p95 30.5 | ≤ 100 | pass |
+| `ingest_duty_cycle` | hard | 0.0711 | 0.347 | 1.31 | p95 0.347 | ≤ 0.5 | pass |
+| `live_sweep_ms` | hard | 0.375 | 0.594 | 2.32 | max 2.32 | ≤ 100 | pass |
+| `api_live_ms` | hard | 28.9 | 41.9 | 351 | p95 41.9 | ≤ 250 | pass |
+| `memory_rss_mib` | hard | 148 | 175 | 179 | max 179 | ≤ 1024 | pass |
+| `ws_fanout_ms` | reference | 20.4 | 28.2 | 390 | p95 28.2 | ≤ 100 | pass |
+| `db_write_cycle_ms` | reference | 21.0 | 57.7 | 1261 | p95 57.7 | ≤ 250 | pass |
+| `db_read_ms` | reference | 5.79 | 9.16 | 16.6 | p95 9.16 | ≤ 500 | pass |
+| `analytics_query_ms` | reference | 9.50 | 13.8 | 16.8 | p95 13.8 | ≤ 500 | pass |
+| `startup_s` | reference | — | — | — | max 0.112 | ≤ 30 | pass |
+| `recovery_s` | reference | — | — | — | max 0.0755 | ≤ 30 | pass |
+
+**All twelve figures pass, and the command exited 0.** This is the first
+fully-passing on-hardware qualification FlightSite has: §5.4's Pi 4 reading
+missed `ingest_duty_cycle` — a hard gate — at a p95 of 0.99 against 0.5, and
+carried `db_write_cycle_ms` at 678 ms against 250. Both are inside their budgets
+here, by a wide margin, on the same harness driving the same deterministic
+scenario at the same 500-aircraft population.
+
+The two runs are a release apart — v0.2.0 and v0.3.1 — and the first row
+deserves a word, because it reads lower than §5.6's ~700: the live set settles
+at a median of 600 here. That is the pacing rather than a product change.
+§5.6's development run was not `--realtime`, so it compressed 600 ticks into
+59 s of wall clock and the live store's 60-second retention expired almost
+nothing; at the product's actual 1 Hz the resident population sits nearer the
+batch the scenario delivers. Both on-hardware runs were paced, and both bottom
+out at the same minimum of 526 aircraft — the deterministic scenario's own
+floor, unchanged between the two releases.
+
+The WebSocket run distributed 2,484 frames with **0 resync reconnects**, again
+confirming slice 057's batching fix on hardware. Recovery adopted **539 open
+sightings** — the identical count to §5.4 and §5.6, because the scenario is
+deterministic — in **0.0755 s**, against 9.3 s on the Pi 4's SD card and 2.33 s
+on a developer machine. The JSON report is on that Pi at
+`/opt/flightsite/data/perf-baseline/report.json`.
+
+#### What this settles, and what it does not
+
+Issue #132 asked one question: is the duty-cycle overrun a deficiency in this
+product, or is it the SD card? The answer is legible in the write-cycle row.
+
+| | Pi 4, SD card (§5.4) | Pi 5, NVMe (§5.5) |
+|---|---|---|
+| `db_write_cycle_ms` p95 | 678 ms | **57.7 ms** |
+| `db_write_cycle_ms` max | 5,180 ms | **1,261 ms** |
+| `ingest_duty_cycle` p95 | 0.99 | **0.347** |
+| `ingest_duty_cycle` max | 5.29 | **1.31** |
+
+An 11.8× fall in write-cycle p95 is not a CPU result. The Pi 5's cores are
+roughly two to three times the Pi 4's, and every purely computational row here
+moved by about that much — `ingest_apply_ms` p95 from 81.2 to 30.5,
+`ws_fanout_ms` from 68.1 to 28.2, `analytics_query_ms` from 48.2 to 13.8. The
+write cycle moved by an order of magnitude more than the arithmetic did, and it
+is the one stage whose cost is dominated by the storage device. §5.4 predicted
+exactly this: *"an SD card that occasionally takes five seconds to commit a
+flush carries the duty cycle straight up with it."* It did, and on NVMe it does
+not. **#132 is closed on that finding**, and no budget was widened to close it.
+
+Two honest limits on the claim. Two variables changed at once — the SoC and the
+storage — so this run does not decompose the improvement to the last
+millisecond; the argument above is an attribution from the *shape* of the
+change, not an isolated experiment. And this does not repeal §5.4: a Pi 4 with
+an SD card still consumes most of a poll under the SPEC §5 envelope. That is a
+statement about a storage configuration rather than about the product, which is
+why it stays recorded there rather than being edited away: an install on an SD
+card is the configuration in which this budget is at risk, and §5.1 already
+tells whoever qualifies a machine to measure the storage it actually uses.
+
+#### §5.3 step 2: five reference budgets are promoted
+
+§5.4 deferred the promotion because a contended run cannot calibrate a
+threshold. §1's asymmetry is what makes the deferral end here: for a budget the
+run **met**, contention is not a confound. Neighbours competing for a machine
+can only make a measurement worse, so a figure inside its budget under load is
+inside it with the worst case already included. Five rows were inside their
+budgets on the contended Pi 4 *and* on this run:
+
+| Metric | Pi 4 (contended) | Pi 5 (this run) | Budget | Gate before → after |
+|---|---|---|---|---|
+| `ws_fanout_ms` | 68.1 ms | 28.2 ms | ≤ 100 ms p95 | reference → **hard** |
+| `db_read_ms` | 26.2 ms | 9.16 ms | ≤ 500 ms p95 | reference → **hard** |
+| `analytics_query_ms` | 48.2 ms | 13.8 ms | ≤ 500 ms p95 | reference → **hard** |
+| `startup_s` | 0.547 s | 0.112 s | ≤ 30 s max | reference → **hard** |
+| `recovery_s` | 9.3 s | 0.0755 s | ≤ 30 s max | reference → **hard** |
+| `db_write_cycle_ms` | **678 ms** | 57.7 ms | ≤ 250 ms p95 | reference → reference |
+
+Two on-hardware readings inside the budget — one of them on the reference
+hardware itself, and taken under a load heavier than the procedure asks for —
+is what SPEC §85 wants before a metric stops being trend-tracked: *convert to
+hard gates once real Pi 4 baselines exist.* The five are `GateKind.HARD` in
+`backend/src/flightsite/perf/budgets.py` as of this slice, and appear in §2.1.
+
+**No budget value moved and no bound was loosened.** Promotion changed one
+field per row. `ws_fanout_ms`, `db_read_ms` and `analytics_query_ms` keep
+`CI_HEADROOM`, so their in-suite bounds are the 500 ms, 2500 ms and 2500 ms the
+harness already reported. `startup_s` and `recovery_s` keep `NO_HEADROOM` and
+are therefore gated at their stated 30 s: giving them the fivefold allowance
+would have asserted 150 s, and a promotion that loosens the bound it enforces
+is not a promotion (§1).
+
+`db_write_cycle_ms` is **not** promoted, and this is the conservative half of
+the same argument. It is the one row the two runs disagree about — 678 ms on an
+SD card, 57.7 ms on NVMe, against a 250 ms budget — so neither reading
+calibrates it. Promoting it on the Pi 5 figure would make the reference
+hardware fail its own gate on the storage most Pi 4 installs use; promoting it
+on the Pi 4 figure is impossible, because that figure missed. It stays a
+reference budget at 250 ms, unwidened, exactly as §5.3 rule 3 requires. What
+would settle it is a clean Pi 4 run on a USB SSD — the same product, the same
+poll, with only the card taken out of the picture.
+
+### 5.6 Development-machine baseline
 
 Recorded for orientation only. A developer machine is not the reference
 hardware, and a figure here says nothing about a Pi 4 beyond ruling out gross
@@ -494,7 +686,7 @@ Slice 057 took the first of the two options named here — coalescing a pass's
 events into fewer frames. `publish_activity` now sends one `activity_batch`
 frame per pass (`docs/API.md` §4.4), capped at 128 events per frame, so the
 frame count follows the detector's 5-second cadence rather than the size of the
-backlog. Re-running §5.5's command on a fresh database takes the reconnect
+backlog. Re-running §5.6's command on a fresh database takes the reconnect
 count to zero.
 
 ---
@@ -709,7 +901,7 @@ exit status; that is what makes it a reference budget.
 
 #### 7.6.1 Development-machine baseline
 
-Recorded for orientation only, and for the same reason as §5.5: a developer
+Recorded for orientation only, and for the same reason as §5.6: a developer
 machine is not the reference hardware, but the ratio between these numbers and
 a future Pi 4 row is itself useful. What is *not* hardware-dependent here — the
 growth figures and the per-table costs — is as true on a Pi as it is here.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -65,12 +65,12 @@ than principle. `startup_s` and `recovery_s` are budgeted at 30 seconds;
 multiplying that by five would assert 150 s, and a promotion that loosens the
 bound it enforces is not a promotion, so §5.5 promoted both at their stated
 figure. What that leaves is a real bound rather than a formality, and the
-margins differ sharply between the two. Startup measured 0.112 s on a Pi 5 and
-0.547 s on a contended Pi 4 — three hundred times inside the ceiling either way.
+margins differ sharply between the two. Startup measured 0.112 s on a Pi 5 (268×
+inside the ceiling) and 0.547 s on a contended Pi 4 (55×).
 Recovery measured 0.0755 s on the Pi 5 but **9.3 s on the contended Pi 4's SD
 card**, which is only 3.2× inside it, and the repair path is already known to be
-load-sensitive (issue #100). That is the narrowest margin of any gate in the
-table; it is deliberate — recovery is bounded by the open-sighting count and the
+load-sensitive (issue #100). That is the narrowest margin among the five gates
+this section promotes; it is deliberate — recovery is bounded by the open-sighting count and the
 storage device, and both are exactly what the budget is there to bound — but it
 is the row to watch on a slow disk, not one to treat as unfailable.
 
@@ -112,7 +112,7 @@ crossing one now fails.
 | `db_read_ms` | SQLite read/query latency | ≤ 500 ms | p95 | ≤ 2500 ms | A reader competing with the single writer for the WAL. Promoted in §5.5: 26.2 ms on a contended Pi 4, 9.16 ms on a Pi 5. §7 qualifies it again at multi-year scale. |
 | `analytics_query_ms` | analytics query latency | ≤ 500 ms | p95 | ≤ 2500 ms | Slice 031's stated budget, restated under concurrent ingestion. Promoted in §5.5: 48.2 ms on a contended Pi 4, 13.8 ms on a Pi 5. |
 | `startup_s` | startup | ≤ 30 s | max | ≤ 30 s | Migrations, wiring and the first ready report; dominated by disk. Promoted in §5.5 at two orders of magnitude of margin, and with no CI headroom (§1 explains why multiplying it would be meaningless). |
-| `recovery_s` | unclean-shutdown recovery | ≤ 30 s | max | ≤ 30 s | Repair of the sightings a power cut left open (slice 053), bounded by the open-sighting count the harness records. Promoted in §5.5, likewise without headroom — and the tightest row in this table: 539 sightings took 9.3 s on the contended Pi 4's SD card against 0.0755 s on a Pi 5, so the margin on the reference hardware is 3.2× and the path is load-sensitive (issue #100). |
+| `recovery_s` | unclean-shutdown recovery | ≤ 30 s | max | ≤ 30 s | Repair of the sightings a power cut left open (slice 053), bounded by the open-sighting count the harness records. Promoted in §5.5, likewise without headroom — and the tightest of the no-headroom pair: 539 sightings took 9.3 s on the contended Pi 4's SD card against 0.0755 s on a Pi 5, so the margin on the reference hardware is 3.2× and the path is load-sensitive (issue #100). |
 
 ### 2.2 Reference budgets (trend-tracked)
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -73,9 +73,11 @@ Every release branch must complete all applicable items:
 - [ ] Adjacent-version upgrade test: previous release's data dir upgrades in place
 - [ ] Demo-mode validation: full stack runs and exercises scenarios
 - [ ] Live-decoder validation against readsb/dump1090-fa where appropriate
-- [ ] Raspberry Pi qualification where required — run the procedure in
-      `docs/PERFORMANCE.md` §5 and record the baseline there, one subsection per
-      machine (§5.3 step 1)
+- [ ] Raspberry Pi 4 qualification where required — run the procedure in
+      `docs/PERFORMANCE.md` §5
+  - [ ] Baseline recorded under §5, one subsection per machine (§5.3 step 1); a
+        later Pi model runs the same procedure and is recorded beside the Pi 4
+        rather than in place of it
 - [ ] Documentation reviewed for accuracy against the released behavior
 - [ ] `docs/LICENSES.md` reviewed — no unresolved blocked rows for shipped features
 - [ ] Risk register (`docs/RISKS.md`) reviewed

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -73,8 +73,9 @@ Every release branch must complete all applicable items:
 - [ ] Adjacent-version upgrade test: previous release's data dir upgrades in place
 - [ ] Demo-mode validation: full stack runs and exercises scenarios
 - [ ] Live-decoder validation against readsb/dump1090-fa where appropriate
-- [ ] Raspberry Pi 4 qualification where required — run the procedure in
-      `docs/PERFORMANCE.md` §5 and record the baseline in §5.4
+- [ ] Raspberry Pi qualification where required — run the procedure in
+      `docs/PERFORMANCE.md` §5 and record the baseline there, one subsection per
+      machine (§5.3 step 1)
 - [ ] Documentation reviewed for accuracy against the released behavior
 - [ ] `docs/LICENSES.md` reviewed — no unresolved blocked rows for shipped features
 - [ ] Risk register (`docs/RISKS.md`) reviewed

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -145,6 +145,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 062 | Live-set ghost expiry | 007, 008, 009 | opus | medium | Age live records by the decoder's own "last heard" report so dump1090's ~5-minute retention window stops inflating the live count and the 15 s / 60 s thresholds fire on time (issue #134) |
 | 063 | Aircraft label stability | 014, 015 | opus | low | Stop aircraft labels blinking: a hysteresis band on the density tier, and variable anchoring so a colliding label relocates before it hides (issue #143) |
 | 064 | Honest position-fix anchor | 054 | opus | low | Date each position fix by the decode age the frame reports rather than by its arrival, so dead reckoning hands over between fixes without the periodic backwards step (issue #144) |
+| 065 | Raspberry Pi 5 clean performance baseline | 049, 060 | opus | low | Record the first fully-passing on-hardware run in docs/PERFORMANCE.md §5.5 and apply §5.3's promotion rule: five reference budgets become hard gates, SQLite write latency does not (issue #132) |
 
 ## Parallelization Guide
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -145,7 +145,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 062 | Live-set ghost expiry | 007, 008, 009 | opus | medium | Age live records by the decoder's own "last heard" report so dump1090's ~5-minute retention window stops inflating the live count and the 15 s / 60 s thresholds fire on time (issue #134) |
 | 063 | Aircraft label stability | 014, 015 | opus | low | Stop aircraft labels blinking: a hysteresis band on the density tier, and variable anchoring so a colliding label relocates before it hides (issue #143) |
 | 064 | Honest position-fix anchor | 054 | opus | low | Date each position fix by the decode age the frame reports rather than by its arrival, so dead reckoning hands over between fixes without the periodic backwards step (issue #144) |
-| 065 | Raspberry Pi 5 clean performance baseline | 049, 060 | opus | low | Record the first fully-passing on-hardware run in docs/PERFORMANCE.md §5.5 and apply §5.3's promotion rule: five reference budgets become hard gates, SQLite write latency does not (issue #132) |
+| 065 | Raspberry Pi 5 clean performance baseline | 049, 060 | opus | low | Record the first fully-passing on-hardware run in docs/PERFORMANCE.md §5.5 and apply §5.3's promotion rule: five reference budgets become hard gates, SQLite write latency does not (closes issue #132; the clean Pi 4 run that would calibrate it is issue #153) |
 
 ## Parallelization Guide
 

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -223,11 +223,14 @@ How the harness runs:
 - No live-state stalls (live update latency bounded)
 - Backend memory below the 1 GB budget under the reference workload
 - Core APIs remain responsive under load
+- SQLite read/query latency, WebSocket fan-out latency, analytics query latency,
+  startup time and unclean-shutdown recovery time — promoted from trend-tracked on
+  the on-hardware baselines in `docs/PERFORMANCE.md` §5.4 and §5.5, as SPEC §85 asks
 
-**Trend-tracked initially (converted to hard gates once Pi 4 baselines exist):**
+**Trend-tracked (converted to hard gates once real Pi baselines calibrate them):**
 
-- SQLite write/read latency, WebSocket fan-out latency, analytics query latency,
-  startup time, unclean-shutdown recovery time
+- SQLite write latency — the one figure the two recorded Pi runs disagree about,
+  because the storage device sets it (`docs/PERFORMANCE.md` §5.5, issue #132)
 
 ### 6.2 Measured metrics
 

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -230,7 +230,8 @@ How the harness runs:
 **Trend-tracked (converted to hard gates once real Pi baselines calibrate them):**
 
 - SQLite write latency — the one figure the two recorded Pi runs disagree about,
-  because the storage device sets it (`docs/PERFORMANCE.md` §5.5, issue #132)
+  because the storage device sets it (`docs/PERFORMANCE.md` §5.5); the clean Pi 4
+  run on non-SD storage that would calibrate it is issue #153
 
 ### 6.2 Measured metrics
 

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1710,7 +1710,7 @@ slices:
     branch: "065-pi5-baseline"
     status: merged
     depends_on: ["049", "060"]
-    objective: "Record the first fully-passing on-hardware qualification run in docs/PERFORMANCE.md, closing the finding slice 060 filed as issue #132, and apply §5.3's promotion rule now that a clean run exists."
+    objective: "Record the first fully-passing on-hardware qualification run in docs/PERFORMANCE.md, explaining the finding slice 060 filed as issue #132 (closed by this slice's PR, with the reference-hardware follow-up tracked as issue #153), and apply §5.3's promotion rule now that a clean run exists."
     scope:
       - "docs/PERFORMANCE.md §5.5 records the 2026-09-02 Raspberry Pi 5 Model B Rev 1.0 / 8 GB / NVMe run of `flightsite-perf --realtime --ticks 600` against release v0.3.1: date, hardware, environment, command, and all twelve measured figures with their gated statistics and verdicts"
       - "the section states what the run settles relative to §5.4 — the duty-cycle overrun was SD-card write stalls, not a code deficiency (db_write_cycle_ms p95 678 ms -> 57.7 ms, max 5.18 s -> 1.26 s; ingest_duty_cycle p95 0.99 -> 0.347) — and what it does not: two variables changed at once, and a Pi 4 on an SD card still consumes most of a poll"
@@ -1719,31 +1719,38 @@ slices:
       - "no budget value changed and no in-suite bound was loosened: the promoted rows keep the ci_headroom they had, so startup_s and recovery_s are gated at their stated 30 s rather than relaxed to 150 s"
       - "§1, §2.1, §2.2 and §5.3 updated to state the promotion, the asymmetry that licenses it (a figure that met its budget under contention met it with the worst case included), and the headroom exception; §5 retitled for Pi qualification generally and the development-machine baseline renumbered §5.6"
       - "docs/TEST_STRATEGY.md §6.1 and docs/RELEASE.md's qualification checklist item follow the same change"
-      - "tests/perf/test_docs.py pins §5.5's presence, its report of every budget, and that the section names both the issue it closes and the budget that stayed trend-tracked"
+      - "tests/perf/test_docs.py pins §5.5's presence, its report of every budget, and that the section records the not-promoted decision for the budget that stayed trend-tracked rather than merely naming it"
+      - "tests/perf/test_budgets.py pins the exact eleven-member hard set and the exact one-member reference set, so a silent demotion of a promoted row fails a test"
+      - ".github/workflows/perf.yml's header comment states what the sustained job now asserts (eleven gates) instead of describing every budget as trend-tracked"
     out_of_scope:
       - "any change to a budget value, a statistic, or an in-suite bound"
       - "promoting db_write_cycle_ms, which needs a clean Pi 4 run on non-SD storage"
       - "editing §5.4's recorded Pi 4 figures, which stand as taken"
       - "the §7.6 Pi storage baseline, still unrecorded and behind its own procedure (§7.8)"
-      - "re-measuring on a Pi 4, and any change to the reference hardware the budgets are stated for (that would need an ADR)"
+      - "re-measuring on a Pi 4: the clean run on non-SD storage that would calibrate db_write_cycle_ms is issue #153, #132's tracked successor"
+      - "any change to the reference hardware the budgets are stated for, which would need an ADR"
     acceptance_criteria:
-      - "docs/PERFORMANCE.md §5.5 carries the Pi 5 baseline with all twelve figures, the hardware and environment preamble, and the comparison against §5.4 that closes issue #132"
+      - "docs/PERFORMANCE.md §5.5 carries the Pi 5 baseline with all twelve figures, the hardware and environment preamble, and the comparison against §5.4 that explains issue #132's finding and names issue #153 as the reference-hardware follow-up"
       - "the five promoted budgets are GateKind.HARD in perf/budgets.py, appear in §2.1 with their in-suite bounds, and no longer appear in §2.2"
       - "db_write_cycle_ms remains GateKind.REFERENCE with its 250 ms budget unchanged, and §2.2 and §5.5 both say why"
       - "the full backend suite passes with the five promoted gates now failing-capable, including the in-suite smoke run in tests/perf/test_harness.py"
-      - "tests/perf/test_docs.py fails if §5.5 loses the recorded run, omits a budget, or stops naming the finding it closes"
+      - "tests/perf/test_docs.py fails if §5.5 loses the recorded run, omits a budget, or stops recording the not-promoted decision"
+      - "tests/perf/test_budgets.py fails if any promoted row is demoted or db_write_cycle_ms is promoted without a documented decision"
     required_tests:
       - the §5.5 baseline-presence, every-budget and promotion-decision guards in tests/perf/test_docs.py
+      - exact-set pins for the eleven hard gates and the one remaining reference budget in tests/perf/test_budgets.py
       - the existing tests/perf/test_budgets.py and tests/perf/test_harness.py gate-kind invariants, now covering eleven hard gates instead of six
     expected_artifacts:
       - docs/PERFORMANCE.md
       - backend/src/flightsite/perf/budgets.py
       - backend/tests/perf/test_docs.py
+      - backend/tests/perf/test_budgets.py
+      - .github/workflows/perf.yml
       - docs/TEST_STRATEGY.md
       - docs/RELEASE.md
     preferred_agent: opus
     risk_level: low
-    notes: "Closes GitHub issue #132 and completes the qualification story slice 060 left open. Measurement was run by Fable on the owner's Pi 5 over SSH; the JSON report is at /opt/flightsite/data/perf-baseline/report.json on that machine. Added by Fable outside the phase plan."
+    notes: "Completes the qualification story slice 060 left open. This slice's PR closes GitHub issue #132 on the explanation recorded in §5.5 (SD-card write stalls, not a code deficiency); the condition still reproduces on a Pi 4 with an SD card, and the clean Pi 4 run that would calibrate db_write_cycle_ms is tracked as issue #153. Measurement was run by Fable on the owner's Pi 5 over SSH; the JSON report is at /opt/flightsite/data/perf-baseline/report.json on that machine. Added by Fable outside the phase plan."
 
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1704,6 +1704,46 @@ slices:
     preferred_agent: opus
     risk_level: low
     notes: "Owner reported markers still oscillating on the Pi at v0.3.0. Fixes GitHub issue #144, the residual systematic term slice 054's no-correction-blend rationale underestimated. Frontend-only, client-side mirror of slice 062's server-side ageing. Added by Fable outside the phase plan."
+  - id: "065"
+    title: "Raspberry Pi 5 clean performance baseline"
+    phase: 8
+    branch: "065-pi5-baseline"
+    status: merged
+    depends_on: ["049", "060"]
+    objective: "Record the first fully-passing on-hardware qualification run in docs/PERFORMANCE.md, closing the finding slice 060 filed as issue #132, and apply §5.3's promotion rule now that a clean run exists."
+    scope:
+      - "docs/PERFORMANCE.md §5.5 records the 2026-09-02 Raspberry Pi 5 Model B Rev 1.0 / 8 GB / NVMe run of `flightsite-perf --realtime --ticks 600` against release v0.3.1: date, hardware, environment, command, and all twelve measured figures with their gated statistics and verdicts"
+      - "the section states what the run settles relative to §5.4 — the duty-cycle overrun was SD-card write stalls, not a code deficiency (db_write_cycle_ms p95 678 ms -> 57.7 ms, max 5.18 s -> 1.26 s; ingest_duty_cycle p95 0.99 -> 0.347) — and what it does not: two variables changed at once, and a Pi 4 on an SD card still consumes most of a poll"
+      - "the run's own load is stated honestly: an ultrafeeder decoder and three feeder containers (permitted by §5.1 step 3), the live backend ingesting beside the harness, and an idle proxy/database pair, so the figures are upper bounds"
+      - "§5.3 step 2 applied: ws_fanout_ms, db_read_ms, analytics_query_ms, startup_s and recovery_s promoted to GateKind.HARD in backend/src/flightsite/perf/budgets.py, each inside its budget on both the contended Pi 4 and the clean Pi 5; db_write_cycle_ms stays a reference budget because the two runs disagree about it by an order of magnitude"
+      - "no budget value changed and no in-suite bound was loosened: the promoted rows keep the ci_headroom they had, so startup_s and recovery_s are gated at their stated 30 s rather than relaxed to 150 s"
+      - "§1, §2.1, §2.2 and §5.3 updated to state the promotion, the asymmetry that licenses it (a figure that met its budget under contention met it with the worst case included), and the headroom exception; §5 retitled for Pi qualification generally and the development-machine baseline renumbered §5.6"
+      - "docs/TEST_STRATEGY.md §6.1 and docs/RELEASE.md's qualification checklist item follow the same change"
+      - "tests/perf/test_docs.py pins §5.5's presence, its report of every budget, and that the section names both the issue it closes and the budget that stayed trend-tracked"
+    out_of_scope:
+      - "any change to a budget value, a statistic, or an in-suite bound"
+      - "promoting db_write_cycle_ms, which needs a clean Pi 4 run on non-SD storage"
+      - "editing §5.4's recorded Pi 4 figures, which stand as taken"
+      - "the §7.6 Pi storage baseline, still unrecorded and behind its own procedure (§7.8)"
+      - "re-measuring on a Pi 4, and any change to the reference hardware the budgets are stated for (that would need an ADR)"
+    acceptance_criteria:
+      - "docs/PERFORMANCE.md §5.5 carries the Pi 5 baseline with all twelve figures, the hardware and environment preamble, and the comparison against §5.4 that closes issue #132"
+      - "the five promoted budgets are GateKind.HARD in perf/budgets.py, appear in §2.1 with their in-suite bounds, and no longer appear in §2.2"
+      - "db_write_cycle_ms remains GateKind.REFERENCE with its 250 ms budget unchanged, and §2.2 and §5.5 both say why"
+      - "the full backend suite passes with the five promoted gates now failing-capable, including the in-suite smoke run in tests/perf/test_harness.py"
+      - "tests/perf/test_docs.py fails if §5.5 loses the recorded run, omits a budget, or stops naming the finding it closes"
+    required_tests:
+      - the §5.5 baseline-presence, every-budget and promotion-decision guards in tests/perf/test_docs.py
+      - the existing tests/perf/test_budgets.py and tests/perf/test_harness.py gate-kind invariants, now covering eleven hard gates instead of six
+    expected_artifacts:
+      - docs/PERFORMANCE.md
+      - backend/src/flightsite/perf/budgets.py
+      - backend/tests/perf/test_docs.py
+      - docs/TEST_STRATEGY.md
+      - docs/RELEASE.md
+    preferred_agent: opus
+    risk_level: low
+    notes: "Closes GitHub issue #132 and completes the qualification story slice 060 left open. Measurement was run by Fable on the owner's Pi 5 over SSH; the JSON report is at /opt/flightsite/data/perf-baseline/report.json on that machine. Added by Fable outside the phase plan."
 
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,


### PR DESCRIPTION
Slice 065 — closes #132.

Records the 2026-09-02 clean performance baseline from the owner's production hardware (Raspberry Pi 5 / 8 GB / NVMe, v0.3.1): **all 12 metrics pass, exit 0** — the first fully-passing on-hardware qualification.

- **PERFORMANCE.md §5.5**: full 12-metric table with hardware/environment/command, verified figure-by-figure against the report JSON by the review. "What this settles": the Pi 4's `ingest_duty_cycle` failure (#132) was SD-card write stalls — write-cycle p95 678 → 57.7 ms while computational stages moved only 2.4–3.5× — so #132 closes on that explanation. What it leaves open (the reference-hardware calibration of `db_write_cycle_ms`, a clean Pi 4 on non-SD storage) is tracked as #153.
- **§5.3 promotion applied**: `ws_fanout_ms`, `db_read_ms`, `analytics_query_ms`, `startup_s`, `recovery_s` promoted reference → hard — each inside budget on both the contended Pi 4 and the clean Pi 5 (contention explains a miss, never a pass). `db_write_cycle_ms` stays reference pending #153. **No budget value or bound changed in either direction**; `startup_s`/`recovery_s` keep NO_HEADROOM (still gated at 30 s). CI safety was measured by the review: every promoted gate carries wider margin than gates CI already ships.
- New exact-set pin tests make any future promotion/demotion a recorded decision (mutation-verified to bite by both the implementation and the review independently).
- §5.4 (Pi 4 contended) stands as recorded; dev baseline renumbered §5.6; RELEASE.md keeps SPEC §114's verbatim "Raspberry Pi 4 qualification" gate.

Adversarial review: FIX FIRST round (false-closure tense, SPEC-verbatim gate wording, unpinned promotion set, margin overclaims) → all fixed → verification round confirmed each by its own mutation testing, plus an independent full-suite run: 4325 passed, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTAJUucu2ZPAD235B3GQeZ