### PR TITLE
Release v0.3.2

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -18,10 +18,15 @@ name: perf
 # This job is deliberately NOT a required status check. Its budgets are stated
 # for the reference hardware (Raspberry Pi 4) and a shared GitHub runner is
 # neither that hardware nor a quiet one; treating a noisy trend signal as a
-# merge blocker would train people to re-run it until it passed. The Pi 4
-# qualification procedure in docs/PERFORMANCE.md is what converts these
-# reference budgets into hard gates, and that is a release activity run on real
-# hardware.
+# merge blocker would train people to re-run it until it passed.
+#
+# Note that "trend signal" no longer describes most of the table. Slice 065
+# promoted five reference budgets to hard gates on the on-hardware baselines in
+# docs/PERFORMANCE.md §5.4 and §5.5, so this run now asserts eleven of the
+# twelve; db_write_cycle_ms is the one still trend-tracked, awaiting a clean
+# Pi 4 run on non-SD storage (issue #153). Promotion happens in §5.3's
+# procedure, on real hardware at release time — never here, and never because a
+# runner happened to be fast.
 
 on:
   schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ follows [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/) (`0.x.y` during pre-1.0 development).
 This file is updated only on release branches (see `docs/RELEASE.md`).
 
+## [0.3.2] — 2026-09-03
+
+The Military filter comes alive, and the performance story gets its first
+fully-passing hardware qualification.
+
+### Added
+- Measured Raspberry Pi 5 (NVMe) performance baseline in
+  `docs/PERFORMANCE.md` §5.5 — **all 12 metrics pass**, confirming the Pi 4
+  baseline's duty-cycle failure was SD-card write stalls (#132; the clean
+  Pi 4 calibration run is tracked as #153)
+- Five performance budgets promoted from trend-tracked references to hard
+  CI gates on the strength of that run (`ws_fanout`, `db_read`,
+  `analytics_query`, `startup`, `recovery`) — no budget value changed in
+  either direction
+
+### Fixed
+- **The Military quick-filter chip works** once aircraft metadata is
+  imported: it was hard-disabled since the pre-metadata era. It now enables
+  on real metadata availability (Mictronics/FAA/OpenSky — an airports-only
+  import doesn't count), mirrors the filter drawer's checkbox, and when
+  disabled its tooltip says exactly what to do (Settings → Metadata). The
+  drawer's outdated "arrives in a later slice" notes now tell the
+  present-tense truth (#151)
+
 ## [0.3.1] — 2026-09-02
 
 A same-day patch for two owner-reported live-map irritations.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flightsite"
-version = "0.3.1"
+version = "0.3.2"
 description = "FlightSite backend: self-hosted ADS-B observatory API and ingestion service."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/backend/src/flightsite/perf/budgets.py
+++ b/backend/src/flightsite/perf/budgets.py
@@ -56,8 +56,9 @@ matters more than the shared constant: startup measured 0.547 s on a contended
 Pi 4 and 0.112 s on a Pi 5, while recovery measured **9.3 s** on that Pi 4's SD
 card against 0.0755 s on the Pi 5. Recovery therefore sits 3.2x inside its
 ceiling on the reference hardware, on a path already reported as load-sensitive
-(issue #100) — the tightest gate in this table, and the one to read first if a
-run on slow storage goes red.
+(issue #100) — the tightest of the five gates §5.5 promotes. On slow storage the
+rows that actually go red first are ingest_duty_cycle and db_write_cycle_ms
+(issues #132/#153); recovery_s is the promoted gate worth watching beside them.
 """
 
 from __future__ import annotations
@@ -343,7 +344,7 @@ BUDGETS: Final[tuple[Budget, ...]] = (
             "Repairing every sighting left open by a power cut, from checkpoint rows "
             "(slice 053). Bounded by the open-sighting count, which the harness records, and "
             "by the storage device. Promoted on the baselines in docs/PERFORMANCE.md §5.5 and "
-            "kept at NO_HEADROOM, which leaves the narrowest margin of any gate here: 539 open "
+            "kept at NO_HEADROOM, the narrowest margin among the five §5.5 promotions: 539 open "
             "sightings were repaired in 9.3 s on a contended Pi 4 SD card — 3.2x inside the "
             "30 s ceiling — against 0.0755 s on a Pi 5, and the path is already reported as "
             "load-sensitive (issue #100). Promoted knowingly on that figure: the budget bounds "

--- a/backend/src/flightsite/perf/budgets.py
+++ b/backend/src/flightsite/perf/budgets.py
@@ -23,7 +23,14 @@ metrics initially; convert to hard gates once real Pi 4 baselines exist."* They
 are stated against the reference hardware (Raspberry Pi 4), and a dev machine
 beating them by an order of magnitude proves nothing about the Pi. Promoting
 one to :attr:`GateKind.HARD` is a deliberate edit here once
-``docs/PERFORMANCE.md`` carries a recorded Pi 4 baseline for it.
+``docs/PERFORMANCE.md`` carries a recorded Pi baseline for it.
+
+Five of the original six were promoted on the two on-hardware baselines in
+``docs/PERFORMANCE.md`` §5.4 (Pi 4, SD card, contended) and §5.5 (Pi 5, NVMe,
+all twelve gates passed): each was inside its budget on both, and a figure that
+*met* its budget on a contended machine met it with the worst case included.
+``db_write_cycle_ms`` is the one that remains, because those two runs disagree
+about it by an order of magnitude — the storage device sets it (issue #132).
 
 CI headroom
 -----------
@@ -39,6 +46,12 @@ Budgets that measure a *quantity* rather than a duration get
 :data:`NO_HEADROOM`. A 1 GB memory ceiling relaxed five-fold is not a gate, and
 the live population a deterministic scenario produces does not vary with how
 loaded the machine is.
+
+``startup_s`` and ``recovery_s`` are durations that also carry
+:data:`NO_HEADROOM`, for an arithmetic reason rather than a principled one:
+they are budgeted at 30 s against measurements of a tenth of a second, so a
+five-fold allowance would assert a bound nothing could fail. They were promoted
+in slice 065 at their stated 30 s.
 """
 
 from __future__ import annotations
@@ -131,7 +144,8 @@ class Budget:
 
 
 #: The table. Ordered as ``docs/PERFORMANCE.md`` presents it: the hard gates
-#: SPEC §85 names, then the reference budgets awaiting Pi 4 baselines.
+#: SPEC §85 names, then the rows promoted to hard gates on the §5.4/§5.5
+#: baselines, then what remains trend-tracked.
 BUDGETS: Final[tuple[Budget, ...]] = (
     Budget(
         metric="live_population",
@@ -243,29 +257,13 @@ BUDGETS: Final[tuple[Budget, ...]] = (
         value=100.0,
         statistic=Statistic.P95,
         direction=Direction.CEILING,
-        gate=GateKind.REFERENCE,
+        gate=GateKind.HARD,
         ci_headroom=CI_HEADROOM,
         rationale=(
             "One delta built and delivered to every connected client, once per ~1 Hz tick "
-            "(docs/API.md §4.3). Reference until a Pi 4 baseline exists: fan-out cost is "
-            "serialization-bound and scales with client count, which the harness records "
-            "alongside the figure."
-        ),
-    ),
-    Budget(
-        metric="db_write_cycle_ms",
-        title="SQLite write latency (persistence cycle)",
-        spec_metric="SQLite write latency",
-        unit="ms",
-        value=250.0,
-        statistic=Statistic.P95,
-        direction=Direction.CEILING,
-        gate=GateKind.REFERENCE,
-        ci_headroom=CI_HEADROOM,
-        rationale=(
-            "One write-behind cycle committing a tick's accumulated sighting work. It is off "
-            "the hot path by construction (ADR-0008), so this is a health figure rather than a "
-            "correctness limit — reference until Pi 4 SD-card I/O sets the real number."
+            "(docs/API.md §4.3). Promoted from a reference budget on the on-hardware baselines "
+            "in docs/PERFORMANCE.md §5.5: 68.1 ms p95 on a contended Pi 4 and 28.2 ms on a "
+            "Pi 5, both inside the 100 ms budget."
         ),
     ),
     Budget(
@@ -276,12 +274,13 @@ BUDGETS: Final[tuple[Budget, ...]] = (
         value=500.0,
         statistic=Statistic.P95,
         direction=Direction.CEILING,
-        gate=GateKind.REFERENCE,
+        gate=GateKind.HARD,
         ci_headroom=CI_HEADROOM,
         rationale=(
             "History and sightings endpoints served while ingestion runs, i.e. a reader "
-            "competing with the single writer for the WAL. Reference until Pi 4 storage is "
-            "characterized; slice 050 qualifies it at multi-year scale."
+            "competing with the single writer for the WAL. Promoted on the baselines in "
+            "docs/PERFORMANCE.md §5.5: 26.2 ms p95 on a contended Pi 4 and 9.16 ms on a Pi 5, "
+            "against a 500 ms budget. Slice 050 qualifies it again at multi-year scale."
         ),
         also_enforced_by=(
             "tests/api/test_sightings_perf.py",
@@ -296,11 +295,13 @@ BUDGETS: Final[tuple[Budget, ...]] = (
         value=500.0,
         statistic=Statistic.P95,
         direction=Direction.CEILING,
-        gate=GateKind.REFERENCE,
+        gate=GateKind.HARD,
         ci_headroom=CI_HEADROOM,
         rationale=(
             "Roadmap slice 031's stated budget, restated here under concurrent ingestion "
-            "rather than on an idle process. Slice 050 qualifies it on a multi-year dataset."
+            "rather than on an idle process. Promoted on the baselines in "
+            "docs/PERFORMANCE.md §5.5: 48.2 ms p95 on a contended Pi 4 and 13.8 ms on a Pi 5, "
+            "against a 500 ms budget. Slice 050 qualifies it on a multi-year dataset."
         ),
         also_enforced_by=("tests/analytics/test_perf.py",),
     ),
@@ -312,12 +313,14 @@ BUDGETS: Final[tuple[Budget, ...]] = (
         value=30.0,
         statistic=Statistic.MAX,
         direction=Direction.CEILING,
-        gate=GateKind.REFERENCE,
+        gate=GateKind.HARD,
         ci_headroom=NO_HEADROOM,
         rationale=(
-            "Migrations, wiring and the first ready report. Dominated by disk on a Pi 4, so the "
-            "budget is stated for that hardware and carries no CI headroom — a dev machine "
-            "should be nowhere near it."
+            "Migrations, wiring and the first ready report. Dominated by disk on a Pi, so the "
+            "budget is stated for that hardware. Promoted on the baselines in "
+            "docs/PERFORMANCE.md §5.5 — 0.547 s on a contended Pi 4, 0.112 s on a Pi 5 — and "
+            "kept at NO_HEADROOM: multiplying a 30 s ceiling by five would assert a bound no "
+            "machine could fail, and a promotion that loosens its own bound is not one."
         ),
     ),
     Budget(
@@ -328,14 +331,34 @@ BUDGETS: Final[tuple[Budget, ...]] = (
         value=30.0,
         statistic=Statistic.MAX,
         direction=Direction.CEILING,
-        gate=GateKind.REFERENCE,
+        gate=GateKind.HARD,
         ci_headroom=NO_HEADROOM,
         rationale=(
             "Repairing every sighting left open by a power cut, from checkpoint rows "
-            "(slice 053). Bounded by the open-sighting count, which the harness records; "
-            "reference until Pi 4 SD-card I/O sets the real number."
+            "(slice 053). Bounded by the open-sighting count, which the harness records. "
+            "Promoted on the baselines in docs/PERFORMANCE.md §5.5 — 539 open sightings "
+            "repaired in 9.3 s on a contended Pi 4 SD card and 0.0755 s on a Pi 5 — and kept "
+            "at NO_HEADROOM for the same reason as startup."
         ),
         also_enforced_by=("tests/sightings/test_kill_drill.py",),
+    ),
+    Budget(
+        metric="db_write_cycle_ms",
+        title="SQLite write latency (persistence cycle)",
+        spec_metric="SQLite write latency",
+        unit="ms",
+        value=250.0,
+        statistic=Statistic.P95,
+        direction=Direction.CEILING,
+        gate=GateKind.REFERENCE,
+        ci_headroom=CI_HEADROOM,
+        rationale=(
+            "One write-behind cycle committing a tick's accumulated sighting work. It is off "
+            "the hot path by construction (ADR-0008), so this is a health figure rather than a "
+            "correctness limit. The one row the two on-hardware baselines disagree about — "
+            "678 ms p95 on a Pi 4 SD card against 57.7 ms on a Pi 5 NVMe (issue #132) — so it "
+            "stays a reference budget: the storage device, not the code, sets it."
+        ),
     ),
 )
 

--- a/backend/src/flightsite/perf/budgets.py
+++ b/backend/src/flightsite/perf/budgets.py
@@ -30,7 +30,8 @@ Five of the original six were promoted on the two on-hardware baselines in
 all twelve gates passed): each was inside its budget on both, and a figure that
 *met* its budget on a contended machine met it with the worst case included.
 ``db_write_cycle_ms`` is the one that remains, because those two runs disagree
-about it by an order of magnitude — the storage device sets it (issue #132).
+about it by an order of magnitude — the storage device sets it, and the clean
+Pi 4 run on non-SD storage that would calibrate it is issue #153.
 
 CI headroom
 -----------
@@ -48,10 +49,15 @@ the live population a deterministic scenario produces does not vary with how
 loaded the machine is.
 
 ``startup_s`` and ``recovery_s`` are durations that also carry
-:data:`NO_HEADROOM`, for an arithmetic reason rather than a principled one:
-they are budgeted at 30 s against measurements of a tenth of a second, so a
-five-fold allowance would assert a bound nothing could fail. They were promoted
-in slice 065 at their stated 30 s.
+:data:`NO_HEADROOM`. Slice 065 promoted both at their stated 30 s rather than
+relaxing them to 150 s on promotion, because a promotion that loosens the bound
+it enforces is not one. Their margins are not alike, though, and the difference
+matters more than the shared constant: startup measured 0.547 s on a contended
+Pi 4 and 0.112 s on a Pi 5, while recovery measured **9.3 s** on that Pi 4's SD
+card against 0.0755 s on the Pi 5. Recovery therefore sits 3.2x inside its
+ceiling on the reference hardware, on a path already reported as load-sensitive
+(issue #100) — the tightest gate in this table, and the one to read first if a
+run on slow storage goes red.
 """
 
 from __future__ import annotations
@@ -335,10 +341,13 @@ BUDGETS: Final[tuple[Budget, ...]] = (
         ci_headroom=NO_HEADROOM,
         rationale=(
             "Repairing every sighting left open by a power cut, from checkpoint rows "
-            "(slice 053). Bounded by the open-sighting count, which the harness records. "
-            "Promoted on the baselines in docs/PERFORMANCE.md §5.5 — 539 open sightings "
-            "repaired in 9.3 s on a contended Pi 4 SD card and 0.0755 s on a Pi 5 — and kept "
-            "at NO_HEADROOM for the same reason as startup."
+            "(slice 053). Bounded by the open-sighting count, which the harness records, and "
+            "by the storage device. Promoted on the baselines in docs/PERFORMANCE.md §5.5 and "
+            "kept at NO_HEADROOM, which leaves the narrowest margin of any gate here: 539 open "
+            "sightings were repaired in 9.3 s on a contended Pi 4 SD card — 3.2x inside the "
+            "30 s ceiling — against 0.0755 s on a Pi 5, and the path is already reported as "
+            "load-sensitive (issue #100). Promoted knowingly on that figure: the budget bounds "
+            "exactly the disk cost that consumed it."
         ),
         also_enforced_by=("tests/sightings/test_kill_drill.py",),
     ),
@@ -356,8 +365,9 @@ BUDGETS: Final[tuple[Budget, ...]] = (
             "One write-behind cycle committing a tick's accumulated sighting work. It is off "
             "the hot path by construction (ADR-0008), so this is a health figure rather than a "
             "correctness limit. The one row the two on-hardware baselines disagree about — "
-            "678 ms p95 on a Pi 4 SD card against 57.7 ms on a Pi 5 NVMe (issue #132) — so it "
-            "stays a reference budget: the storage device, not the code, sets it."
+            "678 ms p95 on a Pi 4 SD card against 57.7 ms on a Pi 5 NVMe — so it stays a "
+            "reference budget: the storage device, not the code, sets it, and the clean Pi 4 "
+            "run on non-SD storage that would calibrate it is issue #153."
         ),
     ),
 )

--- a/backend/tests/perf/test_budgets.py
+++ b/backend/tests/perf/test_budgets.py
@@ -81,6 +81,46 @@ def test_the_reference_budgets_are_the_ones_spec_85_lets_be_trended() -> None:
     assert not (trended & SPEC_85_HARD_GATES)
 
 
+def test_the_hard_gates_are_the_eleven_documented_ones() -> None:
+    """The exact hard set, pinned as ``tests/perf/storage`` pins its three.
+
+    The two checks above are supersets: they catch a SPEC §85 gate being
+    demoted, but say nothing about the five rows ``docs/PERFORMANCE.md`` §5.5
+    promoted on the recorded Pi baselines. Demoting one of those would restore
+    the pre-promotion behaviour — measured, reported, never failing a run — and
+    every other test in this module would still pass. Promotion was a decision
+    somebody made and wrote down; reversing it has to be one too.
+    """
+    assert {budget.metric for budget in hard_budgets()} == {
+        # SPEC §85's own hard-gate list.
+        "live_population",
+        "ingest_apply_ms",
+        "ingest_duty_cycle",
+        "live_sweep_ms",
+        "api_live_ms",
+        "memory_rss_mib",
+        # Promoted in docs/PERFORMANCE.md §5.5, on the §5.4 and §5.5 baselines.
+        "ws_fanout_ms",
+        "db_read_ms",
+        "analytics_query_ms",
+        "startup_s",
+        "recovery_s",
+    }
+
+
+def test_the_write_cycle_is_the_only_budget_still_trend_tracked() -> None:
+    """§5.5 promoted five of the six, and recorded why the sixth was not.
+
+    ``db_write_cycle_ms`` measured 678 ms on a Pi 4 SD card and 57.7 ms on a
+    Pi 5 NVMe against a 250 ms budget, so neither reading calibrates it and
+    promoting it on the faster one would fail the reference hardware for the
+    storage most Pi 4 installs use. Issue #153 is the run that would settle it.
+    Pinned in both directions, so neither promoting this row nor quietly adding
+    another one beside it happens without a documented decision.
+    """
+    assert {budget.metric for budget in reference_budgets()} == {"db_write_cycle_ms"}
+
+
 def test_the_live_population_floor_is_the_spec_5_envelope() -> None:
     budget = budget_for("live_population")
     assert budget.value == float(TARGET_AIRCRAFT)

--- a/backend/tests/perf/test_docs.py
+++ b/backend/tests/perf/test_docs.py
@@ -18,7 +18,13 @@ from pathlib import Path
 
 import pytest
 
-from flightsite.perf.budgets import BUDGETS, TARGET_AIRCRAFT, Budget, GateKind
+from flightsite.perf.budgets import (
+    BUDGETS,
+    TARGET_AIRCRAFT,
+    Budget,
+    GateKind,
+    reference_budgets,
+)
 
 #: backend/tests/perf/test_docs.py -> repo root.
 DOC = Path(__file__).resolve().parents[3] / "docs" / "PERFORMANCE.md"
@@ -27,8 +33,11 @@ HARD_HEADING = "### 2.1 Hard gates"
 REFERENCE_HEADING = "### 2.2 Reference budgets"
 END_HEADING = "### 2.3"
 
-BASELINE_HEADING = "### 5.4 Recorded baselines"
+BASELINE_HEADING = "### 5.4 Raspberry Pi 4 baseline"
 BASELINE_END_HEADING = "### 5.5"
+
+CLEAN_BASELINE_HEADING = "### 5.5 Raspberry Pi 5 baseline"
+CLEAN_BASELINE_END_HEADING = "### 5.6"
 
 
 @pytest.fixture(scope="module")
@@ -39,13 +48,20 @@ def document() -> str:
 
 @pytest.fixture(scope="module")
 def baseline(document: str) -> str:
-    """§5.4 alone.
+    """§5.4 alone — the contended Pi 4 run.
 
-    Scoped deliberately: §5.5's development-machine table and §7.6's storage
-    section carry their own figures and their own disclaimer, and a check on
-    the whole document would be satisfied — or defeated — by either of them.
+    Scoped deliberately: §5.5's Pi 5 run, §5.6's development-machine table and
+    §7.6's storage section carry their own figures and their own caveats, and a
+    check on the whole document would be satisfied — or defeated — by any of
+    them.
     """
     return section(document, BASELINE_HEADING, BASELINE_END_HEADING)
+
+
+@pytest.fixture(scope="module")
+def clean_baseline(document: str) -> str:
+    """§5.5 alone — the fully-passing Pi 5 run, scoped for the same reason."""
+    return section(document, CLEAN_BASELINE_HEADING, CLEAN_BASELINE_END_HEADING)
 
 
 def section(document: str, start: str, end: str) -> str:
@@ -129,6 +145,55 @@ def test_the_recorded_baseline_reports_every_budget(budget: Budget, baseline: st
     """
     assert budget.metric in baseline, (
         f"{budget.metric} is measured by the harness but absent from §5.4's recorded baseline"
+    )
+
+
+def test_the_document_records_the_clean_pi_baseline(clean_baseline: str) -> None:
+    """Slice 065's result: the first on-hardware run that passed every gate.
+
+    Held the same way §5.4 is held. §5.4 is an upper bound taken on a contended
+    machine and says so; a document that kept it and quietly lost the clean run
+    beside it would read as though qualification had never succeeded.
+    """
+    assert "Raspberry Pi 5" in clean_baseline, (
+        "docs/PERFORMANCE.md §5.5 records the clean on-hardware run; it must name "
+        "the machine it was taken on"
+    )
+    assert "not yet run" not in clean_baseline, (
+        "docs/PERFORMANCE.md §5.5 must not be an empty table"
+    )
+    assert "#132" in clean_baseline, (
+        "docs/PERFORMANCE.md §5.5 answers the finding §5.4 filed; the section has "
+        "to name the issue it closes, or the two readings read as unrelated runs"
+    )
+
+
+@pytest.mark.parametrize("budget", BUDGETS, ids=lambda budget: budget.metric)
+def test_the_clean_baseline_reports_every_budget(budget: Budget, clean_baseline: str) -> None:
+    """§5.3 step 1 again, for the second recorded run.
+
+    The same rule as §5.4's: a run that reports the comfortable rows and omits
+    the rest is not a baseline. It matters more here, because this is the run
+    §5.3 step 2's promotions were decided on.
+    """
+    assert budget.metric in clean_baseline, (
+        f"{budget.metric} is measured by the harness but absent from §5.5's recorded baseline"
+    )
+
+
+@pytest.mark.parametrize("budget", reference_budgets(), ids=lambda budget: budget.metric)
+def test_the_promotion_decision_accounts_for_what_stayed_trend_tracked(
+    budget: Budget, clean_baseline: str
+) -> None:
+    """§5.3 step 2 is a decision, and a decision nobody can read was not made.
+
+    §5.5 applied the promotion rule. A budget still trend-tracked after a run
+    that measured it is the case the rule has to justify explicitly, so the
+    section that promoted the others has to name it.
+    """
+    assert budget.metric in clean_baseline, (
+        f"{budget.metric} was left a reference budget by §5.3 step 2, but §5.5 — "
+        "where that decision was taken — does not mention it"
     )
 
 

--- a/backend/tests/perf/test_docs.py
+++ b/backend/tests/perf/test_docs.py
@@ -187,13 +187,29 @@ def test_the_promotion_decision_accounts_for_what_stayed_trend_tracked(
 ) -> None:
     """§5.3 step 2 is a decision, and a decision nobody can read was not made.
 
-    §5.5 applied the promotion rule. A budget still trend-tracked after a run
-    that measured it is the case the rule has to justify explicitly, so the
-    section that promoted the others has to name it.
+    Mere presence is not enough and is already covered above: a metric named
+    only in §5.5's results table would satisfy that test while leaving the
+    reader no idea why it alone stayed trend-tracked after a run that measured
+    it passing. So this asks for the decision itself — the metric named on a
+    line that says it was *not* promoted, or that it stays a reference budget.
+    Emphasis and code markers are stripped first, because whether the document
+    writes ``**not** promoted`` or ``not promoted`` is layout, and pinning
+    layout is how a documentation test earns its deletion.
     """
-    assert budget.metric in clean_baseline, (
+    decisions = ("not promoted", "stays a reference", "reference -> reference")
+    lines = [
+        line.replace("*", "").replace("`", "").replace("→", "->")
+        for line in clean_baseline.splitlines()
+        if budget.metric in line
+    ]
+    assert lines, (
         f"{budget.metric} was left a reference budget by §5.3 step 2, but §5.5 — "
         "where that decision was taken — does not mention it"
+    )
+    assert any(decision in line for line in lines for decision in decisions), (
+        f"§5.5 names {budget.metric} but never states the decision: the row that "
+        "survived the promotion has to be recorded as not promoted, not merely "
+        f"reported. Lines found: {lines}"
     )
 
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "flightsite"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -61,13 +61,18 @@ population a deterministic scenario produces does not vary with how loaded the
 machine is.
 
 Two timing gates carry no headroom either, and the reason is arithmetic rather
-than principle. `startup_s` and `recovery_s` are budgeted at 30 seconds against
-measurements of a tenth of a second (§5.5); multiplying that ceiling by five
-would assert 150 s, which no machine this product runs on could fail. They were
-promoted at their stated 30 s in §5.5 because a promotion that loosens the
-bound it enforces is not a promotion, and the rule above exists to stop a busy
-runner failing a gate, not to inflate one that already clears its measurements
-by a factor of several hundred.
+than principle. `startup_s` and `recovery_s` are budgeted at 30 seconds;
+multiplying that by five would assert 150 s, and a promotion that loosens the
+bound it enforces is not a promotion, so §5.5 promoted both at their stated
+figure. What that leaves is a real bound rather than a formality, and the
+margins differ sharply between the two. Startup measured 0.112 s on a Pi 5 and
+0.547 s on a contended Pi 4 — three hundred times inside the ceiling either way.
+Recovery measured 0.0755 s on the Pi 5 but **9.3 s on the contended Pi 4's SD
+card**, which is only 3.2× inside it, and the repair path is already known to be
+load-sensitive (issue #100). That is the narrowest margin of any gate in the
+table; it is deliberate — recovery is bounded by the open-sighting count and the
+storage device, and both are exactly what the budget is there to bound — but it
+is the row to watch on a slow disk, not one to treat as unfailable.
 
 ---
 
@@ -107,7 +112,7 @@ crossing one now fails.
 | `db_read_ms` | SQLite read/query latency | ≤ 500 ms | p95 | ≤ 2500 ms | A reader competing with the single writer for the WAL. Promoted in §5.5: 26.2 ms on a contended Pi 4, 9.16 ms on a Pi 5. §7 qualifies it again at multi-year scale. |
 | `analytics_query_ms` | analytics query latency | ≤ 500 ms | p95 | ≤ 2500 ms | Slice 031's stated budget, restated under concurrent ingestion. Promoted in §5.5: 48.2 ms on a contended Pi 4, 13.8 ms on a Pi 5. |
 | `startup_s` | startup | ≤ 30 s | max | ≤ 30 s | Migrations, wiring and the first ready report; dominated by disk. Promoted in §5.5 at two orders of magnitude of margin, and with no CI headroom (§1 explains why multiplying it would be meaningless). |
-| `recovery_s` | unclean-shutdown recovery | ≤ 30 s | max | ≤ 30 s | Repair of the sightings a power cut left open (slice 053), bounded by the open-sighting count the harness records. Promoted in §5.5, likewise without headroom. |
+| `recovery_s` | unclean-shutdown recovery | ≤ 30 s | max | ≤ 30 s | Repair of the sightings a power cut left open (slice 053), bounded by the open-sighting count the harness records. Promoted in §5.5, likewise without headroom — and the tightest row in this table: 539 sightings took 9.3 s on the contended Pi 4's SD card against 0.0755 s on a Pi 5, so the margin on the reference hardware is 3.2× and the path is load-sensitive (issue #100). |
 
 ### 2.2 Reference budgets (trend-tracked)
 
@@ -124,7 +129,7 @@ the table for.
 
 | Metric | SPEC §85 item | Budget (Pi 4) | Statistic | Why not yet a hard gate |
 |---|---|---|---|---|
-| `db_write_cycle_ms` | SQLite write latency | ≤ 250 ms | p95 | Off the hot path by construction (ADR-0008), so this is a health figure rather than a correctness limit. Measured at 678 ms on a Pi 4 SD card and 57.7 ms on a Pi 5 NVMe: the storage substrate, not the code, sets it (§5.5, issue #132). |
+| `db_write_cycle_ms` | SQLite write latency | ≤ 250 ms | p95 | Off the hot path by construction (ADR-0008), so this is a health figure rather than a correctness limit. Measured at 678 ms on a Pi 4 SD card and 57.7 ms on a Pi 5 NVMe: the storage substrate, not the code, sets it (§5.5). The clean Pi 4 run on non-SD storage that would calibrate it is issue #153. |
 
 ### 2.3 Where else these are enforced
 
@@ -362,8 +367,11 @@ userland on an aarch64 kernel), Docker Compose · 500 aircraft, 600 ticks,
 > hardware's number.
 >
 > **The re-run landed: §5.5, on a Pi 5 with an NVMe SSD, passes all twelve
-> gates and closes issue #132.** This section stays exactly as recorded — it is
-> the Pi 4 reading, and a baseline that gets edited is not a baseline.
+> gates and explains the overrun below.** Issue #132 is closed on that
+> explanation; the reference-hardware question it leaves open — a clean Pi 4 on
+> non-SD storage — is tracked as **issue #153**. This section stays exactly as
+> recorded: it is the Pi 4 reading, and a baseline that gets edited is not a
+> baseline.
 
 Budgets below are the Pi 4 budgets from §2 at face value. `CI_HEADROOM` does
 not apply: it exists so that a shared CI runner cannot fail a gate, and this
@@ -471,10 +479,13 @@ Nginx Proxy Manager and MariaDB pair resident on the host. The harness runs
 in-process against its own temporary database, so what it measured was a second
 full pipeline standing up beside the first.
 
-That is a *lighter* load than §5.4's but it is not a quiet machine either, and
-the figures are stated as the upper bounds they are. It does not weaken the
-result: every gate passed, and a gate passed with neighbours on the machine is a
-gate passed with them included.
+The container inventory is *larger* than §5.4's, not smaller. What is lighter is
+the contention that mattered there: the neighbours' writes no longer queue
+behind one SD card, and the proxy and database pair were idle rather than
+serving. So this is not the quiet machine §5.2 describes either, and the figures
+are stated as the upper bounds they are. That does not weaken the result: every
+gate passed, and a gate passed with neighbours on the machine is a gate passed
+with them included.
 
 Budgets are the Pi 4 budgets from §2 at face value, as in §5.4 — the same
 comparison, so the two tables can be read against each other. The Gate column
@@ -532,15 +543,17 @@ product, or is it the SD card? The answer is legible in the write-cycle row.
 | `ingest_duty_cycle` p95 | 0.99 | **0.347** |
 | `ingest_duty_cycle` max | 5.29 | **1.31** |
 
-An 11.8× fall in write-cycle p95 is not a CPU result. The Pi 5's cores are
-roughly two to three times the Pi 4's, and every purely computational row here
-moved by about that much — `ingest_apply_ms` p95 from 81.2 to 30.5,
-`ws_fanout_ms` from 68.1 to 28.2, `analytics_query_ms` from 48.2 to 13.8. The
-write cycle moved by an order of magnitude more than the arithmetic did, and it
-is the one stage whose cost is dominated by the storage device. §5.4 predicted
+An 11.8× fall in write-cycle p95 is not a CPU result. The purely computational
+rows moved by between **2.4× and 3.5×** — `ingest_apply_ms` p95 81.2 → 30.5
+(2.7×), `ws_fanout_ms` 68.1 → 28.2 (2.4×), `analytics_query_ms` 48.2 → 13.8
+(3.5×) — which is the range a Pi 5's cores against a Pi 4's would predict. The
+write cycle moved three to five times further than any of them, and it is the
+one stage whose cost is dominated by the storage device. §5.4 predicted
 exactly this: *"an SD card that occasionally takes five seconds to commit a
 flush carries the duty cycle straight up with it."* It did, and on NVMe it does
-not. **#132 is closed on that finding**, and no budget was widened to close it.
+not. **#132 is closed on that explanation**, and no budget was widened to close
+it: the finding is understood rather than made to disappear, and what it leaves
+open on the reference hardware is tracked as **#153**.
 
 Two honest limits on the claim. Two variables changed at once — the SoC and the
 storage — so this run does not decompose the improvement to the last
@@ -582,7 +595,11 @@ field per row. `ws_fanout_ms`, `db_read_ms` and `analytics_query_ms` keep
 harness already reported. `startup_s` and `recovery_s` keep `NO_HEADROOM` and
 are therefore gated at their stated 30 s: giving them the fivefold allowance
 would have asserted 150 s, and a promotion that loosens the bound it enforces
-is not a promotion (§1).
+is not a promotion (§1). Read against the reference hardware rather than
+against this run, `recovery_s` is the tightest of the five — 9.3 s of the 30 on
+§5.4's SD card, on a path issue #100 already reports as load-sensitive. It is
+promoted on that figure knowingly: 3.2× is a margin, the budget bounds exactly
+the disk cost that consumed it, and a gate nothing can reach is not a gate.
 
 `db_write_cycle_ms` is **not** promoted, and this is the conservative half of
 the same argument. It is the one row the two runs disagree about — 678 ms on an
@@ -591,8 +608,9 @@ calibrates it. Promoting it on the Pi 5 figure would make the reference
 hardware fail its own gate on the storage most Pi 4 installs use; promoting it
 on the Pi 4 figure is impossible, because that figure missed. It stays a
 reference budget at 250 ms, unwidened, exactly as §5.3 rule 3 requires. What
-would settle it is a clean Pi 4 run on a USB SSD — the same product, the same
-poll, with only the card taken out of the picture.
+would settle it is a clean Pi 4 run on non-SD storage — the same product, the
+same poll, with only the card taken out of the picture. That run is **issue
+#153**, #132's successor and the row's outstanding calibration.
 
 ### 5.6 Development-machine baseline
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -66,8 +66,8 @@ measurements of a tenth of a second (§5.5); multiplying that ceiling by five
 would assert 150 s, which no machine this product runs on could fail. They were
 promoted at their stated 30 s in §5.5 because a promotion that loosens the
 bound it enforces is not a promotion, and the rule above exists to stop a busy
-runner failing a gate, not to inflate one that already has three orders of
-magnitude of room.
+runner failing a gate, not to inflate one that already clears its measurements
+by a factor of several hundred.
 
 ---
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -20,8 +20,10 @@ reason for that. Some limits are correctness-critical: cross one and the live
 picture becomes a backlog, or the process heads for the OOM killer. Others are
 questions of comfort whose real answer depends on the reference hardware — and
 a budget calibrated on a developer laptop tells you nothing about an SD card on
-a Pi. §5.4 now carries a first Pi 4 reading, taken on a contended machine; it
-informs the second kind of budget without yet being firm enough to fix one.
+a Pi. §5 now carries two on-hardware readings: a contended Pi 4 on an SD card
+(§5.4) and a fully-passing Pi 5 on NVMe (§5.5). Between them they were enough
+to fix five of the six budgets of the second kind, which became hard gates in
+§5.5. One did not, and §5.5 says why.
 
 So budgets come in two kinds, and every row of the table below is labelled.
 
@@ -29,14 +31,18 @@ So budgets come in two kinds, and every row of the table below is labelled.
 |---|---|---|
 | Enforced | Fails the test suite, on every PR | Measured, reported, trended; never fails a run |
 | Stated for | Any hardware the suite runs on | Raspberry Pi 4 |
-| Why | Correctness-critical: crossing it breaks the product | Comfort or headroom; the real limit needs Pi 4 data |
-| Becomes hard when | — | A Pi 4 baseline is recorded here (§5) and the row is promoted |
+| Why | Correctness-critical: crossing it breaks the product | Comfort or headroom; the real limit needs Pi data |
+| Becomes hard when | — | An on-hardware baseline in §5 backs it and the row is promoted (five were, in §5.5) |
 
 A reference budget is not a weaker budget. It is a budget that has not yet been
 calibrated against the hardware it is stated for, and reporting it as a hard
 gate on a developer machine would be dressing up a guess. A *contended* Pi 4 —
-which is what §5.4 records — does not lift that objection either; §5.4's
-closing note says why promotion waits for a clean re-run.
+which is what §5.4 records — does not lift that objection for a figure that
+*missed* its budget, because contention is then a live explanation for the
+miss. It does lift it for a figure that *met* one: neighbours competing for the
+machine can only have made a measurement worse, so a pass under contention is a
+pass with the worst case included. That asymmetry is the whole of §5.5's
+promotion argument.
 
 ### CI headroom
 
@@ -47,12 +53,21 @@ shared runner under coverage instrumentation is slow and noisy, and a bound
 five times the budget still catches every structural regression (a hot-path
 await, a per-aircraft query, a superlinear scan) while never failing on a busy
 machine. In practice the measured figures sit one to two orders of magnitude
-inside the asserted bound; see §5.5.
+inside the asserted bound; see §5.6.
 
 Budgets that measure a *quantity* rather than a duration get no headroom at
 all. A 1 GB memory ceiling relaxed fivefold is not a gate, and the live
 population a deterministic scenario produces does not vary with how loaded the
 machine is.
+
+Two timing gates carry no headroom either, and the reason is arithmetic rather
+than principle. `startup_s` and `recovery_s` are budgeted at 30 seconds against
+measurements of a tenth of a second (§5.5); multiplying that ceiling by five
+would assert 150 s, which no machine this product runs on could fail. They were
+promoted at their stated 30 s in §5.5 because a promotion that loosens the
+bound it enforces is not a promotion, and the rule above exists to stop a busy
+runner failing a gate, not to inflate one that already has three orders of
+magnitude of room.
 
 ---
 
@@ -64,11 +79,21 @@ and the harness judges every run against it. A budget that lives only in a
 document drifts from the test enforcing it; a budget that lives only in a test
 is invisible to whoever is deciding whether a Pi 4 is fast enough.
 
+Multi-year database behavior — the tenth item on SPEC §85's list — is roadmap
+slice 050's scope and is deliberately absent from both tables below. It has a
+table of its own in §7, which restates `db_read_ms` and `analytics_query_ms` at
+multi-year scale and adds the growth, retention, backup and restore budgets
+that only mean anything once a database has years in it.
+
 ### 2.1 Hard gates
 
-These are SPEC §85's own list: *ingestion keeps up; 500-aircraft workload
-remains functional; no live-state stalls; memory below agreed budget; core APIs
-responsive.*
+The first six are SPEC §85's own list: *ingestion keeps up; 500-aircraft
+workload remains functional; no live-state stalls; memory below agreed budget;
+core APIs responsive.* The last five were reference budgets until §5.5, and are
+here because SPEC §85 asks for exactly that — *convert to hard gates once real
+Pi baselines exist* — and two on-hardware runs now exist. Their budgets and
+their in-suite bounds are unchanged by the promotion; what changed is that
+crossing one now fails.
 
 | Metric | SPEC §85 item | Budget | Statistic | In-suite bound | What it protects |
 |---|---|---|---|---|---|
@@ -78,32 +103,28 @@ responsive.*
 | `live_sweep_ms` | live-state update latency | ≤ 100 ms | max | ≤ 500 ms | The lifecycle sweep runs every second over the whole live set, so it shares the apply budget. |
 | `api_live_ms` | core APIs responsive | ≤ 250 ms | p95 | ≤ 1250 ms | `/api/v1/aircraft/current` answers from memory, so under load this is serialization and nothing else. Past a quarter second the map feels stalled. |
 | `memory_rss_mib` | memory use | ≤ 1024 MiB | max | ≤ 1024 MiB | SPEC §5. An absolute ceiling on a 4 GB Pi shared with the frontend container and the decoder. |
+| `ws_fanout_ms` | WebSocket distribution | ≤ 100 ms | p95 | ≤ 500 ms | One delta built and delivered to every connected client per ~1 Hz tick (`docs/API.md` §4.3). Promoted in §5.5: measured at 68.1 ms on a contended Pi 4 and 28.2 ms on a Pi 5. |
+| `db_read_ms` | SQLite read/query latency | ≤ 500 ms | p95 | ≤ 2500 ms | A reader competing with the single writer for the WAL. Promoted in §5.5: 26.2 ms on a contended Pi 4, 9.16 ms on a Pi 5. §7 qualifies it again at multi-year scale. |
+| `analytics_query_ms` | analytics query latency | ≤ 500 ms | p95 | ≤ 2500 ms | Slice 031's stated budget, restated under concurrent ingestion. Promoted in §5.5: 48.2 ms on a contended Pi 4, 13.8 ms on a Pi 5. |
+| `startup_s` | startup | ≤ 30 s | max | ≤ 30 s | Migrations, wiring and the first ready report; dominated by disk. Promoted in §5.5 at two orders of magnitude of margin, and with no CI headroom (§1 explains why multiplying it would be meaningless). |
+| `recovery_s` | unclean-shutdown recovery | ≤ 30 s | max | ≤ 30 s | Repair of the sightings a power cut left open (slice 053), bounded by the open-sighting count the harness records. Promoted in §5.5, likewise without headroom. |
 
 ### 2.2 Reference budgets (trend-tracked)
 
 SPEC §85: *trend-track less critical metrics initially; convert to hard gates
 once real Pi 4 baselines exist.*
 
-A first Pi 4 baseline now exists (§5.4), so the per-row rationales below are no
-longer arguing from no data at all. None of these rows is promoted on it: that
-run was contended and its figures are upper bounds, so §5.3's promotion step is
-deferred to the clean re-run rather than applied to numbers that would set
-every threshold in the wrong place. §5.4 gives the argument in full.
+Five of the original six were converted in §5.5 and now sit in §2.1. One row
+remains, and it is the one the two recorded runs disagree about: the Pi 4's SD
+card missed it by a factor of nearly three (§5.4) while the Pi 5's NVMe met it
+with room to spare (§5.5). A budget whose measured value moves an order of
+magnitude with the storage device underneath it is not calibrated by either
+reading on its own, which is precisely the condition §1 reserves this half of
+the table for.
 
 | Metric | SPEC §85 item | Budget (Pi 4) | Statistic | Why not yet a hard gate |
 |---|---|---|---|---|
-| `ws_fanout_ms` | WebSocket distribution | ≤ 100 ms | p95 | Serialization-bound and scales with client count, which the harness records alongside the figure. |
-| `db_write_cycle_ms` | SQLite write latency | ≤ 250 ms | p95 | Off the hot path by construction (ADR-0008), so this is a health figure rather than a correctness limit. Pi 4 SD-card I/O sets the real number. |
-| `db_read_ms` | SQLite read/query latency | ≤ 500 ms | p95 | A reader competing with the single writer for the WAL. Pi 4 storage is uncharacterized; slice 050 qualifies it at multi-year scale. |
-| `analytics_query_ms` | analytics query latency | ≤ 500 ms | p95 | Slice 031's stated budget, restated under concurrent ingestion. Slice 050 qualifies it on a multi-year dataset. |
-| `startup_s` | startup | ≤ 30 s | max | Dominated by disk on a Pi 4. |
-| `recovery_s` | unclean-shutdown recovery | ≤ 30 s | max | Bounded by the open-sighting count, which the harness records. Pi 4 SD-card I/O sets the real number. |
-
-Multi-year database behavior — the tenth item on SPEC §85's list — is roadmap
-slice 050's scope and is deliberately absent from this table. It has a table of
-its own in §7, which restates `db_read_ms` and `analytics_query_ms` above at
-multi-year scale and adds the growth, retention, backup and restore budgets
-that only mean anything once a database has years in it.
+| `db_write_cycle_ms` | SQLite write latency | ≤ 250 ms | p95 | Off the hot path by construction (ADR-0008), so this is a health figure rather than a correctness limit. Measured at 678 ms on a Pi 4 SD card and 57.7 ms on a Pi 5 NVMe: the storage substrate, not the code, sets it (§5.5, issue #132). |
 
 ### 2.3 Where else these are enforced
 
@@ -265,15 +286,23 @@ the command drops straight into a release check.
 
 ---
 
-## 5. Raspberry Pi 4 qualification procedure
+## 5. Raspberry Pi qualification procedure
 
 Run this before a release (SPEC §107's release checklist names Pi 4 performance
 qualification), and whenever a change is expected to move any figure in §2.
 
+The reference hardware the budgets are stated for is still the Raspberry Pi 4;
+the procedure below is written for it and is unchanged. Two runs are recorded:
+a Pi 4 (§5.4) and a Pi 5 (§5.5). A newer Pi runs the same procedure and is
+recorded the same way — what a baseline has to state is the hardware it was
+taken on, not that the hardware was one particular model.
+
 ### 5.1 Prepare
 
 1. A Raspberry Pi 4 (4 GB or better) on Raspberry Pi OS 64-bit, with the
-   storage the install actually uses — SD card or USB SSD, not a tmpfs.
+   storage the install actually uses — SD card or USB SSD, not a tmpfs. A later
+   model runs the same procedure; record which, because the figures are only
+   readable against the machine that produced them.
 2. Deploy the release candidate with Docker Compose per `docs/DEVELOPMENT.md`.
 3. Stop anything else competing for the machine. A decoder feeding the Pi is
    fine and realistic; a desktop session is not.
@@ -294,17 +323,22 @@ table and the JSON off the Pi.
 
 ### 5.3 Record and promote
 
-1. Add a row set to §5.4 with the date, the release, the hardware and every
-   measured figure.
-2. For each **reference** budget now backed by a Pi 4 baseline, decide whether
-   to promote it to a hard gate: change its `gate` to `GateKind.HARD` in
+1. Add a subsection to §5 with the date, the release, the hardware and every
+   measured figure — one subsection per machine, so a later run adds a reading
+   rather than overwriting one.
+2. For each **reference** budget now backed by an on-hardware baseline, decide
+   whether to promote it to a hard gate. §1's asymmetry governs what a
+   *contended* run can back: a figure that met its budget under contention met
+   it with the worst case included, and a figure that missed one under
+   contention has not been measured at all. Promote by changing its `gate` to
+   `GateKind.HARD` in
    `backend/src/flightsite/perf/budgets.py`, set an appropriate `ci_headroom`,
    and update §2 above. `tests/perf/test_budgets.py` will hold the new
    invariant.
 3. If a measured figure exceeds its budget, that is a finding: file it as a
    roadmap entry or an issue rather than widening the budget to fit.
 
-### 5.4 Recorded baselines
+### 5.4 Raspberry Pi 4 baseline — SD card, contended
 
 **2026-09-01** · FlightSite **v0.2.0** · Raspberry Pi 4 Model B Rev 1.5, 4 GB
 RAM (3794 MB), SD-card root (`/dev/root`, 59 GB), Raspberry Pi OS (armhf
@@ -326,10 +360,17 @@ userland on an aarch64 kernel), Docker Compose · 500 aircraft, 600 ticks,
 > quiet-machine measurement §5.2 describes. **A clean re-run is pending**;
 > until it lands, read every figure here as an upper bound rather than as the
 > hardware's number.
+>
+> **The re-run landed: §5.5, on a Pi 5 with an NVMe SSD, passes all twelve
+> gates and closes issue #132.** This section stays exactly as recorded — it is
+> the Pi 4 reading, and a baseline that gets edited is not a baseline.
 
 Budgets below are the Pi 4 budgets from §2 at face value. `CI_HEADROOM` does
 not apply: it exists so that a shared CI runner cannot fail a gate, and this
-*is* the reference hardware the budgets are stated for.
+*is* the reference hardware the budgets are stated for. The Gate column is the
+gate each row carried **when this run was taken**; five of the six reference
+rows were promoted to hard gates in §5.5, on this run's evidence together with
+that one's.
 
 | Metric | Gate | median | p95 | max | Gated statistic | Pi 4 budget | Result |
 |---|---|---|---|---|---|---|---|
@@ -347,9 +388,9 @@ not apply: it exists so that a shared CI runner cannot fail a gate, and this
 | `recovery_s` | reference | — | — | — | max 9.3 | ≤ 30 | pass |
 
 The WebSocket run distributed 3,560 frames with **0 resync reconnects**, which
-is slice 057's batching fix (§5.5's closing note) confirmed on real hardware
+is slice 057's batching fix (§5.6's closing note) confirmed on real hardware
 rather than on the machine that wrote it. Recovery adopted **539 open
-sightings** in 9.3 s, the same open-sighting count as §5.5's development run
+sightings** in 9.3 s, the same open-sighting count as §5.6's development run
 and about four times its cost — the clearest single expression of what SD-card
 I/O does to this product. The JSON report is on that Pi at
 `/opt/flightsite/data/perf-baseline/report.json`; §5.2 asks for it to be copied
@@ -360,7 +401,7 @@ finding.** `ingest_duty_cycle` is a hard gate and its p95 of 0.99 is twice its
 budget: at that figure the per-tick hot path is consuming a whole 1 Hz poll,
 with no margin left. Its driver is visible one row down — `db_write_cycle_ms`
 p95 678 ms against a 250 ms budget, with a maximum of 5.18 s. The duty cycle
-sums the harness's stages serially (§5.5 explains why, and why the product does
+sums the harness's stages serially (§5.6 explains why, and why the product does
 not), so an SD card that occasionally takes five seconds to commit a flush
 carries the duty cycle straight up with it.
 
@@ -402,7 +443,158 @@ their budgets even under this load, and the sixth is the write-cycle row that
 #132 exists to explain. The clean re-run is the point at which §5.3 step 2 gets
 applied for real.
 
-### 5.5 Development-machine baseline
+*It was.* §5.5 records the re-run, and step 2 promoted exactly those five —
+the ones that held here under contention and again on a quiet-storage machine.
+The sixth, `db_write_cycle_ms`, is the one this run and that one disagree
+about, and it stays a reference budget for that reason.
+
+### 5.5 Raspberry Pi 5 baseline — NVMe, clean run
+
+**2026-09-02** · FlightSite **v0.3.1** · Raspberry Pi 5 Model B Rev 1.0, 8 GB
+RAM, NVMe SSD root (476.9 G), Debian 12 (bookworm) arm64, kernel 6.12.96,
+Docker CE 29.7, Python 3.12.14 · 500 aircraft, 600 ticks, 4 WebSocket clients,
+629 s wall
+
+```bash
+docker compose exec flightsite-backend \
+  flightsite-perf --realtime --ticks 600 \
+                  --data-dir /opt/flightsite/data/perf-baseline \
+                  --json /opt/flightsite/data/perf-baseline/report.json
+```
+
+Taken on the owner's live receiver, exactly as §5.2 prescribes. The machine was
+running its ordinary job
+throughout: an ultrafeeder decoder and the piaware, FlightRadar24 and OpenSky
+feeder containers — the "decoder feeding the Pi" §5.1 step 3 explicitly
+permits — plus the live FlightSite backend serving and ingesting, and an idle
+Nginx Proxy Manager and MariaDB pair resident on the host. The harness runs
+in-process against its own temporary database, so what it measured was a second
+full pipeline standing up beside the first.
+
+That is a *lighter* load than §5.4's but it is not a quiet machine either, and
+the figures are stated as the upper bounds they are. It does not weaken the
+result: every gate passed, and a gate passed with neighbours on the machine is a
+gate passed with them included.
+
+Budgets are the Pi 4 budgets from §2 at face value, as in §5.4 — the same
+comparison, so the two tables can be read against each other. The Gate column
+is the gate each row carried when the run was taken; the promotion below is
+what this run changed.
+
+| Metric | Gate | median | p95 | max | Gated statistic | Pi 4 budget | Result |
+|---|---|---|---|---|---|---|---|
+| `live_population` | hard | 600 | 631 | 778 | min 526 | ≥ 500 | pass |
+| `ingest_apply_ms` | hard | 20.5 | 30.5 | 368 | p95 30.5 | ≤ 100 | pass |
+| `ingest_duty_cycle` | hard | 0.0711 | 0.347 | 1.31 | p95 0.347 | ≤ 0.5 | pass |
+| `live_sweep_ms` | hard | 0.375 | 0.594 | 2.32 | max 2.32 | ≤ 100 | pass |
+| `api_live_ms` | hard | 28.9 | 41.9 | 351 | p95 41.9 | ≤ 250 | pass |
+| `memory_rss_mib` | hard | 148 | 175 | 179 | max 179 | ≤ 1024 | pass |
+| `ws_fanout_ms` | reference | 20.4 | 28.2 | 390 | p95 28.2 | ≤ 100 | pass |
+| `db_write_cycle_ms` | reference | 21.0 | 57.7 | 1261 | p95 57.7 | ≤ 250 | pass |
+| `db_read_ms` | reference | 5.79 | 9.16 | 16.6 | p95 9.16 | ≤ 500 | pass |
+| `analytics_query_ms` | reference | 9.50 | 13.8 | 16.8 | p95 13.8 | ≤ 500 | pass |
+| `startup_s` | reference | — | — | — | max 0.112 | ≤ 30 | pass |
+| `recovery_s` | reference | — | — | — | max 0.0755 | ≤ 30 | pass |
+
+**All twelve figures pass, and the command exited 0.** This is the first
+fully-passing on-hardware qualification FlightSite has: §5.4's Pi 4 reading
+missed `ingest_duty_cycle` — a hard gate — at a p95 of 0.99 against 0.5, and
+carried `db_write_cycle_ms` at 678 ms against 250. Both are inside their budgets
+here, by a wide margin, on the same harness driving the same deterministic
+scenario at the same 500-aircraft population.
+
+The two runs are a release apart — v0.2.0 and v0.3.1 — and the first row
+deserves a word, because it reads lower than §5.6's ~700: the live set settles
+at a median of 600 here. That is the pacing rather than a product change.
+§5.6's development run was not `--realtime`, so it compressed 600 ticks into
+59 s of wall clock and the live store's 60-second retention expired almost
+nothing; at the product's actual 1 Hz the resident population sits nearer the
+batch the scenario delivers. Both on-hardware runs were paced, and both bottom
+out at the same minimum of 526 aircraft — the deterministic scenario's own
+floor, unchanged between the two releases.
+
+The WebSocket run distributed 2,484 frames with **0 resync reconnects**, again
+confirming slice 057's batching fix on hardware. Recovery adopted **539 open
+sightings** — the identical count to §5.4 and §5.6, because the scenario is
+deterministic — in **0.0755 s**, against 9.3 s on the Pi 4's SD card and 2.33 s
+on a developer machine. The JSON report is on that Pi at
+`/opt/flightsite/data/perf-baseline/report.json`.
+
+#### What this settles, and what it does not
+
+Issue #132 asked one question: is the duty-cycle overrun a deficiency in this
+product, or is it the SD card? The answer is legible in the write-cycle row.
+
+| | Pi 4, SD card (§5.4) | Pi 5, NVMe (§5.5) |
+|---|---|---|
+| `db_write_cycle_ms` p95 | 678 ms | **57.7 ms** |
+| `db_write_cycle_ms` max | 5,180 ms | **1,261 ms** |
+| `ingest_duty_cycle` p95 | 0.99 | **0.347** |
+| `ingest_duty_cycle` max | 5.29 | **1.31** |
+
+An 11.8× fall in write-cycle p95 is not a CPU result. The Pi 5's cores are
+roughly two to three times the Pi 4's, and every purely computational row here
+moved by about that much — `ingest_apply_ms` p95 from 81.2 to 30.5,
+`ws_fanout_ms` from 68.1 to 28.2, `analytics_query_ms` from 48.2 to 13.8. The
+write cycle moved by an order of magnitude more than the arithmetic did, and it
+is the one stage whose cost is dominated by the storage device. §5.4 predicted
+exactly this: *"an SD card that occasionally takes five seconds to commit a
+flush carries the duty cycle straight up with it."* It did, and on NVMe it does
+not. **#132 is closed on that finding**, and no budget was widened to close it.
+
+Two honest limits on the claim. Two variables changed at once — the SoC and the
+storage — so this run does not decompose the improvement to the last
+millisecond; the argument above is an attribution from the *shape* of the
+change, not an isolated experiment. And this does not repeal §5.4: a Pi 4 with
+an SD card still consumes most of a poll under the SPEC §5 envelope. That is a
+statement about a storage configuration rather than about the product, which is
+why it stays recorded there rather than being edited away: an install on an SD
+card is the configuration in which this budget is at risk, and §5.1 already
+tells whoever qualifies a machine to measure the storage it actually uses.
+
+#### §5.3 step 2: five reference budgets are promoted
+
+§5.4 deferred the promotion because a contended run cannot calibrate a
+threshold. §1's asymmetry is what makes the deferral end here: for a budget the
+run **met**, contention is not a confound. Neighbours competing for a machine
+can only make a measurement worse, so a figure inside its budget under load is
+inside it with the worst case already included. Five rows were inside their
+budgets on the contended Pi 4 *and* on this run:
+
+| Metric | Pi 4 (contended) | Pi 5 (this run) | Budget | Gate before → after |
+|---|---|---|---|---|
+| `ws_fanout_ms` | 68.1 ms | 28.2 ms | ≤ 100 ms p95 | reference → **hard** |
+| `db_read_ms` | 26.2 ms | 9.16 ms | ≤ 500 ms p95 | reference → **hard** |
+| `analytics_query_ms` | 48.2 ms | 13.8 ms | ≤ 500 ms p95 | reference → **hard** |
+| `startup_s` | 0.547 s | 0.112 s | ≤ 30 s max | reference → **hard** |
+| `recovery_s` | 9.3 s | 0.0755 s | ≤ 30 s max | reference → **hard** |
+| `db_write_cycle_ms` | **678 ms** | 57.7 ms | ≤ 250 ms p95 | reference → reference |
+
+Two on-hardware readings inside the budget — one of them on the reference
+hardware itself, and taken under a load heavier than the procedure asks for —
+is what SPEC §85 wants before a metric stops being trend-tracked: *convert to
+hard gates once real Pi 4 baselines exist.* The five are `GateKind.HARD` in
+`backend/src/flightsite/perf/budgets.py` as of this slice, and appear in §2.1.
+
+**No budget value moved and no bound was loosened.** Promotion changed one
+field per row. `ws_fanout_ms`, `db_read_ms` and `analytics_query_ms` keep
+`CI_HEADROOM`, so their in-suite bounds are the 500 ms, 2500 ms and 2500 ms the
+harness already reported. `startup_s` and `recovery_s` keep `NO_HEADROOM` and
+are therefore gated at their stated 30 s: giving them the fivefold allowance
+would have asserted 150 s, and a promotion that loosens the bound it enforces
+is not a promotion (§1).
+
+`db_write_cycle_ms` is **not** promoted, and this is the conservative half of
+the same argument. It is the one row the two runs disagree about — 678 ms on an
+SD card, 57.7 ms on NVMe, against a 250 ms budget — so neither reading
+calibrates it. Promoting it on the Pi 5 figure would make the reference
+hardware fail its own gate on the storage most Pi 4 installs use; promoting it
+on the Pi 4 figure is impossible, because that figure missed. It stays a
+reference budget at 250 ms, unwidened, exactly as §5.3 rule 3 requires. What
+would settle it is a clean Pi 4 run on a USB SSD — the same product, the same
+poll, with only the card taken out of the picture.
+
+### 5.6 Development-machine baseline
 
 Recorded for orientation only. A developer machine is not the reference
 hardware, and a figure here says nothing about a Pi 4 beyond ruling out gross
@@ -494,7 +686,7 @@ Slice 057 took the first of the two options named here — coalescing a pass's
 events into fewer frames. `publish_activity` now sends one `activity_batch`
 frame per pass (`docs/API.md` §4.4), capped at 128 events per frame, so the
 frame count follows the detector's 5-second cadence rather than the size of the
-backlog. Re-running §5.5's command on a fresh database takes the reconnect
+backlog. Re-running §5.6's command on a fresh database takes the reconnect
 count to zero.
 
 ---
@@ -709,7 +901,7 @@ exit status; that is what makes it a reference budget.
 
 #### 7.6.1 Development-machine baseline
 
-Recorded for orientation only, and for the same reason as §5.5: a developer
+Recorded for orientation only, and for the same reason as §5.6: a developer
 machine is not the reference hardware, but the ratio between these numbers and
 a future Pi 4 row is itself useful. What is *not* hardware-dependent here — the
 growth figures and the per-table costs — is as true on a Pi as it is here.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -65,12 +65,12 @@ than principle. `startup_s` and `recovery_s` are budgeted at 30 seconds;
 multiplying that by five would assert 150 s, and a promotion that loosens the
 bound it enforces is not a promotion, so §5.5 promoted both at their stated
 figure. What that leaves is a real bound rather than a formality, and the
-margins differ sharply between the two. Startup measured 0.112 s on a Pi 5 and
-0.547 s on a contended Pi 4 — three hundred times inside the ceiling either way.
+margins differ sharply between the two. Startup measured 0.112 s on a Pi 5 (268×
+inside the ceiling) and 0.547 s on a contended Pi 4 (55×).
 Recovery measured 0.0755 s on the Pi 5 but **9.3 s on the contended Pi 4's SD
 card**, which is only 3.2× inside it, and the repair path is already known to be
-load-sensitive (issue #100). That is the narrowest margin of any gate in the
-table; it is deliberate — recovery is bounded by the open-sighting count and the
+load-sensitive (issue #100). That is the narrowest margin among the five gates
+this section promotes; it is deliberate — recovery is bounded by the open-sighting count and the
 storage device, and both are exactly what the budget is there to bound — but it
 is the row to watch on a slow disk, not one to treat as unfailable.
 
@@ -112,7 +112,7 @@ crossing one now fails.
 | `db_read_ms` | SQLite read/query latency | ≤ 500 ms | p95 | ≤ 2500 ms | A reader competing with the single writer for the WAL. Promoted in §5.5: 26.2 ms on a contended Pi 4, 9.16 ms on a Pi 5. §7 qualifies it again at multi-year scale. |
 | `analytics_query_ms` | analytics query latency | ≤ 500 ms | p95 | ≤ 2500 ms | Slice 031's stated budget, restated under concurrent ingestion. Promoted in §5.5: 48.2 ms on a contended Pi 4, 13.8 ms on a Pi 5. |
 | `startup_s` | startup | ≤ 30 s | max | ≤ 30 s | Migrations, wiring and the first ready report; dominated by disk. Promoted in §5.5 at two orders of magnitude of margin, and with no CI headroom (§1 explains why multiplying it would be meaningless). |
-| `recovery_s` | unclean-shutdown recovery | ≤ 30 s | max | ≤ 30 s | Repair of the sightings a power cut left open (slice 053), bounded by the open-sighting count the harness records. Promoted in §5.5, likewise without headroom — and the tightest row in this table: 539 sightings took 9.3 s on the contended Pi 4's SD card against 0.0755 s on a Pi 5, so the margin on the reference hardware is 3.2× and the path is load-sensitive (issue #100). |
+| `recovery_s` | unclean-shutdown recovery | ≤ 30 s | max | ≤ 30 s | Repair of the sightings a power cut left open (slice 053), bounded by the open-sighting count the harness records. Promoted in §5.5, likewise without headroom — and the tightest of the no-headroom pair: 539 sightings took 9.3 s on the contended Pi 4's SD card against 0.0755 s on a Pi 5, so the margin on the reference hardware is 3.2× and the path is load-sensitive (issue #100). |
 
 ### 2.2 Reference budgets (trend-tracked)
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -73,9 +73,11 @@ Every release branch must complete all applicable items:
 - [ ] Adjacent-version upgrade test: previous release's data dir upgrades in place
 - [ ] Demo-mode validation: full stack runs and exercises scenarios
 - [ ] Live-decoder validation against readsb/dump1090-fa where appropriate
-- [ ] Raspberry Pi qualification where required — run the procedure in
-      `docs/PERFORMANCE.md` §5 and record the baseline there, one subsection per
-      machine (§5.3 step 1)
+- [ ] Raspberry Pi 4 qualification where required — run the procedure in
+      `docs/PERFORMANCE.md` §5
+  - [ ] Baseline recorded under §5, one subsection per machine (§5.3 step 1); a
+        later Pi model runs the same procedure and is recorded beside the Pi 4
+        rather than in place of it
 - [ ] Documentation reviewed for accuracy against the released behavior
 - [ ] `docs/LICENSES.md` reviewed — no unresolved blocked rows for shipped features
 - [ ] Risk register (`docs/RISKS.md`) reviewed

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -73,8 +73,9 @@ Every release branch must complete all applicable items:
 - [ ] Adjacent-version upgrade test: previous release's data dir upgrades in place
 - [ ] Demo-mode validation: full stack runs and exercises scenarios
 - [ ] Live-decoder validation against readsb/dump1090-fa where appropriate
-- [ ] Raspberry Pi 4 qualification where required — run the procedure in
-      `docs/PERFORMANCE.md` §5 and record the baseline in §5.4
+- [ ] Raspberry Pi qualification where required — run the procedure in
+      `docs/PERFORMANCE.md` §5 and record the baseline there, one subsection per
+      machine (§5.3 step 1)
 - [ ] Documentation reviewed for accuracy against the released behavior
 - [ ] `docs/LICENSES.md` reviewed — no unresolved blocked rows for shipped features
 - [ ] Risk register (`docs/RISKS.md`) reviewed

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -145,6 +145,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 062 | Live-set ghost expiry | 007, 008, 009 | opus | medium | Age live records by the decoder's own "last heard" report so dump1090's ~5-minute retention window stops inflating the live count and the 15 s / 60 s thresholds fire on time (issue #134) |
 | 063 | Aircraft label stability | 014, 015 | opus | low | Stop aircraft labels blinking: a hysteresis band on the density tier, and variable anchoring so a colliding label relocates before it hides (issue #143) |
 | 064 | Honest position-fix anchor | 054 | opus | low | Date each position fix by the decode age the frame reports rather than by its arrival, so dead reckoning hands over between fixes without the periodic backwards step (issue #144) |
+| 065 | Raspberry Pi 5 clean performance baseline | 049, 060 | opus | low | Record the first fully-passing on-hardware run in docs/PERFORMANCE.md §5.5 and apply §5.3's promotion rule: five reference budgets become hard gates, SQLite write latency does not (issue #132) |
 
 ## Parallelization Guide
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -145,6 +145,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 062 | Live-set ghost expiry | 007, 008, 009 | opus | medium | Age live records by the decoder's own "last heard" report so dump1090's ~5-minute retention window stops inflating the live count and the 15 s / 60 s thresholds fire on time (issue #134) |
 | 063 | Aircraft label stability | 014, 015 | opus | low | Stop aircraft labels blinking: a hysteresis band on the density tier, and variable anchoring so a colliding label relocates before it hides (issue #143) |
 | 064 | Honest position-fix anchor | 054 | opus | low | Date each position fix by the decode age the frame reports rather than by its arrival, so dead reckoning hands over between fixes without the periodic backwards step (issue #144) |
+| 066 | Military chip metadata gate | 017, 025 | opus | low | Gate the live map's Military quick-filter chip on whether this install has imported aircraft metadata instead of on the long-lifted slice-017 gate, and refresh the drawer's stale metadata notes (issue #151) |
 
 ## Parallelization Guide
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -145,7 +145,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 062 | Live-set ghost expiry | 007, 008, 009 | opus | medium | Age live records by the decoder's own "last heard" report so dump1090's ~5-minute retention window stops inflating the live count and the 15 s / 60 s thresholds fire on time (issue #134) |
 | 063 | Aircraft label stability | 014, 015 | opus | low | Stop aircraft labels blinking: a hysteresis band on the density tier, and variable anchoring so a colliding label relocates before it hides (issue #143) |
 | 064 | Honest position-fix anchor | 054 | opus | low | Date each position fix by the decode age the frame reports rather than by its arrival, so dead reckoning hands over between fixes without the periodic backwards step (issue #144) |
-| 065 | Raspberry Pi 5 clean performance baseline | 049, 060 | opus | low | Record the first fully-passing on-hardware run in docs/PERFORMANCE.md §5.5 and apply §5.3's promotion rule: five reference budgets become hard gates, SQLite write latency does not (issue #132) |
+| 065 | Raspberry Pi 5 clean performance baseline | 049, 060 | opus | low | Record the first fully-passing on-hardware run in docs/PERFORMANCE.md §5.5 and apply §5.3's promotion rule: five reference budgets become hard gates, SQLite write latency does not (closes issue #132; the clean Pi 4 run that would calibrate it is issue #153) |
 
 ## Parallelization Guide
 

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -223,11 +223,14 @@ How the harness runs:
 - No live-state stalls (live update latency bounded)
 - Backend memory below the 1 GB budget under the reference workload
 - Core APIs remain responsive under load
+- SQLite read/query latency, WebSocket fan-out latency, analytics query latency,
+  startup time and unclean-shutdown recovery time — promoted from trend-tracked on
+  the on-hardware baselines in `docs/PERFORMANCE.md` §5.4 and §5.5, as SPEC §85 asks
 
-**Trend-tracked initially (converted to hard gates once Pi 4 baselines exist):**
+**Trend-tracked (converted to hard gates once real Pi baselines calibrate them):**
 
-- SQLite write/read latency, WebSocket fan-out latency, analytics query latency,
-  startup time, unclean-shutdown recovery time
+- SQLite write latency — the one figure the two recorded Pi runs disagree about,
+  because the storage device sets it (`docs/PERFORMANCE.md` §5.5, issue #132)
 
 ### 6.2 Measured metrics
 

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -230,7 +230,8 @@ How the harness runs:
 **Trend-tracked (converted to hard gates once real Pi baselines calibrate them):**
 
 - SQLite write latency — the one figure the two recorded Pi runs disagree about,
-  because the storage device sets it (`docs/PERFORMANCE.md` §5.5, issue #132)
+  because the storage device sets it (`docs/PERFORMANCE.md` §5.5); the clean Pi 4
+  run on non-SD storage that would calibrate it is issue #153
 
 ### 6.2 Measured metrics
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flightsite-frontend",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flightsite-frontend",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@radix-ui/react-separator": "^1.1.15",
         "@radix-ui/react-slot": "^1.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flightsite-frontend",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/frontend/src/features/filters/components/FilterDrawer.test.tsx
+++ b/frontend/src/features/filters/components/FilterDrawer.test.tsx
@@ -157,18 +157,29 @@ describe("FilterDrawer", () => {
     ).toHaveTextContent(/matches nothing until an aircraft-metadata import/i);
   });
 
-  it("notes the missing import on every metadata-backed section when nothing is imported", async () => {
+  it("notes the missing import on exactly the two import-only sections", async () => {
     renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
 
-    // Category/operator, classification, and mission category.
+    // Category/operator and classification — and those two only. Mission is
+    // not among them: the classification engine infers it from the
+    // callsign's airline designator with no import at all.
     const notes = await screen.findAllByText(
       /matches nothing until an aircraft-metadata import runs \(settings → metadata\)/i,
     );
-    expect(notes).toHaveLength(3);
+    expect(notes).toHaveLength(2);
   });
 
-  it("drops the metadata-import notes once metadata is imported", async () => {
+  it("tells the truth about mission category, which callsign inference already fills", async () => {
+    renderDrawer();
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }));
+
+    const note = screen.getByText(/inferred from the callsign/i);
+    expect(note).toHaveTextContent(/widens coverage by adding type-based/i);
+    expect(note).not.toHaveTextContent(/matches nothing until/i);
+  });
+
+  it("keeps the mission-category note and drops the import notes once metadata is imported", async () => {
     installMetadataApiMock({ statusSequence: [IMPORTED] });
     renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
@@ -180,7 +191,10 @@ describe("FilterDrawer", () => {
         ),
       ).not.toBeInTheDocument(),
     );
-    // The filters themselves are untouched — only the caveat goes away.
+    // The mission note is unconditional — it describes how mission is
+    // derived, not a prerequisite.
+    expect(screen.getByText(/inferred from the callsign/i)).toBeInTheDocument();
+    // The filters themselves are untouched — only the caveats go away.
     expect(screen.getByRole("checkbox", { name: "Military" })).toBeEnabled();
     expect(screen.getByLabelText(/aircraft type/i)).toBeEnabled();
   });

--- a/frontend/src/features/filters/components/FilterDrawer.test.tsx
+++ b/frontend/src/features/filters/components/FilterDrawer.test.tsx
@@ -1,18 +1,54 @@
-import { render, screen, within } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FilterDrawer } from "@/features/filters/components/FilterDrawer";
 import { useFilterStore } from "@/features/filters/store/useFilterStore";
 import { DEFAULT_FILTERS } from "@/features/filters/types";
+import type { MetadataStatusResponse } from "@/lib/api/metadata";
+import { installMetadataApiMock, metadataSource } from "@/test/metadataApiMock";
+import { renderWithProviders } from "@/test/test-utils";
+
+/** One source with a dataset installed — the case where the drawer's
+ * metadata-backed filters genuinely filter. */
+const IMPORTED: MetadataStatusResponse = {
+  sources: [
+    metadataSource({
+      name: "mictronics",
+      status: "ok",
+      row_count: 412_003,
+      last_success_ms: 1_756_600_000_000,
+      dataset_version: "2026-08-01",
+    }),
+  ],
+};
 
 beforeEach(() => {
   useFilterStore.setState({ filters: DEFAULT_FILTERS });
+  // Default: a stock install with nothing imported, so the metadata-import
+  // notes are present unless a test says otherwise.
+  installMetadataApiMock({
+    statusSequence: [
+      {
+        sources: [metadataSource({ name: "mictronics", status: "never-run" })],
+      },
+    ],
+  });
 });
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** The drawer reads metadata status through TanStack Query, so every render
+ * needs a `QueryClientProvider` (roadmap slice 066). */
+function renderDrawer() {
+  return renderWithProviders(<FilterDrawer />);
+}
 
 describe("FilterDrawer", () => {
   it("starts closed and opens on toggle", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     expect(screen.queryByTestId("filter-drawer")).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
@@ -23,7 +59,7 @@ describe("FilterDrawer", () => {
   });
 
   it("closes on Escape", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     expect(screen.getByTestId("filter-drawer")).toBeInTheDocument();
 
@@ -32,7 +68,7 @@ describe("FilterDrawer", () => {
   });
 
   it("closes on the close button", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.click(
       screen.getByRole("button", { name: /close filters/i }),
@@ -41,12 +77,12 @@ describe("FilterDrawer", () => {
   });
 
   it("shows no active-count badge with the defaults", () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     expect(screen.queryByTestId("filter-active-count")).not.toBeInTheDocument();
   });
 
   it("updates the active-count badge as filters change and clears via Clear all", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
 
     await userEvent.type(
@@ -62,7 +98,7 @@ describe("FilterDrawer", () => {
   });
 
   it("edits the altitude range", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.type(screen.getByLabelText(/minimum altitude/i), "1000");
     expect(useFilterStore.getState().filters.altitudeMinFt).toBe(1000);
@@ -75,14 +111,14 @@ describe("FilterDrawer", () => {
   });
 
   it("edits the distance override", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.type(screen.getByLabelText(/maximum distance/i), "75");
     expect(useFilterStore.getState().filters.maxDistanceNm).toBe(75);
   });
 
   it("edits the category, operator, and operator-group text filters", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.type(screen.getByLabelText(/aircraft type/i), "737");
     await userEvent.type(screen.getByLabelText(/^operator$/i), "BAW");
@@ -95,7 +131,7 @@ describe("FilterDrawer", () => {
   });
 
   it("toggles emergency-only and interesting-only", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.click(
       screen.getByRole("checkbox", { name: /emergency squawk only/i }),
@@ -109,20 +145,48 @@ describe("FilterDrawer", () => {
     });
   });
 
-  it("toggles a classification checkbox and explains the today-selects-nothing behavior", async () => {
-    render(<FilterDrawer />);
+  it("toggles a classification checkbox and explains that it needs a metadata import", async () => {
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.click(screen.getByRole("checkbox", { name: "Military" }));
     expect(useFilterStore.getState().filters.classifications).toEqual([
       "military",
     ]);
     expect(
-      screen.getByText(/selects nothing until aircraft metadata/i),
-    ).toBeInTheDocument();
+      screen.getByText(/never guesses a classification/i),
+    ).toHaveTextContent(/matches nothing until an aircraft-metadata import/i);
+  });
+
+  it("notes the missing import on every metadata-backed section when nothing is imported", async () => {
+    renderDrawer();
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }));
+
+    // Category/operator, classification, and mission category.
+    const notes = await screen.findAllByText(
+      /matches nothing until an aircraft-metadata import runs \(settings → metadata\)/i,
+    );
+    expect(notes).toHaveLength(3);
+  });
+
+  it("drops the metadata-import notes once metadata is imported", async () => {
+    installMetadataApiMock({ statusSequence: [IMPORTED] });
+    renderDrawer();
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(
+          /matches nothing until an aircraft-metadata import/i,
+        ),
+      ).not.toBeInTheDocument(),
+    );
+    // The filters themselves are untouched — only the caveat goes away.
+    expect(screen.getByRole("checkbox", { name: "Military" })).toBeEnabled();
+    expect(screen.getByLabelText(/aircraft type/i)).toBeEnabled();
   });
 
   it("adds and removes a mission category chip", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     const input = screen.getByLabelText(/add mission category/i);
     await userEvent.type(input, "medevac{enter}");
@@ -135,7 +199,7 @@ describe("FilterDrawer", () => {
   });
 
   it("selects a ground-traffic mode from the segmented control", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     const group = screen.getByRole("radiogroup", { name: /ground traffic/i });
     await userEvent.click(within(group).getByRole("radio", { name: "Dim" }));
@@ -143,7 +207,7 @@ describe("FilterDrawer", () => {
   });
 
   it("toggles hide-stale and hide-non-positioned checkboxes", async () => {
-    render(<FilterDrawer />);
+    renderDrawer();
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.click(
       screen.getByRole("checkbox", { name: /hide stale aircraft/i }),

--- a/frontend/src/features/filters/components/FilterDrawer.tsx
+++ b/frontend/src/features/filters/components/FilterDrawer.tsx
@@ -7,14 +7,24 @@
  * filter state of its own and can never drift from what the map is
  * actually drawing.
  *
- * Fields that match aircraft metadata (type/operator/operator group,
- * classification, mission) stay fully interactive rather than disabled, but
- * carry an inline note whenever this install has not imported metadata yet —
- * without it those filters match nothing, and the note says where to fix
- * that. Once an import has landed (`useMetadataAvailable`, slice 066) the
- * notes disappear, because the filters genuinely filter. "Interesting only"
- * was gated the same way until slice 038 started populating `interesting`
- * and slice 039 surfaced it.
+ * Fields that can only match imported aircraft metadata — type, operator,
+ * operator group, and the classification flags — stay fully interactive
+ * rather than disabled, but carry an inline note whenever this install has
+ * not imported any, because without it they match nothing. Once an import
+ * has landed (`useMetadataAvailable`, slice 066) those notes disappear,
+ * because the filters genuinely filter.
+ *
+ * Mission category is deliberately *not* in that set. The classification
+ * engine infers a mission from the callsign's airline designator against a
+ * bundled operator directory (`classification/engine.py`, `operators.py`),
+ * so airline traffic carries a mission on a metadata-less install; metadata
+ * only widens the coverage by adding type-code inference. Its note says
+ * that, unconditionally, rather than claiming a prerequisite it does not
+ * have. Classification flags are the opposite case and the note is right
+ * there: "a callsign never sets a flag" is that engine's own rule.
+ *
+ * "Interesting only" was gated the same way until slice 038 started
+ * populating `interesting` and slice 039 surfaced it.
  */
 
 import { Filter, X } from "lucide-react";
@@ -379,7 +389,10 @@ export function FilterDrawer() {
                   ))}
                 </ul>
               )}
-              {!metadataAvailable && <MetadataImportNote />}
+              <PlumbingNote>
+                Inferred from the callsign&apos;s airline designator; aircraft
+                metadata widens coverage by adding type-based missions.
+              </PlumbingNote>
             </FilterSection>
 
             <FilterSection title="Status">

--- a/frontend/src/features/filters/components/FilterDrawer.tsx
+++ b/frontend/src/features/filters/components/FilterDrawer.tsx
@@ -7,13 +7,14 @@
  * filter state of its own and can never drift from what the map is
  * actually drawing.
  *
- * Fields that target metadata the decoder does not populate until a later
- * slice (aircraft type/operator/operator group, classification, mission —
- * see `types.ts`'s doc comment) stay fully interactive rather than disabled,
- * but carry an inline note explaining why they will not change what's on the
- * map yet. "Interesting only" was one of those until slice 038 started
- * populating `interesting` and slice 039 surfaced it; its note is gone
- * because the filter now genuinely filters.
+ * Fields that match aircraft metadata (type/operator/operator group,
+ * classification, mission) stay fully interactive rather than disabled, but
+ * carry an inline note whenever this install has not imported metadata yet —
+ * without it those filters match nothing, and the note says where to fix
+ * that. Once an import has landed (`useMetadataAvailable`, slice 066) the
+ * notes disappear, because the filters genuinely filter. "Interesting only"
+ * was gated the same way until slice 038 started populating `interesting`
+ * and slice 039 surfaced it.
  */
 
 import { Filter, X } from "lucide-react";
@@ -30,6 +31,7 @@ import type {
 } from "@/features/filters/types";
 import { useDialogFocus } from "@/lib/a11y/useDialogFocus";
 import { useRovingFocus } from "@/lib/a11y/useRovingFocus";
+import { useMetadataAvailable } from "@/lib/api/metadata";
 import { cn } from "@/lib/utils";
 
 const CLASSIFICATION_OPTIONS: { value: ClassificationFlag; label: string }[] = [
@@ -44,10 +46,24 @@ const GROUND_OPTIONS: { value: GroundTrafficMode; label: string }[] = [
   { value: "hide", label: "Hide" },
 ];
 
-/** A metadata-gated field's explanation, reused wherever slice 024/038
- * data is what the filter actually needs. */
+/** A short explanation under a field — what it does, or what it still
+ * needs. The metadata-gated sections render one only while the install has
+ * no metadata (see `MetadataImportNote`); the rest are unconditional. */
 function PlumbingNote({ children }: { children: ReactNode }) {
   return <p className="text-[11px] text-muted-foreground">{children}</p>;
+}
+
+/** The one wording for "this filter has no data to match against yet",
+ * rendered only when it is true. `children` adds any section-specific
+ * caveat after the shared sentence. */
+function MetadataImportNote({ children }: { children?: ReactNode }) {
+  return (
+    <PlumbingNote>
+      Matches nothing until an aircraft-metadata import runs (Settings →
+      Metadata).
+      {children}
+    </PlumbingNote>
+  );
 }
 
 function FilterSection({
@@ -77,6 +93,7 @@ function numberOrNull(value: string): number | null {
 
 export function FilterDrawer() {
   const [isOpen, setIsOpen] = useState(false);
+  const metadataAvailable = useMetadataAvailable();
   const filters = useFilterStore((state) => state.filters);
   const setAltitudeRange = useFilterStore((state) => state.setAltitudeRange);
   const setMaxDistanceNm = useFilterStore((state) => state.setMaxDistanceNm);
@@ -301,10 +318,7 @@ export function FilterDrawer() {
                   />
                 </div>
               </div>
-              <PlumbingNote>
-                Activates once aircraft metadata populates these fields (roadmap
-                slice 024).
-              </PlumbingNote>
+              {!metadataAvailable && <MetadataImportNote />}
             </FilterSection>
 
             <FilterSection title="Classification">
@@ -323,11 +337,13 @@ export function FilterDrawer() {
                   </label>
                 ))}
               </div>
-              <PlumbingNote>
-                Selects nothing until aircraft metadata (slice 024) arrives —
-                FlightSite never guesses a classification it hasn&apos;t
-                confirmed.
-              </PlumbingNote>
+              {!metadataAvailable && (
+                <MetadataImportNote>
+                  {" "}
+                  FlightSite never guesses a classification it hasn&apos;t
+                  confirmed.
+                </MetadataImportNote>
+              )}
             </FilterSection>
 
             <FilterSection title="Mission category">
@@ -363,9 +379,7 @@ export function FilterDrawer() {
                   ))}
                 </ul>
               )}
-              <PlumbingNote>
-                Same as classification: selects nothing until slice 024.
-              </PlumbingNote>
+              {!metadataAvailable && <MetadataImportNote />}
             </FilterSection>
 
             <FilterSection title="Status">

--- a/frontend/src/features/filters/components/QuickFilterChips.test.tsx
+++ b/frontend/src/features/filters/components/QuickFilterChips.test.tsx
@@ -59,6 +59,27 @@ describe("QuickFilterChips", () => {
     expect(militaryChip()).toBeDisabled();
   });
 
+  it("leaves an already-active military filter releasable with no metadata imported", async () => {
+    useFilterStore.getState().toggleClassification("military");
+    renderWithProviders(<QuickFilterChips />);
+
+    // Active, so clickable — the alternative is a filter you can see but
+    // cannot turn off from where it is shown.
+    expect(militaryChip()).toBeEnabled();
+    expect(militaryChip()).toHaveAttribute("aria-pressed", "true");
+
+    await userEvent.hover(screen.getByTestId("military-chip-trigger"));
+    const tooltip = await screen.findAllByText(
+      /filter active, but no aircraft metadata/i,
+    );
+    expect(tooltip.length).toBeGreaterThan(0);
+
+    await userEvent.click(militaryChip());
+    expect(useFilterStore.getState().filters.classifications).toEqual([]);
+    // Released, and now correctly back to disabled.
+    expect(militaryChip()).toBeDisabled();
+  });
+
   it("enables the Military chip and toggles the military classification once metadata is imported", async () => {
     installMetadataApiMock({ statusSequence: [IMPORTED] });
     renderWithProviders(<QuickFilterChips />);

--- a/frontend/src/features/filters/components/QuickFilterChips.test.tsx
+++ b/frontend/src/features/filters/components/QuickFilterChips.test.tsx
@@ -1,28 +1,134 @@
-import { render, screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { FilterDrawer } from "@/features/filters/components/FilterDrawer";
 import { QuickFilterChips } from "@/features/filters/components/QuickFilterChips";
 import { useFilterStore } from "@/features/filters/store/useFilterStore";
 import { DEFAULT_FILTERS } from "@/features/filters/types";
+import type { MetadataStatusResponse } from "@/lib/api/metadata";
+import { installMetadataApiMock, metadataSource } from "@/test/metadataApiMock";
+import { renderWithProviders } from "@/test/test-utils";
+
+/** A status document reporting one source with a dataset installed — the
+ * "metadata available" case the Military chip is gated on. */
+const IMPORTED: MetadataStatusResponse = {
+  sources: [
+    metadataSource({
+      name: "mictronics",
+      status: "ok",
+      row_count: 412_003,
+      last_success_ms: 1_756_600_000_000,
+      dataset_version: "2026-08-01",
+    }),
+  ],
+};
+
+/** A stock install: the source is registered, but nothing has been imported. */
+const NOT_IMPORTED: MetadataStatusResponse = {
+  sources: [metadataSource({ name: "mictronics", status: "never-run" })],
+};
 
 beforeEach(() => {
   useFilterStore.setState({ filters: DEFAULT_FILTERS });
+  installMetadataApiMock({ statusSequence: [NOT_IMPORTED] });
 });
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function militaryChip() {
+  return screen.getByRole("button", { name: "Military" });
+}
+
 describe("QuickFilterChips", () => {
-  it("renders the Military chip disabled with an explanatory tooltip", async () => {
-    render(<QuickFilterChips />);
-    expect(screen.getByRole("button", { name: "Military" })).toBeDisabled();
+  it("keeps the Military chip disabled with a tooltip pointing at Settings when no metadata is imported", async () => {
+    renderWithProviders(<QuickFilterChips />);
+    expect(militaryChip()).toBeDisabled();
 
     await userEvent.hover(screen.getByTestId("military-chip-trigger"));
-    expect(
-      await screen.findByText(/activates with aircraft metadata/i),
-    ).toBeInTheDocument();
+    // Radix renders the content plus a visually-hidden copy for assistive
+    // tech, so both carry the wording — assert on the set, not on one node.
+    const tooltip = await screen.findAllByText(
+      /no aircraft metadata imported yet/i,
+    );
+    expect(tooltip.length).toBeGreaterThan(0);
+    expect(tooltip[0]).toHaveTextContent(/settings → metadata/i);
+    // Still disabled after the status has settled — no enable-then-disable.
+    expect(militaryChip()).toBeDisabled();
+  });
+
+  it("enables the Military chip and toggles the military classification once metadata is imported", async () => {
+    installMetadataApiMock({ statusSequence: [IMPORTED] });
+    renderWithProviders(<QuickFilterChips />);
+
+    await waitFor(() => expect(militaryChip()).toBeEnabled());
+    expect(militaryChip()).toHaveAttribute("aria-pressed", "false");
+
+    await userEvent.click(militaryChip());
+    expect(useFilterStore.getState().filters.classifications).toEqual([
+      "military",
+    ]);
+    expect(militaryChip()).toHaveAttribute("aria-pressed", "true");
+
+    await userEvent.click(militaryChip());
+    expect(useFilterStore.getState().filters.classifications).toEqual([]);
+    expect(militaryChip()).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("reflects an externally-set military classification as active", async () => {
+    installMetadataApiMock({ statusSequence: [IMPORTED] });
+    useFilterStore.getState().toggleClassification("military");
+    renderWithProviders(<QuickFilterChips />);
+
+    await waitFor(() => expect(militaryChip()).toBeEnabled());
+    expect(militaryChip()).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("mirrors the drawer's Military checkbox in both directions", async () => {
+    installMetadataApiMock({ statusSequence: [IMPORTED] });
+    renderWithProviders(
+      <>
+        <QuickFilterChips />
+        <FilterDrawer />
+      </>,
+    );
+    await waitFor(() => expect(militaryChip()).toBeEnabled());
+    await userEvent.click(screen.getByRole("button", { name: /^filters$/i }));
+
+    const checkbox = screen.getByRole("checkbox", { name: "Military" });
+    await userEvent.click(militaryChip());
+    expect(checkbox).toBeChecked();
+
+    await userEvent.click(checkbox);
+    expect(militaryChip()).toHaveAttribute("aria-pressed", "false");
+    expect(useFilterStore.getState().filters.classifications).toEqual([]);
+  });
+
+  it("keeps the Military chip disabled while the metadata status is still loading", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+    renderWithProviders(<QuickFilterChips />);
+    expect(militaryChip()).toBeDisabled();
+  });
+
+  it("keeps the Military chip disabled when the metadata status request fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("network down"))),
+    );
+    renderWithProviders(<QuickFilterChips />);
+
+    // Give the failed query a chance to settle: the safe state must survive it.
+    await waitFor(() => expect(militaryChip()).toBeDisabled());
+    expect(screen.getByTestId("military-chip-trigger")).toBeInTheDocument();
   });
 
   it("toggles emergency-only", async () => {
-    render(<QuickFilterChips />);
+    renderWithProviders(<QuickFilterChips />);
     const chip = screen.getByRole("button", { name: "Emergency" });
     expect(chip).toHaveAttribute("aria-pressed", "false");
 
@@ -35,7 +141,7 @@ describe("QuickFilterChips", () => {
   });
 
   it("toggles airborne-only via the ground-traffic filter", async () => {
-    render(<QuickFilterChips />);
+    renderWithProviders(<QuickFilterChips />);
     const chip = screen.getByRole("button", { name: "Airborne only" });
 
     await userEvent.click(chip);
@@ -48,7 +154,7 @@ describe("QuickFilterChips", () => {
 
   it("reflects an externally-set ground mode as active", () => {
     useFilterStore.getState().setGroundTraffic("hide");
-    render(<QuickFilterChips />);
+    renderWithProviders(<QuickFilterChips />);
     expect(
       screen.getByRole("button", { name: "Airborne only" }),
     ).toHaveAttribute("aria-pressed", "true");

--- a/frontend/src/features/filters/components/QuickFilterChips.tsx
+++ b/frontend/src/features/filters/components/QuickFilterChips.tsx
@@ -1,14 +1,18 @@
 /**
  * One-tap common filters, wired to the exact same `useFilterStore` the
  * drawer edits (roadmap slice 017) — a chip is a shortcut into the model,
- * never a second source of truth for it.
+ * never a second source of truth for it. "Military" and the drawer's
+ * Military checkbox are the same `classifications` entry seen twice.
  *
- * "Military" targets `classification.military`, which is `null` on every
- * live payload until slice 024 (see `types.ts`'s doc comment): toggling it
- * on today would silently empty the map with no way to tell why, so the
- * chip stays disabled with a tooltip instead of pretending to work.
- * "Emergency" (`emergency` squawk) and "Airborne only" (ground traffic) are
- * real decoder fields today and are fully live.
+ * "Military" targets `classification.military`, which only exists on live
+ * payloads once this install has imported aircraft metadata. The chip was
+ * hard-disabled from slice 017 until slice 066 because no metadata system
+ * existed at all; now that one does, the gate is on the *data*, not on
+ * history: `useMetadataAvailable` asks whether any source has rows
+ * installed, and the chip toggles for real when it does. With no import the
+ * chip stays disabled — turning it on would silently empty the map — and
+ * says where to fix that. "Emergency" (`emergency` squawk) and "Airborne
+ * only" (ground traffic) are decoder fields and are always live.
  */
 
 import {
@@ -18,6 +22,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useFilterStore } from "@/features/filters/store/useFilterStore";
+import { useMetadataAvailable } from "@/lib/api/metadata";
 import { cn } from "@/lib/utils";
 
 function Chip({
@@ -55,8 +60,17 @@ export function QuickFilterChips() {
   const filters = useFilterStore((state) => state.filters);
   const setEmergencyOnly = useFilterStore((state) => state.setEmergencyOnly);
   const setGroundTraffic = useFilterStore((state) => state.setGroundTraffic);
+  const toggleClassification = useFilterStore(
+    (state) => state.toggleClassification,
+  );
+  const metadataAvailable = useMetadataAvailable();
 
   const airborneOnly = filters.groundTraffic === "hide";
+  // Read from the store either way, disabled or not: the drawer's checkbox
+  // stays interactive without metadata, and a filter restored from the URL
+  // can arrive military-selected, so the chip reports the model rather than
+  // its own availability.
+  const militaryActive = filters.classifications.includes("military");
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -67,17 +81,28 @@ export function QuickFilterChips() {
         // map controls never overlap.
         className="absolute left-3 top-12 z-10 flex flex-wrap gap-1.5"
       >
-        <Tooltip>
-          <TooltipTrigger asChild>
-            {/* A disabled button suppresses its own pointer events in most
-             * browsers, so the hover target — and the tooltip trigger — is
-             * this wrapping span, not the button itself. */}
-            <span data-testid="military-chip-trigger">
-              <Chip label="Military" active={false} disabled />
-            </span>
-          </TooltipTrigger>
-          <TooltipContent>Activates with aircraft metadata</TooltipContent>
-        </Tooltip>
+        {metadataAvailable ? (
+          <Chip
+            label="Military"
+            active={militaryActive}
+            onClick={() => toggleClassification("military")}
+          />
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {/* A disabled button suppresses its own pointer events in most
+               * browsers, so the hover target — and the tooltip trigger — is
+               * this wrapping span, not the button itself. */}
+              <span data-testid="military-chip-trigger">
+                <Chip label="Military" active={militaryActive} disabled />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              No aircraft metadata imported yet — run Settings → Metadata →
+              Update Aircraft Metadata
+            </TooltipContent>
+          </Tooltip>
+        )}
 
         <Chip
           label="Emergency"

--- a/frontend/src/features/filters/components/QuickFilterChips.tsx
+++ b/frontend/src/features/filters/components/QuickFilterChips.tsx
@@ -8,11 +8,14 @@
  * payloads once this install has imported aircraft metadata. The chip was
  * hard-disabled from slice 017 until slice 066 because no metadata system
  * existed at all; now that one does, the gate is on the *data*, not on
- * history: `useMetadataAvailable` asks whether any source has rows
- * installed, and the chip toggles for real when it does. With no import the
- * chip stays disabled — turning it on would silently empty the map — and
- * says where to fix that. "Emergency" (`emergency` squawk) and "Airborne
- * only" (ground traffic) are decoder fields and are always live.
+ * history: `useMetadataAvailable` asks whether any airframe source has rows
+ * installed, and the chip toggles for real when it does. With no import,
+ * turning the filter *on* would silently empty the map, so the chip is
+ * disabled and says where to fix that — but a filter already on (restored
+ * from the URL, or set in the drawer) leaves the chip enabled, because an
+ * active filter must always be releasable from where its state is shown.
+ * "Emergency" (`emergency` squawk) and "Airborne only" (ground traffic) are
+ * decoder fields and are always live.
  */
 
 import {
@@ -71,6 +74,20 @@ export function QuickFilterChips() {
   // can arrive military-selected, so the chip reports the model rather than
   // its own availability.
   const militaryActive = filters.classifications.includes("military");
+  // Disabled only where clicking would *start* a filter that matches
+  // nothing. An already-active filter stays clickable however unavailable
+  // the metadata is — otherwise the one control showing "military only" is
+  // the one control that cannot turn it off again.
+  const militaryDisabled = !metadataAvailable && !militaryActive;
+
+  const militaryChip = (
+    <Chip
+      label="Military"
+      active={militaryActive}
+      disabled={militaryDisabled}
+      onClick={() => toggleClassification("military")}
+    />
+  );
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -82,24 +99,19 @@ export function QuickFilterChips() {
         className="absolute left-3 top-12 z-10 flex flex-wrap gap-1.5"
       >
         {metadataAvailable ? (
-          <Chip
-            label="Military"
-            active={militaryActive}
-            onClick={() => toggleClassification("military")}
-          />
+          militaryChip
         ) : (
           <Tooltip>
             <TooltipTrigger asChild>
               {/* A disabled button suppresses its own pointer events in most
                * browsers, so the hover target — and the tooltip trigger — is
                * this wrapping span, not the button itself. */}
-              <span data-testid="military-chip-trigger">
-                <Chip label="Military" active={militaryActive} disabled />
-              </span>
+              <span data-testid="military-chip-trigger">{militaryChip}</span>
             </TooltipTrigger>
             <TooltipContent>
-              No aircraft metadata imported yet — run Settings → Metadata →
-              Update Aircraft Metadata
+              {militaryActive
+                ? "Filter active, but no aircraft metadata is imported — it matches nothing until one runs"
+                : "No aircraft metadata imported yet — run Settings → Metadata → Update Aircraft Metadata"}
             </TooltipContent>
           </Tooltip>
         )}

--- a/frontend/src/lib/api/metadata.test.ts
+++ b/frontend/src/lib/api/metadata.test.ts
@@ -128,7 +128,7 @@ describe("hasImportedMetadata", () => {
     ).toBe(false);
   });
 
-  it("is true when any one source has rows installed", () => {
+  it("is true when any one airframe source has rows installed", () => {
     expect(
       hasImportedMetadata({
         sources: [
@@ -142,6 +142,70 @@ describe("hasImportedMetadata", () => {
         ],
       }),
     ).toBe(true);
+  });
+
+  it("ignores the airports source, whose rows are airports rather than airframes", () => {
+    // SPEC §27 keeps every source's outcome independent, so this — airports
+    // imported, both airframe sources failed — is an ordinary state, and it
+    // must not read as "this install has aircraft metadata".
+    expect(
+      hasImportedMetadata({
+        sources: [
+          metadataSource({
+            name: "airports",
+            status: "ok",
+            row_count: 80_412,
+            last_success_ms: 1_756_600_000_000,
+          }),
+          metadataSource({
+            name: "mictronics",
+            status: "failed",
+            last_error: "download failed",
+          }),
+          metadataSource({
+            name: "faa",
+            status: "failed",
+            last_error: "download failed",
+          }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("is true for airports alongside an airframe source with rows", () => {
+    expect(
+      hasImportedMetadata({
+        sources: [
+          metadataSource({
+            name: "airports",
+            status: "ok",
+            row_count: 80_412,
+            last_success_ms: 1_756_600_000_000,
+          }),
+          metadataSource({
+            name: "opensky",
+            status: "ok",
+            row_count: 512_000,
+            last_success_ms: 1_756_600_000_000,
+          }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores an unrecognized source name — a new airframe source lands with the code that names it", () => {
+    expect(
+      hasImportedMetadata({
+        sources: [
+          metadataSource({
+            name: "some-future-source",
+            status: "ok",
+            row_count: 1_000,
+            last_success_ms: 1_756_600_000_000,
+          }),
+        ],
+      }),
+    ).toBe(false);
   });
 
   it("stays true while a later run is in flight or has failed — the installed dataset is still there", () => {

--- a/frontend/src/lib/api/metadata.test.ts
+++ b/frontend/src/lib/api/metadata.test.ts
@@ -3,7 +3,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   getMetadataStatus,
+  hasImportedMetadata,
   triggerMetadataUpdate,
+  useMetadataAvailable,
   useMetadataStatusQuery,
   useTriggerMetadataUpdateMutation,
 } from "@/lib/api/metadata";
@@ -91,6 +93,141 @@ describe("useMetadataStatusQuery", () => {
       () => expect(result.current.data?.sources[0]?.status).toBe("ok"),
       { timeout: 4000 },
     );
+  });
+});
+
+describe("hasImportedMetadata", () => {
+  it("is false with no status document at all", () => {
+    expect(hasImportedMetadata(undefined)).toBe(false);
+  });
+
+  it("is false for a stock install with no registered sources", () => {
+    expect(hasImportedMetadata({ sources: [] })).toBe(false);
+  });
+
+  it("is false for a registered source that has never run", () => {
+    expect(
+      hasImportedMetadata({
+        sources: [metadataSource({ name: "mictronics", status: "never-run" })],
+      }),
+    ).toBe(false);
+  });
+
+  it("is false for a source reporting zero rows", () => {
+    expect(
+      hasImportedMetadata({
+        sources: [
+          metadataSource({
+            name: "mictronics",
+            status: "ok",
+            row_count: 0,
+            last_success_ms: 1_756_600_000_000,
+          }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("is true when any one source has rows installed", () => {
+    expect(
+      hasImportedMetadata({
+        sources: [
+          metadataSource({ name: "mictronics", status: "never-run" }),
+          metadataSource({
+            name: "faa",
+            status: "ok",
+            row_count: 412_003,
+            last_success_ms: 1_756_600_000_000,
+          }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("stays true while a later run is in flight or has failed — the installed dataset is still there", () => {
+    const installed = {
+      row_count: 412_003,
+      last_success_ms: 1_756_600_000_000,
+      dataset_version: "2026-08-01",
+    };
+    expect(
+      hasImportedMetadata({
+        sources: [
+          metadataSource({ name: "faa", status: "running", ...installed }),
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      hasImportedMetadata({
+        sources: [
+          metadataSource({
+            name: "faa",
+            status: "failed",
+            last_error: "download failed",
+            ...installed,
+          }),
+        ],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("useMetadataAvailable", () => {
+  it("reports availability once the status document lands", async () => {
+    installMetadataApiMock({
+      statusSequence: [
+        {
+          sources: [
+            metadataSource({
+              name: "mictronics",
+              status: "ok",
+              row_count: 412_003,
+              last_success_ms: 1_756_600_000_000,
+            }),
+          ],
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useMetadataAvailable(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    // Never the other way round: unavailable until the data says otherwise.
+    expect(result.current).toBe(false);
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it("stays unavailable while the status request is still in flight", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+
+    const { result } = renderHook(() => useMetadataAvailable(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await Promise.resolve();
+    expect(result.current).toBe(false);
+  });
+
+  it("stays unavailable when the status request fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("network down"))),
+    );
+
+    const { result } = renderHook(
+      () => ({
+        available: useMetadataAvailable(),
+        query: useMetadataStatusQuery(),
+      }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.query.isError).toBe(true));
+    expect(result.current.available).toBe(false);
   });
 });
 

--- a/frontend/src/lib/api/metadata.ts
+++ b/frontend/src/lib/api/metadata.ts
@@ -86,7 +86,32 @@ export function useMetadataStatusQuery(): UseQueryResult<MetadataStatusResponse>
   });
 }
 
-/** True when this source row proves a dataset is actually installed.
+/** The registered sources whose rows are *airframes*.
+ *
+ * The status endpoint reports every registered source and carries no field
+ * saying what kind of rows a source installs, so the distinction has to be
+ * drawn by name. `airports` (slice 027) is a metadata source in every
+ * mechanical sense — its own status row, its own `row_count` in the tens of
+ * thousands — but, as `backend/src/flightsite/metadata/registry.py`'s module
+ * docstring puts it, its "rows are airports rather than airframes". SPEC §27
+ * makes each source's outcome independent, so "airports ok, mictronics and
+ * faa failed" is an ordinary state; counting airports there would report
+ * metadata as available over an empty `aircraft_metadata` table — exactly
+ * the silently-empty-map hazard the original chip gate existed to prevent.
+ *
+ * The frontend already draws this line in `MetadataSection`'s
+ * `SOURCE_LABELS`, which names these three and lets `airports` fall through
+ * to the generic label. An unrecognized name is treated as
+ * not-an-airframe-source: a new aircraft source arrives together with the
+ * frontend change that names it, and failing closed until then only leaves a
+ * filter unavailable, where failing open would leave it lying. */
+const AIRCRAFT_METADATA_SOURCES: ReadonlySet<string> = new Set([
+  "mictronics",
+  "faa",
+  "opensky",
+]);
+
+/** True when this source row proves an *airframe* dataset is installed.
  *
  * `row_count` is written only by a successful promotion and cleared only by
  * a metadata reset, so a positive count is the single field that separates
@@ -97,13 +122,17 @@ export function useMetadataStatusQuery(): UseQueryResult<MetadataStatusResponse>
  * the previous dataset intact) — neither of those takes the data away, so
  * neither should take the metadata-backed filters away. */
 function sourceHasRows(source: MetadataSourceStatusEntry): boolean {
-  return source.row_count !== null && source.row_count > 0;
+  return (
+    AIRCRAFT_METADATA_SOURCES.has(source.name) &&
+    source.row_count !== null &&
+    source.row_count > 0
+  );
 }
 
-/** Whether a status document reports any source with rows installed.
- * `undefined` — status not loaded yet, or the request failed — reads as
- * "no metadata", the safe answer: a filter that would silently match
- * nothing stays visibly unavailable until we know better. */
+/** Whether a status document reports any airframe source with rows
+ * installed. `undefined` — status not loaded yet, or the request failed —
+ * reads as "no metadata", the safe answer: a filter that would silently
+ * match nothing stays visibly unavailable until we know better. */
 export function hasImportedMetadata(
   status: MetadataStatusResponse | undefined,
 ): boolean {

--- a/frontend/src/lib/api/metadata.ts
+++ b/frontend/src/lib/api/metadata.ts
@@ -86,6 +86,43 @@ export function useMetadataStatusQuery(): UseQueryResult<MetadataStatusResponse>
   });
 }
 
+/** True when this source row proves a dataset is actually installed.
+ *
+ * `row_count` is written only by a successful promotion and cleared only by
+ * a metadata reset, so a positive count is the single field that separates
+ * "an import ran and installed rows" from "registered but never run", "still
+ * downloading its first dataset", and "failed with nothing to show". It
+ * deliberately keeps describing the installed dataset while a later run is
+ * `"running"` or after one has `"failed"` (SPEC §27: a failed import leaves
+ * the previous dataset intact) — neither of those takes the data away, so
+ * neither should take the metadata-backed filters away. */
+function sourceHasRows(source: MetadataSourceStatusEntry): boolean {
+  return source.row_count !== null && source.row_count > 0;
+}
+
+/** Whether a status document reports any source with rows installed.
+ * `undefined` — status not loaded yet, or the request failed — reads as
+ * "no metadata", the safe answer: a filter that would silently match
+ * nothing stays visibly unavailable until we know better. */
+export function hasImportedMetadata(
+  status: MetadataStatusResponse | undefined,
+): boolean {
+  return status?.sources.some(sourceHasRows) ?? false;
+}
+
+/** Does this install have aircraft metadata for the metadata-backed filters
+ * (classification, mission, type/operator) to match against?
+ *
+ * Reads {@link useMetadataStatusQuery} rather than fetching the status
+ * document a second time: one query key with one set of options, however
+ * many components ask. While the status is loading or errored this answers
+ * `false`, so a gated control opens up only on positive evidence and never
+ * flashes enabled before turning itself off again. */
+export function useMetadataAvailable(): boolean {
+  const { data } = useMetadataStatusQuery();
+  return hasImportedMetadata(data);
+}
+
 /** Triggers an update and refreshes {@link useMetadataStatusQuery} with an
  * immediate refetch, so the "running" state (and the polling it drives)
  * shows up as soon as the backend has scheduled the run rather than waiting

--- a/frontend/src/test/overlaysApiMock.ts
+++ b/frontend/src/test/overlaysApiMock.ts
@@ -55,9 +55,10 @@ const EMPTY_SIGHTING_LIST: SightingListResponse = {
  * and `GET /api/v1/sightings/{id}`, which back the track backfill (roadmap
  * slice 061) — and `GET /api/internal/metadata/status`, which the filter
  * chips and drawer read to decide whether the metadata-backed filters have
- * anything to match (roadmap slice 066), so map tests can exercise the real API clients and TanStack
- * Query hooks without a running backend. Any other URL throws, surfacing an
- * un-mocked request as a test failure instead of a silent network error. */
+ * anything to match (roadmap slice 066). So map tests can exercise the real
+ * API clients and TanStack Query hooks without a running backend. Any other
+ * URL throws, surfacing an un-mocked request as a test failure instead of a
+ * silent network error. */
 export function installOverlaysApiMock(options: MockOverlaysApiOptions = {}) {
   const fetchMock = vi.fn(
     async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/frontend/src/test/overlaysApiMock.ts
+++ b/frontend/src/test/overlaysApiMock.ts
@@ -1,6 +1,7 @@
 import type { FeatureCollection } from "geojson";
 import { vi } from "vitest";
 
+import type { MetadataStatusResponse } from "@/lib/api/metadata";
 import type { SightingDetail, SightingListResponse } from "@/lib/api/sightings";
 
 /** An empty `FeatureCollection` — the default response for both endpoints,
@@ -33,6 +34,11 @@ export interface MockOverlaysApiOptions {
   /** `id -> SightingDetail` for `GET /api/v1/sightings/{id}`; an id with no
    * entry 404s. */
   sightingDetail?: Record<number, SightingDetail>;
+  /** Response `GET /api/internal/metadata/status` returns — the filter
+   * chips and drawer read it to decide whether the metadata-backed filters
+   * have anything to match (roadmap slice 066). Defaults to no registered
+   * sources, i.e. a stock install with no import behind it. */
+  metadataStatus?: MetadataStatusResponse;
 }
 
 /** The `GET /api/v1/sightings` default: no open sighting for anything. */
@@ -47,7 +53,9 @@ const EMPTY_SIGHTING_LIST: SightingListResponse = {
  * `GET /api/v1/airspace` (roadmap slice 028), plus the two sightings reads the
  * Live Map itself makes when an aircraft is selected — `GET /api/v1/sightings`
  * and `GET /api/v1/sightings/{id}`, which back the track backfill (roadmap
- * slice 061) — so map tests can exercise the real API clients and TanStack
+ * slice 061) — and `GET /api/internal/metadata/status`, which the filter
+ * chips and drawer read to decide whether the metadata-backed filters have
+ * anything to match (roadmap slice 066), so map tests can exercise the real API clients and TanStack
  * Query hooks without a running backend. Any other URL throws, surfacing an
  * un-mocked request as a test failure instead of a silent network error. */
 export function installOverlaysApiMock(options: MockOverlaysApiOptions = {}) {
@@ -95,6 +103,13 @@ export function installOverlaysApiMock(options: MockOverlaysApiOptions = {}) {
           );
         }
         return jsonResponse(detail);
+      }
+
+      if (
+        url.pathname === "/api/internal/metadata/status" &&
+        method === "GET"
+      ) {
+        return jsonResponse(options.metadataStatus ?? { sources: [] });
       }
 
       throw new Error(`Unhandled fetch in test: ${method} ${raw}`);

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -83,6 +83,11 @@ releases:
     after_phase: 8
     theme: "Same-day patch: aircraft label stability (hysteresis + relocate-before-hide)
       and the honest position-fix anchor (slices 063-064). Recorded 2026-09-02."
+  - version: "v0.3.2"
+    after_phase: 8
+    theme: "Military filter activation on real metadata availability + the clean
+      Pi 5 performance baseline with five budgets promoted to hard gates
+      (slices 065-066). Recorded 2026-09-03."
   - version: "v1.0.0"
     after_phase: 8
     theme: "Qualified stable release per SPEC.md §114 definition of done."

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1712,12 +1712,15 @@ slices:
     depends_on: ["017", "025"]
     objective: "Lift the slice-017 gate that left the live map's Military quick-filter chip permanently disabled, and gate it on the install's actual metadata instead of on roadmap history — so the chip toggles for real once an import has landed, and says where to run one when it has not (issue #151)."
     scope:
-      - "`lib/api/metadata.ts` gains `hasImportedMetadata(status)` and the `useMetadataAvailable()` hook, both deriving availability from `row_count > 0` on any source - the one field written only by a successful promotion, so it separates an installed dataset from never-run, first-run-in-flight and failed"
+      - "`lib/api/metadata.ts` gains `hasImportedMetadata(status)` and the `useMetadataAvailable()` hook, deriving availability from `row_count > 0` on an *airframe* source - the one field written only by a successful promotion, so it separates an installed dataset from never-run, first-run-in-flight and failed"
+      - "the airframe sources are named explicitly (mictronics, faa, opensky) because the status payload carries no kind discriminator: slice 027's `airports` source reports its own five-figure `row_count` while installing no airframes at all (registry.py: \"rows are airports rather than airframes\"), and SPEC §27's per-source independence makes airports-ok-airframes-failed an ordinary state that must not read as \"this install has aircraft metadata\""
       - "`useMetadataAvailable` reads the existing `useMetadataStatusQuery` rather than fetching `/api/internal/metadata/status` a second time: one key, one set of options, however many components ask (the slice-061 lesson about divergent observers of one key)"
       - "unknown status - loading or errored - answers `false`, so a gated control opens only on positive evidence and never flashes enabled before disabling itself"
-      - "`QuickFilterChips` renders Military as a real toggle when metadata is available, wired to `toggleClassification(\"military\")` with `aria-pressed` read from `filters.classifications`; when it is not, the chip stays disabled and its tooltip points at Settings -> Metadata instead of at a future slice"
+      - "`QuickFilterChips` renders Military as a real toggle when metadata is available, wired to `toggleClassification(\"military\")` with `aria-pressed` read from `filters.classifications`; when it is not, the chip is disabled and its tooltip points at Settings -> Metadata instead of at a future slice"
+      - "an already-active military filter keeps the chip enabled even with no metadata, so a selection restored from the URL or set in the drawer stays releasable from where its state is shown; that case gets its own tooltip saying the filter is on and matching nothing"
       - "the chip reports the store's military selection whether enabled or disabled, so it can never disagree with the drawer checkbox it mirrors"
-      - "`FilterDrawer` replaces the three stale slice-024 plumbing notes (category/operator, classification, mission category) with one `MetadataImportNote` wording, rendered only while metadata is absent and gone once an import has landed"
+      - "`FilterDrawer` replaces the stale slice-024 plumbing notes on the two import-only sections (category/operator, classification) with one `MetadataImportNote` wording, rendered only while metadata is absent"
+      - "mission category gets an unconditional honest note instead of an import note: the classification engine infers a mission from the callsign's airline designator against a bundled operator directory, so mission is populated with no import at all and metadata only widens coverage by adding type-code inference"
       - "`test/overlaysApiMock.ts` serves the metadata-status read the live map now makes, with a `metadataStatus` option"
     out_of_scope:
       - "the drawer's metadata-backed inputs themselves, which stay fully interactive with or without metadata - a note, never a disabled field"
@@ -1726,18 +1729,23 @@ slices:
       - "`features/filters/types.ts`'s module docstring, which still describes the metadata fields as slice-024-pending - a separate documentation-only cleanup"
       - "any new metadata source, import trigger, or Settings-page change"
     acceptance_criteria:
-      - "with a source reporting rows installed, the Military chip is enabled, toggles `classifications` military on and off, and carries the matching `aria-pressed`"
+      - "with an airframe source reporting rows installed, the Military chip is enabled, toggles `classifications` military on and off, and carries the matching `aria-pressed`"
+      - "an airports-only import - airports ok, airframe sources failed or never run - leaves the chip disabled and the drawer notes in place"
       - "with no import, the chip is disabled and its tooltip names the prerequisite and where to fulfil it"
+      - "with no import but the filter already active, the chip is enabled, says so, and one click clears the filter"
       - "toggling the chip checks the drawer's Military checkbox and vice versa - one store, two views"
       - "while the status is loading or after it fails, the chip is disabled; it never renders enabled first"
-      - "the drawer shows one import note per metadata-backed section without metadata, and none with it"
+      - "the drawer shows an import note on exactly the two import-only sections without metadata, and none with it"
+      - "the mission-category note describes callsign inference and claims no import prerequisite, with or without metadata"
       - "no drawer or chip copy references an unlanded slice"
     required_tests:
       - predicate unit tests over undefined/empty/never-run/zero-row/populated documents and the running-and-failed cases that must stay available
+      - predicate unit tests for the airports source alone (false), airports beside an airframe source (true), and an unrecognized source name (false)
       - hook tests for the false-until-proven default, the in-flight case, and the errored case
       - chip tests for the disabled tooltip, the enabled toggle, external selection, loading and error safe states
+      - a chip test for the active-but-unavailable case: enabled, its own tooltip, and clearable in one click
       - a mirror test rendering chips and drawer together and driving each from the other
-      - drawer tests for the note count without metadata and their absence with it
+      - drawer tests for the import-note count without metadata, their absence with it, and the mission note's presence in both
     expected_artifacts:
       - frontend/src/lib/api/metadata.ts
       - frontend/src/features/filters/components/QuickFilterChips.tsx

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1710,7 +1710,7 @@ slices:
     branch: "065-pi5-baseline"
     status: merged
     depends_on: ["049", "060"]
-    objective: "Record the first fully-passing on-hardware qualification run in docs/PERFORMANCE.md, closing the finding slice 060 filed as issue #132, and apply §5.3's promotion rule now that a clean run exists."
+    objective: "Record the first fully-passing on-hardware qualification run in docs/PERFORMANCE.md, explaining the finding slice 060 filed as issue #132 (closed by this slice's PR, with the reference-hardware follow-up tracked as issue #153), and apply §5.3's promotion rule now that a clean run exists."
     scope:
       - "docs/PERFORMANCE.md §5.5 records the 2026-09-02 Raspberry Pi 5 Model B Rev 1.0 / 8 GB / NVMe run of `flightsite-perf --realtime --ticks 600` against release v0.3.1: date, hardware, environment, command, and all twelve measured figures with their gated statistics and verdicts"
       - "the section states what the run settles relative to §5.4 — the duty-cycle overrun was SD-card write stalls, not a code deficiency (db_write_cycle_ms p95 678 ms -> 57.7 ms, max 5.18 s -> 1.26 s; ingest_duty_cycle p95 0.99 -> 0.347) — and what it does not: two variables changed at once, and a Pi 4 on an SD card still consumes most of a poll"
@@ -1719,31 +1719,38 @@ slices:
       - "no budget value changed and no in-suite bound was loosened: the promoted rows keep the ci_headroom they had, so startup_s and recovery_s are gated at their stated 30 s rather than relaxed to 150 s"
       - "§1, §2.1, §2.2 and §5.3 updated to state the promotion, the asymmetry that licenses it (a figure that met its budget under contention met it with the worst case included), and the headroom exception; §5 retitled for Pi qualification generally and the development-machine baseline renumbered §5.6"
       - "docs/TEST_STRATEGY.md §6.1 and docs/RELEASE.md's qualification checklist item follow the same change"
-      - "tests/perf/test_docs.py pins §5.5's presence, its report of every budget, and that the section names both the issue it closes and the budget that stayed trend-tracked"
+      - "tests/perf/test_docs.py pins §5.5's presence, its report of every budget, and that the section records the not-promoted decision for the budget that stayed trend-tracked rather than merely naming it"
+      - "tests/perf/test_budgets.py pins the exact eleven-member hard set and the exact one-member reference set, so a silent demotion of a promoted row fails a test"
+      - ".github/workflows/perf.yml's header comment states what the sustained job now asserts (eleven gates) instead of describing every budget as trend-tracked"
     out_of_scope:
       - "any change to a budget value, a statistic, or an in-suite bound"
       - "promoting db_write_cycle_ms, which needs a clean Pi 4 run on non-SD storage"
       - "editing §5.4's recorded Pi 4 figures, which stand as taken"
       - "the §7.6 Pi storage baseline, still unrecorded and behind its own procedure (§7.8)"
-      - "re-measuring on a Pi 4, and any change to the reference hardware the budgets are stated for (that would need an ADR)"
+      - "re-measuring on a Pi 4: the clean run on non-SD storage that would calibrate db_write_cycle_ms is issue #153, #132's tracked successor"
+      - "any change to the reference hardware the budgets are stated for, which would need an ADR"
     acceptance_criteria:
-      - "docs/PERFORMANCE.md §5.5 carries the Pi 5 baseline with all twelve figures, the hardware and environment preamble, and the comparison against §5.4 that closes issue #132"
+      - "docs/PERFORMANCE.md §5.5 carries the Pi 5 baseline with all twelve figures, the hardware and environment preamble, and the comparison against §5.4 that explains issue #132's finding and names issue #153 as the reference-hardware follow-up"
       - "the five promoted budgets are GateKind.HARD in perf/budgets.py, appear in §2.1 with their in-suite bounds, and no longer appear in §2.2"
       - "db_write_cycle_ms remains GateKind.REFERENCE with its 250 ms budget unchanged, and §2.2 and §5.5 both say why"
       - "the full backend suite passes with the five promoted gates now failing-capable, including the in-suite smoke run in tests/perf/test_harness.py"
-      - "tests/perf/test_docs.py fails if §5.5 loses the recorded run, omits a budget, or stops naming the finding it closes"
+      - "tests/perf/test_docs.py fails if §5.5 loses the recorded run, omits a budget, or stops recording the not-promoted decision"
+      - "tests/perf/test_budgets.py fails if any promoted row is demoted or db_write_cycle_ms is promoted without a documented decision"
     required_tests:
       - the §5.5 baseline-presence, every-budget and promotion-decision guards in tests/perf/test_docs.py
+      - exact-set pins for the eleven hard gates and the one remaining reference budget in tests/perf/test_budgets.py
       - the existing tests/perf/test_budgets.py and tests/perf/test_harness.py gate-kind invariants, now covering eleven hard gates instead of six
     expected_artifacts:
       - docs/PERFORMANCE.md
       - backend/src/flightsite/perf/budgets.py
       - backend/tests/perf/test_docs.py
+      - backend/tests/perf/test_budgets.py
+      - .github/workflows/perf.yml
       - docs/TEST_STRATEGY.md
       - docs/RELEASE.md
     preferred_agent: opus
     risk_level: low
-    notes: "Closes GitHub issue #132 and completes the qualification story slice 060 left open. Measurement was run by Fable on the owner's Pi 5 over SSH; the JSON report is at /opt/flightsite/data/perf-baseline/report.json on that machine. Added by Fable outside the phase plan."
+    notes: "Completes the qualification story slice 060 left open. This slice's PR closes GitHub issue #132 on the explanation recorded in §5.5 (SD-card write stalls, not a code deficiency); the condition still reproduces on a Pi 4 with an SD card, and the clean Pi 4 run that would calibrate db_write_cycle_ms is tracked as issue #153. Measurement was run by Fable on the owner's Pi 5 over SSH; the JSON report is at /opt/flightsite/data/perf-baseline/report.json on that machine. Added by Fable outside the phase plan."
 
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1704,6 +1704,51 @@ slices:
     preferred_agent: opus
     risk_level: low
     notes: "Owner reported markers still oscillating on the Pi at v0.3.0. Fixes GitHub issue #144, the residual systematic term slice 054's no-correction-blend rationale underestimated. Frontend-only, client-side mirror of slice 062's server-side ageing. Added by Fable outside the phase plan."
+  - id: "066"
+    title: "Military chip metadata gate"
+    phase: 8
+    branch: "066-military-chip"
+    status: merged
+    depends_on: ["017", "025"]
+    objective: "Lift the slice-017 gate that left the live map's Military quick-filter chip permanently disabled, and gate it on the install's actual metadata instead of on roadmap history — so the chip toggles for real once an import has landed, and says where to run one when it has not (issue #151)."
+    scope:
+      - "`lib/api/metadata.ts` gains `hasImportedMetadata(status)` and the `useMetadataAvailable()` hook, both deriving availability from `row_count > 0` on any source - the one field written only by a successful promotion, so it separates an installed dataset from never-run, first-run-in-flight and failed"
+      - "`useMetadataAvailable` reads the existing `useMetadataStatusQuery` rather than fetching `/api/internal/metadata/status` a second time: one key, one set of options, however many components ask (the slice-061 lesson about divergent observers of one key)"
+      - "unknown status - loading or errored - answers `false`, so a gated control opens only on positive evidence and never flashes enabled before disabling itself"
+      - "`QuickFilterChips` renders Military as a real toggle when metadata is available, wired to `toggleClassification(\"military\")` with `aria-pressed` read from `filters.classifications`; when it is not, the chip stays disabled and its tooltip points at Settings -> Metadata instead of at a future slice"
+      - "the chip reports the store's military selection whether enabled or disabled, so it can never disagree with the drawer checkbox it mirrors"
+      - "`FilterDrawer` replaces the three stale slice-024 plumbing notes (category/operator, classification, mission category) with one `MetadataImportNote` wording, rendered only while metadata is absent and gone once an import has landed"
+      - "`test/overlaysApiMock.ts` serves the metadata-status read the live map now makes, with a `metadataStatus` option"
+    out_of_scope:
+      - "the drawer's metadata-backed inputs themselves, which stay fully interactive with or without metadata - a note, never a disabled field"
+      - "`applyFilters` and its null-excludes semantics, unchanged: this slice changes what the UI says and enables, not what a selection matches"
+      - "backend changes; `/api/internal/metadata/status` already carries everything the predicate needs"
+      - "`features/filters/types.ts`'s module docstring, which still describes the metadata fields as slice-024-pending - a separate documentation-only cleanup"
+      - "any new metadata source, import trigger, or Settings-page change"
+    acceptance_criteria:
+      - "with a source reporting rows installed, the Military chip is enabled, toggles `classifications` military on and off, and carries the matching `aria-pressed`"
+      - "with no import, the chip is disabled and its tooltip names the prerequisite and where to fulfil it"
+      - "toggling the chip checks the drawer's Military checkbox and vice versa - one store, two views"
+      - "while the status is loading or after it fails, the chip is disabled; it never renders enabled first"
+      - "the drawer shows one import note per metadata-backed section without metadata, and none with it"
+      - "no drawer or chip copy references an unlanded slice"
+    required_tests:
+      - predicate unit tests over undefined/empty/never-run/zero-row/populated documents and the running-and-failed cases that must stay available
+      - hook tests for the false-until-proven default, the in-flight case, and the errored case
+      - chip tests for the disabled tooltip, the enabled toggle, external selection, loading and error safe states
+      - a mirror test rendering chips and drawer together and driving each from the other
+      - drawer tests for the note count without metadata and their absence with it
+    expected_artifacts:
+      - frontend/src/lib/api/metadata.ts
+      - frontend/src/features/filters/components/QuickFilterChips.tsx
+      - frontend/src/features/filters/components/FilterDrawer.tsx
+      - frontend/src/lib/api/metadata.test.ts
+      - frontend/src/features/filters/components/QuickFilterChips.test.tsx
+      - frontend/src/features/filters/components/FilterDrawer.test.tsx
+      - frontend/src/test/overlaysApiMock.ts
+    preferred_agent: opus
+    risk_level: low
+    notes: "Owner-reported at v0.3.1: the chip had been disabled since slice 017, when no metadata system existed; slices 022-025 landed one and nobody lifted the gate. Fixes GitHub issue #151. Frontend-only. Added by Fable outside the phase plan."
 
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1704,6 +1704,46 @@ slices:
     preferred_agent: opus
     risk_level: low
     notes: "Owner reported markers still oscillating on the Pi at v0.3.0. Fixes GitHub issue #144, the residual systematic term slice 054's no-correction-blend rationale underestimated. Frontend-only, client-side mirror of slice 062's server-side ageing. Added by Fable outside the phase plan."
+  - id: "065"
+    title: "Raspberry Pi 5 clean performance baseline"
+    phase: 8
+    branch: "065-pi5-baseline"
+    status: merged
+    depends_on: ["049", "060"]
+    objective: "Record the first fully-passing on-hardware qualification run in docs/PERFORMANCE.md, closing the finding slice 060 filed as issue #132, and apply §5.3's promotion rule now that a clean run exists."
+    scope:
+      - "docs/PERFORMANCE.md §5.5 records the 2026-09-02 Raspberry Pi 5 Model B Rev 1.0 / 8 GB / NVMe run of `flightsite-perf --realtime --ticks 600` against release v0.3.1: date, hardware, environment, command, and all twelve measured figures with their gated statistics and verdicts"
+      - "the section states what the run settles relative to §5.4 — the duty-cycle overrun was SD-card write stalls, not a code deficiency (db_write_cycle_ms p95 678 ms -> 57.7 ms, max 5.18 s -> 1.26 s; ingest_duty_cycle p95 0.99 -> 0.347) — and what it does not: two variables changed at once, and a Pi 4 on an SD card still consumes most of a poll"
+      - "the run's own load is stated honestly: an ultrafeeder decoder and three feeder containers (permitted by §5.1 step 3), the live backend ingesting beside the harness, and an idle proxy/database pair, so the figures are upper bounds"
+      - "§5.3 step 2 applied: ws_fanout_ms, db_read_ms, analytics_query_ms, startup_s and recovery_s promoted to GateKind.HARD in backend/src/flightsite/perf/budgets.py, each inside its budget on both the contended Pi 4 and the clean Pi 5; db_write_cycle_ms stays a reference budget because the two runs disagree about it by an order of magnitude"
+      - "no budget value changed and no in-suite bound was loosened: the promoted rows keep the ci_headroom they had, so startup_s and recovery_s are gated at their stated 30 s rather than relaxed to 150 s"
+      - "§1, §2.1, §2.2 and §5.3 updated to state the promotion, the asymmetry that licenses it (a figure that met its budget under contention met it with the worst case included), and the headroom exception; §5 retitled for Pi qualification generally and the development-machine baseline renumbered §5.6"
+      - "docs/TEST_STRATEGY.md §6.1 and docs/RELEASE.md's qualification checklist item follow the same change"
+      - "tests/perf/test_docs.py pins §5.5's presence, its report of every budget, and that the section names both the issue it closes and the budget that stayed trend-tracked"
+    out_of_scope:
+      - "any change to a budget value, a statistic, or an in-suite bound"
+      - "promoting db_write_cycle_ms, which needs a clean Pi 4 run on non-SD storage"
+      - "editing §5.4's recorded Pi 4 figures, which stand as taken"
+      - "the §7.6 Pi storage baseline, still unrecorded and behind its own procedure (§7.8)"
+      - "re-measuring on a Pi 4, and any change to the reference hardware the budgets are stated for (that would need an ADR)"
+    acceptance_criteria:
+      - "docs/PERFORMANCE.md §5.5 carries the Pi 5 baseline with all twelve figures, the hardware and environment preamble, and the comparison against §5.4 that closes issue #132"
+      - "the five promoted budgets are GateKind.HARD in perf/budgets.py, appear in §2.1 with their in-suite bounds, and no longer appear in §2.2"
+      - "db_write_cycle_ms remains GateKind.REFERENCE with its 250 ms budget unchanged, and §2.2 and §5.5 both say why"
+      - "the full backend suite passes with the five promoted gates now failing-capable, including the in-suite smoke run in tests/perf/test_harness.py"
+      - "tests/perf/test_docs.py fails if §5.5 loses the recorded run, omits a budget, or stops naming the finding it closes"
+    required_tests:
+      - the §5.5 baseline-presence, every-budget and promotion-decision guards in tests/perf/test_docs.py
+      - the existing tests/perf/test_budgets.py and tests/perf/test_harness.py gate-kind invariants, now covering eleven hard gates instead of six
+    expected_artifacts:
+      - docs/PERFORMANCE.md
+      - backend/src/flightsite/perf/budgets.py
+      - backend/tests/perf/test_docs.py
+      - docs/TEST_STRATEGY.md
+      - docs/RELEASE.md
+    preferred_agent: opus
+    risk_level: low
+    notes: "Closes GitHub issue #132 and completes the qualification story slice 060 left open. Measurement was run by Fable on the owner's Pi 5 over SSH; the JSON report is at /opt/flightsite/data/perf-baseline/report.json on that machine. Added by Fable outside the phase plan."
 
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,


### PR DESCRIPTION
Release v0.3.2 — Military filter activation + the clean Pi 5 performance qualification (slices 065–066).

- **Military chip works** with imported metadata; honest gating and tooltips otherwise (#151)
- **Pi 5 NVMe baseline recorded** — first fully-passing 12-metric hardware qualification; closes #132's investigation (#153 tracks the Pi 4 calibration)
- **Five perf budgets promoted to hard CI gates**, no values changed

Both slices adversarially reviewed (FIX FIRST rounds caught and fixed an airports-source predicate hole and margin overclaims; verification rounds returned MERGE with mutation-tested pins). Release mechanics: uv.lock refreshed + `uv sync --locked` clean; main verified ancestor.

Post-merge: tag `v0.3.2` → GitHub Release → GHCR publish → back-merge → upgrade fermi.local. Owner pre-approved this train ("Go ahead and cut v0.3.2 and update fermi.local").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTAJUucu2ZPAD235B3GQeZ