### PR TITLE
chore: back-merge v0.3.2 release into dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ follows [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/) (`0.x.y` during pre-1.0 development).
 This file is updated only on release branches (see `docs/RELEASE.md`).
 
+## [0.3.2] — 2026-09-03
+
+The Military filter comes alive, and the performance story gets its first
+fully-passing hardware qualification.
+
+### Added
+- Measured Raspberry Pi 5 (NVMe) performance baseline in
+  `docs/PERFORMANCE.md` §5.5 — **all 12 metrics pass**, confirming the Pi 4
+  baseline's duty-cycle failure was SD-card write stalls (#132; the clean
+  Pi 4 calibration run is tracked as #153)
+- Five performance budgets promoted from trend-tracked references to hard
+  CI gates on the strength of that run (`ws_fanout`, `db_read`,
+  `analytics_query`, `startup`, `recovery`) — no budget value changed in
+  either direction
+
+### Fixed
+- **The Military quick-filter chip works** once aircraft metadata is
+  imported: it was hard-disabled since the pre-metadata era. It now enables
+  on real metadata availability (Mictronics/FAA/OpenSky — an airports-only
+  import doesn't count), mirrors the filter drawer's checkbox, and when
+  disabled its tooltip says exactly what to do (Settings → Metadata). The
+  drawer's outdated "arrives in a later slice" notes now tell the
+  present-tense truth (#151)
+
 ## [0.3.1] — 2026-09-02
 
 A same-day patch for two owner-reported live-map irritations.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flightsite"
-version = "0.3.1"
+version = "0.3.2"
 description = "FlightSite backend: self-hosted ADS-B observatory API and ingestion service."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "flightsite"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flightsite-frontend",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flightsite-frontend",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@radix-ui/react-separator": "^1.1.15",
         "@radix-ui/react-slot": "^1.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flightsite-frontend",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -83,6 +83,11 @@ releases:
     after_phase: 8
     theme: "Same-day patch: aircraft label stability (hysteresis + relocate-before-hide)
       and the honest position-fix anchor (slices 063-064). Recorded 2026-09-02."
+  - version: "v0.3.2"
+    after_phase: 8
+    theme: "Military filter activation on real metadata availability + the clean
+      Pi 5 performance baseline with five budgets promoted to hard gates
+      (slices 065-066). Recorded 2026-09-03."
   - version: "v1.0.0"
     after_phase: 8
     theme: "Qualified stable release per SPEC.md §114 definition of done."


### PR DESCRIPTION
Keeps main an ancestor of dev after the v0.3.2 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTAJUucu2ZPAD235B3GQeZ