### PR TITLE
docs: open-issue severity triage and label scale (slice 067)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -311,6 +311,33 @@ Issue (template: `Roadmap slice`) created when the slice starts. The PR links th
 issue (`Closes #N`); merging closes it; the roadmap status is updated in the same
 motion. GitHub Projects is not used for v1.
 
+### Issue labels (slice 067)
+
+Every open issue carries exactly one `severity:*` label, set at triage against the
+code on `dev` (not against the issue text alone). The scale ranks every issue, not
+only bugs: for an enhancement or documentation item it reads as priority.
+
+| Label | Meaning |
+|---|---|
+| `severity:critical` | Data loss or corruption, a crash or hang of the running service, or a secret reaching logs, diagnostics, or the API. Blocks any release. |
+| `severity:high` | A documented feature does not work for real users and there is no workaround. Blocks v1.0.0 (SPEC §114). |
+| `severity:medium` | Wrong or degraded behavior with a workaround or a limited surface. Fix before v1.0.0, or document it as a known limitation and say so on the issue. |
+| `severity:low` | Polish, efficiency, test or demo affordances, cosmetic. Never blocks a release. Bundle candidates. |
+
+Two orthogonal labels qualify the severity:
+
+- `release-gate` — the item blocks a SPEC §114 definition-of-done checkbox regardless
+  of its severity (for example a documentation gap that makes "architecture
+  documentation matches reality" false).
+- `decision` — the item needs an owner or ADR decision before any code is written;
+  the triage comment states the options.
+
+Type labels (`bug`, `enhancement`, `documentation`) keep their GitHub-default
+meaning. SPEC §114's "no known critical/high-severity product bugs remain" is
+answered by the query in `docs/RELEASE.md`; a slice that fixes a labeled issue
+closes it with `Closes #N` in the PR body so the query stays truthful without a
+second triage pass.
+
 ## Parallel development (SPEC §96)
 
 - Parallelize only slices with no unresolved dependency conflicts.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -114,7 +114,9 @@ v1.0.0 may be proposed only when **all** of the following hold:
 - [ ] Upgrade path works
 - [ ] Demo mode works
 - [ ] Live readsb/dump1090-fa ingestion is validated
-- [ ] No known critical/high-severity product bugs remain
+- [ ] No known critical/high-severity product bugs remain — the query
+      `gh issue list --state open --search 'label:severity:critical,severity:high label:bug'`
+      returns nothing (label definitions: `docs/DEVELOPMENT.md`, GitHub Issues)
 - [ ] Architecture documentation matches reality
 - [ ] API documentation matches reality
 - [ ] Deployment documentation matches reality

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,10 +31,10 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | Version | After Phase | Theme |
 |---|---|---|
 | v0.1.0 | 3 | Live radar MVP: ingestion, sightings, live map, demo mode, setup wizard |
-| v0.2.0 | 4 | Aircraft identity: offline metadata, classification, enrichment, overlays |
-| v0.3.0 | 5 | History & analytics |
-| v0.4.0 | 6 | Alerts & notifications |
-| v0.5.0 | 7 | Operations: backup/restore, maintenance, diagnostics |
+| v0.2.0 | 8 | Consolidated release: identity completion, history & analytics, alerts & notifications, operations, and the Phase 8 hardening pass (the planned v0.2–v0.5 themes shipped together; recorded 2026-09-01) |
+| v0.3.0 | 8 | Fresh-install polish and live-picture correctness from the first real deployment (slices 056–062; recorded 2026-09-02) |
+| v0.3.1 | 8 | Same-day patch: aircraft label stability and the honest position-fix anchor (slices 063–064; recorded 2026-09-02) |
+| v0.3.2 | 8 | Military filter activation on real metadata availability + the clean Pi 5 performance baseline with five budgets promoted to hard gates (slices 065–066; recorded 2026-09-03) |
 | v1.0.0 | 8 | Qualified stable release per SPEC §114 definition of done |
 
 ## Slices
@@ -147,6 +147,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 064 | Honest position-fix anchor | 054 | opus | low | Date each position fix by the decode age the frame reports rather than by its arrival, so dead reckoning hands over between fixes without the periodic backwards step (issue #144) |
 | 065 | Raspberry Pi 5 clean performance baseline | 049, 060 | opus | low | Record the first fully-passing on-hardware run in docs/PERFORMANCE.md §5.5 and apply §5.3's promotion rule: five reference budgets become hard gates, SQLite write latency does not (closes issue #132; the clean Pi 4 run that would calibrate it is issue #153) |
 | 066 | Military chip metadata gate | 017, 025 | opus | low | Gate the live map's Military quick-filter chip on whether this install has imported aircraft metadata instead of on the long-lifted slice-017 gate, and refresh the drawer's stale metadata notes (issue #151) |
+| 067 | Open-issue severity triage | 066 | opus | low | Re-verify every open issue against dev, close the ones merged slices already fixed, and label the rest by severity (plus release-gate / decision) so the SPEC §114 bug gate is a label query; records the Pi 5 + SSD runtime environment (issue #157) |
 
 ## Parallelization Guide
 

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -30,7 +30,7 @@
 #   - Documentation relevant to the slice is updated within the slice.
 
 version: 2  # v2: Phase 0 review-gate corrections (dependency completions, 009 split into 009/052/053, packed track storage, numeric perf criteria, licensing register)
-updated: "2026-08-31"
+updated: "2026-09-04"
 
 phases:
   - number: 0
@@ -1809,6 +1809,40 @@ slices:
     preferred_agent: opus
     risk_level: low
     notes: "Owner-reported at v0.3.1: the chip had been disabled since slice 017, when no metadata system existed; slices 022-025 landed one and nobody lifted the gate. Fixes GitHub issue #151. Frontend-only. Added by Fable outside the phase plan."
+
+  - id: "067"
+    title: "Open-issue severity triage"
+    phase: 8
+    branch: "067-issue-triage"
+    status: merged
+    depends_on: ["066"]
+    objective: "Triage every open GitHub issue against the current dev tree, close the ones merged slices already fixed, label the rest by severity so SPEC §114's 'no known critical/high-severity product bugs' gate becomes a label query instead of a judgement call, and record that the owner's runtime environment is now a Raspberry Pi 5 with an SSD (issue #157)."
+    scope:
+      - "a severity label set (`severity:critical`, `severity:high`, `severity:medium`, `severity:low`) with definitions in docs/DEVELOPMENT.md's GitHub Issues section, plus `release-gate` for items that block the SPEC §114 definition of done regardless of severity and `decision` for items that need an owner or ADR decision rather than code"
+      - "every open issue re-verified against the code on dev before labeling: issues that merged slices already resolved but whose PRs carried no closing keyword (#91 via slice 038, #101 via slice 060, #111 via slice 055, #107/#115/#116/#117/#121 via slice 058) are closed with a comment naming the fixing PR; the partially resolved #112 gets a comment saying which items remain"
+      - "each remaining open issue gets exactly one severity label, a type label (bug / enhancement / documentation), `release-gate` and/or `decision` where they apply, and a triage comment with the rationale and the on-dev verification"
+      - "docs/RELEASE.md's §114 checklist item for critical/high bugs names the label query that answers it"
+      - "the roadmap records that the owner's runtime environment is now a Raspberry Pi 5 with an SSD (the hardware of the §5.5 baseline), so the pending Pi 4 SSD run (#153) and SPEC §5/§114's Pi 4 wording are an explicit owner decision rather than an assumed next step"
+      - "docs/ROADMAP.md's release-checkpoints table re-synced with the releases roadmap.yaml actually records (SPEC §92)"
+    out_of_scope:
+      - "fixing any triaged issue; each fix is its own slice or bundle slice"
+      - "amending SPEC.md §5 or §114 for the Pi 5 environment: the SPEC is the owner's verbatim contract, so this slice asks the question on #153 and does not answer it"
+      - "GitHub Projects, milestones, or label automation"
+    acceptance_criteria:
+      - "no open issue lacks a severity label"
+      - "no open issue describes a defect that dev already fixes"
+      - "the label definitions are documented and the release checklist points at the query that answers the §114 bug gate"
+      - "docs/ROADMAP.md agrees with roadmap.yaml on slices and on recorded releases"
+    required_tests:
+      - none — documentation and issue-tracker changes only; the existing suites stay green
+    expected_artifacts:
+      - planning/roadmap.yaml
+      - docs/ROADMAP.md
+      - docs/DEVELOPMENT.md
+      - docs/RELEASE.md
+    preferred_agent: opus
+    risk_level: low
+    notes: "First slice after v0.3.2, opened because every phase-plan slice is merged and the road to v1.0.0 runs through SPEC §114, whose bug gate needs a severity vocabulary to be answerable. Triage outcome on 2026-09-04: 20 open issues, 8 closed as already fixed, 12 labeled; none critical, one high (#153, a release-gate decision, not a defect), five medium (#104, #105, #114, #129, #145), six low. Owner statement recorded the same day: the production runtime is now a Raspberry Pi 5 with an SSD. Added by Fable outside the phase plan."
 
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,


### PR DESCRIPTION
## Slice 067 — Open-issue severity triage

Closes #157.

Every phase-plan slice is merged and v0.3.2 is out, so the road to v1.0.0 runs through SPEC §114. Its "no known critical/high-severity product bugs" checkbox was unanswerable: 20 open issues, none labeled, eight of them already fixed by merged slices whose PRs carried no closing keyword.

**Tracker (on GitHub, verified against `dev` before each label):**
- Closed as already fixed, each with a comment naming the fixing PR: #91 (slice 038, PR #94), #101 (slice 060), #111 (slice 055, PR #124), #107 / #115 / #116 / #117 / #121 (slice 058, PR #131). #112 stays open with a comment saying which of its three items remain.
- Labeled the remaining 12 with exactly one `severity:*`, a type label, and `release-gate` / `decision` where they apply, each with a rationale comment. Outcome: 0 critical · 1 high (#153, a release-gate **decision**, not a defect) · 5 medium (#104, #105, #114, #129, #145) · 6 low.
- The §114 bug-gate query `label:severity:critical,severity:high label:bug` returns nothing today.

**Repo:**
- `docs/DEVELOPMENT.md`: label definitions under GitHub Issues.
- `docs/RELEASE.md`: the §114 bug checkbox names the query that answers it.
- `planning/roadmap.yaml` + `docs/ROADMAP.md`: slice 067 recorded; ROADMAP.md's release-checkpoints table re-synced with the releases the YAML already records (it still listed the never-shipped v0.2–v0.5 phase themes; SPEC §92).

**Runtime environment note:** the owner's production host is now a Raspberry Pi 5 with an SSD (the §5.5 baseline hardware). SPEC §5/§114 still name the Pi 4, so #153 is now labeled `release-gate` + `decision` with the two options stated; this slice does not amend the SPEC.

No code, no migration, no tests changed; documentation and tracker only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHktB3arcz5Hwr34nYArtJ