### PR TITLE
feat: route enrichment credit economy and airport names (slice 070)

### DIFF
--- a/backend/src/flightsite/airports/index.py
+++ b/backend/src/flightsite/airports/index.py
@@ -114,16 +114,24 @@ class AirportIndex:
             which the repository makes deterministic by loading in ident order.
     """
 
-    __slots__ = ("_by_ident", "_cells", "_size")
+    __slots__ = ("_by_iata", "_by_ident", "_cells", "_size")
 
     def __init__(self, airports: Iterable[AirportRecord] = ()) -> None:
         cells: dict[tuple[int, int], list[AirportRecord]] = {}
         by_ident: dict[str, AirportRecord] = {}
+        by_iata: dict[str, AirportRecord] = {}
         for airport in airports:
             by_ident[airport.ident] = airport
+            if airport.iata is not None:
+                # First writer wins, and the repository loads in ident order,
+                # so a duplicated IATA code — upstream has a handful — resolves
+                # to the same field on every rebuild rather than to whichever
+                # row happened to be read second.
+                by_iata.setdefault(airport.iata, airport)
             cells.setdefault((_lat_cell(airport.lat), _lon_cell(airport.lon)), []).append(airport)
         self._cells = cells
         self._by_ident = by_ident
+        self._by_iata = by_iata
         self._size = len(by_ident)
 
     def __len__(self) -> int:
@@ -141,6 +149,27 @@ class AirportIndex:
         stored ``inferred_airport_ident`` gets a name back without a query.
         """
         return self._by_ident.get(ident.upper())
+
+    def name_for(self, ident: str) -> str | None:
+        """This field's name, or ``None`` if the local dataset has no such field.
+
+        The lookup behind the ``origin_name``/``destination_name`` members of
+        ``docs/API.md`` §2.6's ``route`` block, and it is on the live path: the
+        aircraft serializer calls it twice per aircraft per ~1 Hz frame, so it
+        is a dictionary access and never a query.
+
+        ICAO first, then IATA, because a route ident is whichever of the two
+        the provider had (:mod:`flightsite.enrichment.aerodatabox` prefers ICAO
+        and falls back to IATA), and both keys are already in memory.
+        ``.upper()`` is a fallback rather than the first move: every stored
+        ident is normalized upper-case (:mod:`flightsite.airports.records`) and
+        so is every enriched one, so the common call allocates nothing.
+        """
+        record = self._by_ident.get(ident) or self._by_iata.get(ident)
+        if record is None:
+            key = ident.upper()
+            record = self._by_ident.get(key) or self._by_iata.get(key)
+        return None if record is None else record.name
 
     def nearest(self, position: Position, *, within_nm: float) -> NearestAirport | None:
         """The closest airport within ``within_nm``, or ``None`` if none is.

--- a/backend/src/flightsite/airports/service.py
+++ b/backend/src/flightsite/airports/service.py
@@ -198,6 +198,24 @@ class AirportContextService:
         """
         return self._answers.get(icao)
 
+    def name_for(self, ident: str) -> str | None:
+        """The local name of the airport with this ident, or ``None``.
+
+        The lookup behind ``route.origin_name``/``route.destination_name``
+        (``docs/API.md`` §2.6). Unrelated to the nearest-airport inference this
+        service otherwise makes: it answers a question about an ident somebody
+        *else* supplied — the route enrichment provider — from the same
+        in-memory dataset, and it makes no claim of its own.
+
+        A dictionary access on
+        :meth:`~flightsite.airports.index.AirportIndex.name_for`, with no
+        ``await`` and no session, because the live aircraft serializer calls it
+        twice per aircraft per frame. ``None`` on an install that has never
+        imported the airport dataset, and for any ident the dataset does not
+        carry.
+        """
+        return self._index.name_for(ident)
+
     # ------------------------------------------------------------- lifecycle
 
     async def start(self) -> None:

--- a/backend/src/flightsite/api/context.py
+++ b/backend/src/flightsite/api/context.py
@@ -16,8 +16,9 @@ lifespan hook has started anything.
 
 Nothing here touches SQLite on the aircraft path — the live registry answers
 from memory, and so do the metadata cache, the airport context service's
-in-memory index, and the persistence worker's accumulators (which carry the
-open sighting's id and its enriched route), which is the invariant
+in-memory index (which also names a route's origin and destination airports),
+and the persistence worker's accumulators (which carry the open sighting's id
+and its enriched route), which is the invariant
 ``docs/ARCHITECTURE.md`` §3.1 states as "no live request or decoder poll ever
 waits on SQLite" and §3.3 restates as "metadata joins and rarity checks hit a
 cache, not the database". The one database read in this module is T0 for the
@@ -240,6 +241,7 @@ class LiveApiContext:
                 metadata=cache.get(record.icao),
                 route=worker.route_for(record.icao),
                 airport=airports.context_for(record.icao),
+                airport_names=airports.name_for,
                 watchlists=watchlists.matches(record.icao),
                 interesting=alerts.interesting(record.icao),
             )
@@ -285,6 +287,7 @@ class LiveApiContext:
                 metadata=cache.get(record.icao),
                 route=worker.route_for(record.icao),
                 airport=airports.context_for(record.icao),
+                airport_names=airports.name_for,
                 watchlists=watchlists.matches(record.icao),
                 interesting=interesting,
             )
@@ -319,6 +322,7 @@ class LiveApiContext:
                         metadata=cache.get(icao),
                         route=worker.route_for(icao),
                         airport=airports.context_for(icao),
+                        airport_names=airports.name_for,
                         watchlists=watchlists.matches(icao),
                         interesting=alerts.interesting(icao),
                     )
@@ -445,7 +449,9 @@ class LiveApiContext:
         is_open = row["ended_ms"] is None
         events = await repository.get_events(sighting_id)
         path = await repository.get_path(sighting_id, is_open=is_open)
-        return sighting_detail_payload(row, events=events, path=path)
+        return sighting_detail_payload(
+            row, events=events, path=path, airport_names=self.airports.name_for
+        )
 
     # ------------------------------------------------------------ analytics
 

--- a/backend/src/flightsite/api/internal.py
+++ b/backend/src/flightsite/api/internal.py
@@ -85,7 +85,7 @@ from flightsite.api.serializers import iso_utc
 from flightsite.config import ConfigError, ConfigStore, ReceiverSettings, Settings
 from flightsite.db import from_epoch_ms, utc_now_ms
 from flightsite.enrichment import EnrichmentService
-from flightsite.enrichment.service import build_provider
+from flightsite.enrichment.service import build_economy, build_provider
 from flightsite.ingest import ConnectionTestResult, DecoderEndpoint, Position, check_connection
 from flightsite.live import LiveStore
 from flightsite.metadata import ImportRun, MetadataService
@@ -339,19 +339,21 @@ async def _apply_enrichment(app: FastAPI, settings: Settings) -> None:
     yet, and the cost of dropping those is that the next observation of each
     flight queues it again.
 
-    The provider is rebuilt from ``app.state.settings``' successor rather than
-    from the request body, for the reason
-    :mod:`flightsite.api.ingestion` gives for the same choice: a running
-    install and its next boot must not read one configuration two ways.
-    :meth:`~flightsite.enrichment.EnrichmentService.apply_provider` then
-    decides what the new provider *means*, including that a save which did not
-    touch this section means nothing at all.
+    The provider and the spending plan — ``route_ttl_days`` and
+    ``daily_lookup_budget``, slice 070 — are rebuilt from
+    ``app.state.settings``' successor rather than from the request body, for
+    the reason :mod:`flightsite.api.ingestion` gives for the same choice: a
+    running install and its next boot must not read one configuration two ways.
+    :meth:`~flightsite.enrichment.EnrichmentService.apply_provider` then decides
+    what the new configuration *means*, including that a save which did not
+    touch this section means nothing at all, and that a save which changed only
+    a number adopts it without restarting the worker.
     """
     enrichment: EnrichmentService | None = getattr(app.state, "enrichment", None)
     if enrichment is None:  # pragma: no cover - the app always builds the service
         return
     try:
-        await enrichment.apply_provider(build_provider(settings))
+        await enrichment.apply_provider(build_provider(settings), build_economy(settings))
     except Exception as exc:
         _apply_failed("enrichment", exc)
 

--- a/backend/src/flightsite/api/schemas.py
+++ b/backend/src/flightsite/api/schemas.py
@@ -1183,8 +1183,34 @@ class DiagnosticsNotifications(_Model):
     permission_known_by: Literal["client"] = "client"
 
 
+class DiagnosticsEnrichmentBudget(_Model):
+    """The day's lookup allowance (``enrichment.daily_lookup_budget``).
+
+    ``limit`` and ``remaining`` are ``null`` on an uncapped install — the
+    default — which is not the same as ``0``: one means there is no ceiling,
+    the other would mean the ceiling has been reached.
+    """
+
+    limit: int | None = None
+    used_today: int = 0
+    remaining: int | None = None
+    #: The next 00:00 UTC, when ``used_today`` returns to zero. The collector
+    #: always names an instant; the key is nullable for the same reason every
+    #: other one here is (§2.7 — a stable key, never a missing one).
+    resets_at: IsoTimestamp | None = None
+
+
+class DiagnosticsEnrichmentCache(_Model):
+    """How the route cache is performing (slice 070)."""
+
+    hits: int = 0
+    misses: int = 0
+    #: Rows confirmed on enough separate days to be frozen for 30 days.
+    learned: int = 0
+
+
 class DiagnosticsEnrichment(_Model):
-    """SPEC §67: enrichment failures."""
+    """SPEC §67: enrichment failures, plus what the day's credits bought."""
 
     enabled: bool = False
     running: bool = False
@@ -1193,6 +1219,8 @@ class DiagnosticsEnrichment(_Model):
     dropped: int = 0
     pending: int = 0
     failures: int = 0
+    budget: DiagnosticsEnrichmentBudget = Field(default_factory=DiagnosticsEnrichmentBudget)
+    cache: DiagnosticsEnrichmentCache = Field(default_factory=DiagnosticsEnrichmentCache)
 
 
 class DiagnosticsWebSocket(_Model):
@@ -1286,6 +1314,8 @@ __all__ = [
     "DiagnosticsDatabase",
     "DiagnosticsDecoder",
     "DiagnosticsEnrichment",
+    "DiagnosticsEnrichmentBudget",
+    "DiagnosticsEnrichmentCache",
     "DiagnosticsError",
     "DiagnosticsLive",
     "DiagnosticsMaintenance",

--- a/backend/src/flightsite/api/schemas.py
+++ b/backend/src/flightsite/api/schemas.py
@@ -68,13 +68,27 @@ class RouteView(_Model):
     deliberately a different field: SPEC §41 keeps what somebody told
     FlightSite structurally apart from what FlightSite guessed.
 
-    Both keys are always present; either may be ``null`` on its own — a
+    Both idents are always present; either may be ``null`` on its own — a
     provider that named one airport and not the other is reporting half a
     route, which is information, not an error.
+
+    ``origin_name`` and ``destination_name`` (slice 070) are those idents
+    resolved against the **local** ``airports`` table (slice 027), which is the
+    only place FlightSite looks: no second provider call, and no name at all
+    until an airports import has run. A name is therefore ``null`` far more
+    often than its ident is, and it never replaces one — a client renders the
+    name when there is one and the code when there is not.
     """
 
     origin: str | None = None
+    #: Local name of :attr:`origin`, or ``null`` when the ident is unknown
+    #: locally (or absent). Carries no provenance of its own: the ident's
+    #: ``route`` entry names where the route came from, and this is a label
+    #: for it, not a second claim.
+    origin_name: str | None = None
     destination: str | None = None
+    #: Local name of :attr:`destination` — see :attr:`origin_name`.
+    destination_name: str | None = None
 
 
 class NearestAirportView(_Model):

--- a/backend/src/flightsite/api/serializers.py
+++ b/backend/src/flightsite/api/serializers.py
@@ -38,6 +38,16 @@ aircraft is low near a field. Everything inside it is attributed
 ``heuristic`` — SPEC §41 requires the inference to be clearly labeled, and
 §2.6's own example names exactly this provenance key.
 
+Slice 070 adds ``origin_name`` and ``destination_name`` inside ``route``. They
+are looked up through an injected :data:`AirportNameLookup` — in the running
+app the airport index's own
+:meth:`~flightsite.airports.service.AirportContextService.name_for` — rather
+than fetched here, for the same reason the metadata is passed in: this function
+runs once per aircraft per ~1 Hz delta frame, so the lookup has to be a
+dictionary access and can never be a query or a provider call. Nothing was
+removed to make room: the two idents stay exactly where they were, and a client
+that only knows about them is unaffected.
+
 Slice 037 adds ``watchlists``: always a list, ``[]`` when nothing matches,
 never absent — the same always-present, empty-when-none shape §2.7's null
 pattern takes for a list rather than a scalar. ``docs/API.md`` §5 notes an
@@ -100,7 +110,7 @@ decoder values.
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Any, Final
 
@@ -170,6 +180,24 @@ BEARING_DECIMALS: Final = 2
 #: the whole deserves.
 NEAREST_AIRPORT_PROVENANCE: Final = "heuristic"
 
+#: How a payload asks for an airport's local name, given its ident. Injected
+#: rather than imported so this module keeps its "no application state, no
+#: database" property: in the running app it is
+#: :meth:`~flightsite.airports.service.AirportContextService.name_for`, a
+#: dictionary access over the in-memory airport index (slice 027); in a test it
+#: is whatever the test wants it to be.
+type AirportNameLookup = Callable[[str], str | None]
+
+
+def no_airport_names(ident: str) -> None:
+    """The default :data:`AirportNameLookup`: nothing is known locally.
+
+    What an install that has never imported the airport dataset answers, and
+    what a caller with no index to hand gets — the same ``null`` either way,
+    because §2.7 makes "unknown" one answer rather than several.
+    """
+    return None
+
 
 def iso_utc(moment: datetime) -> str:
     """Format an instant as ``docs/API.md`` §2.2 UTC ISO-8601.
@@ -202,18 +230,44 @@ def _round(value: float | None, decimals: int) -> float | None:
     return None if value is None else round(value, decimals)
 
 
-def _route(route: SightingRoute | None) -> dict[str, str | None]:
-    """The §2.6 ``route`` block: both keys always, values ``null`` if unknown.
+def route_block(
+    origin: str | None,
+    destination: str | None,
+    airport_names: AirportNameLookup,
+) -> dict[str, str | None]:
+    """The §2.6 ``route`` block: four keys always, values ``null`` if unknown.
 
     A stable object rather than a nullable one. "No route yet", "not an airline
     flight", "enrichment is off" and "nobody has a route for this flight" are
     four different reasons for the same display, and a client that has to
     distinguish an absent block from a block of nulls before it can render
     *Unknown* is carrying that distinction for nothing (§2.7).
+
+    ``origin_name`` and ``destination_name`` are those same idents looked up in
+    the **local** ``airports`` table (slice 027) — never a second provider call
+    and never a database read. An ident the local dataset does not carry, and
+    every ident at all on an install that has never run an airports import,
+    names ``null``; the ident itself is still published, so a client renders the
+    code it has rather than nothing. A name is a label for an ident somebody
+    else reported, not a claim of FlightSite's own, so it carries no provenance
+    entry separate from ``route``'s.
+
+    ``airport_names`` is called at most twice, and only for an ident that is
+    actually there — see the module docstring on what that costs per frame.
     """
+    return {
+        "origin": origin,
+        "origin_name": None if origin is None else airport_names(origin),
+        "destination": destination,
+        "destination_name": None if destination is None else airport_names(destination),
+    }
+
+
+def _route(route: SightingRoute | None, airport_names: AirportNameLookup) -> dict[str, str | None]:
+    """:func:`route_block` for the live payload's in-memory route record."""
     if route is None:
-        return {"origin": None, "destination": None}
-    return {"origin": route.origin_ident, "destination": route.destination_ident}
+        return route_block(None, None, airport_names)
+    return route_block(route.origin_ident, route.destination_ident, airport_names)
 
 
 def _nearest_airport(context: AirportContext | None) -> dict[str, Any] | None:
@@ -269,6 +323,7 @@ def aircraft_payload(
     metadata: AircraftMetadataView | None = None,
     route: SightingRoute | None = None,
     airport: AirportContext | None = None,
+    airport_names: AirportNameLookup = no_airport_names,
     watchlists: Sequence[str] = (),
     interesting: InterestingState | None = None,
 ) -> dict[str, Any]:
@@ -300,6 +355,13 @@ def aircraft_payload(
             state for most of the sky: no airport dataset imported, the
             aircraft is at cruise, or it is nowhere near a field. It serializes
             as ``nearest_airport: null``, never as a missing key.
+        airport_names: how to turn a route ident into the airport's local name
+            for §2.6's ``origin_name``/``destination_name`` (slice 070). The
+            running app passes
+            :meth:`~flightsite.airports.service.AirportContextService.name_for`,
+            a dictionary access over the same in-memory index ``airport`` comes
+            from; the default answers ``None`` for everything, which is what an
+            install with no imported airport dataset publishes anyway.
         watchlists: the names of every watchlist (SPEC §42, roadmap slice 037)
             this aircraft currently matches, from
             :meth:`~flightsite.watchlists.matcher.WatchlistMatcher.matches` —
@@ -348,7 +410,7 @@ def aircraft_payload(
         "operator": None if resolved is None else resolved.operator_name,
         "operator_group": None if metadata is None else metadata.operator_group,
         "classification": None if metadata is None else metadata.classification.payload(),
-        "route": _route(route),
+        "route": _route(route, airport_names),
         "nearest_airport": _nearest_airport(airport),
         "interesting": None if interesting is None else interesting.payload(),
         "watchlists": list(watchlists),
@@ -883,6 +945,7 @@ def sighting_detail_payload(
     *,
     events: Sequence[RowMapping],
     path: Sequence[TrackSample],
+    airport_names: AirportNameLookup = no_airport_names,
 ) -> dict[str, Any]:
     """One sighting's full detail — ``docs/API.md`` §3.6.
 
@@ -892,6 +955,10 @@ def sighting_detail_payload(
     to attribute" rule :func:`_provenance` applies to the live payload: a
     sighting with no route enrichment publishes no ``route`` provenance
     entry at all, not one naming a source for two nulls.
+
+    ``airport_names`` is the same injected lookup :func:`aircraft_payload`
+    takes, so a stored route ident is named here exactly as a live one is —
+    one block shape, one source of names (slice 070).
     """
     return {
         "id": row["id"],
@@ -902,7 +969,7 @@ def sighting_detail_payload(
         "ended_at": None if row["ended_ms"] is None else iso_utc(from_epoch_ms(row["ended_ms"])),
         "duration_s": None if row["duration_ms"] is None else row["duration_ms"] // 1000,
         "closure_reason": row["closure_reason"],
-        "route": {"origin": row["origin_ident"], "destination": row["destination_ident"]},
+        "route": route_block(row["origin_ident"], row["destination_ident"], airport_names),
         "reception": {
             "rssi_peak_db": row["rssi_peak_db"],
             "rssi_avg_db": row["rssi_avg_db"],
@@ -1091,6 +1158,7 @@ __all__ = [
     "EXPOSED_PROVENANCE_FIELDS",
     "METADATA_PROVENANCE_KEYS",
     "NEAREST_AIRPORT_PROVENANCE",
+    "AirportNameLookup",
     "activity_event_payload",
     "aircraft_detail_payload",
     "aircraft_history_row_payload",
@@ -1105,12 +1173,14 @@ __all__ = [
     "analytics_window_payload",
     "iso_utc",
     "lifetime_payload",
+    "no_airport_names",
     "receiver_lifetime_stats_payload",
     "receiver_metric_series_payload",
     "receiver_payload",
     "receiver_range_by_bearing_payload",
     "receiver_scorecard_payload",
     "receiver_signal_distribution_payload",
+    "route_block",
     "sighting_detail_payload",
     "sighting_event_payload",
     "sighting_path_point_payload",

--- a/backend/src/flightsite/app.py
+++ b/backend/src/flightsite/app.py
@@ -21,6 +21,7 @@ from flightsite.activity import (
 )
 from flightsite.airports import (
     AIRPORTS_SOURCE,
+    AirportContext,
     AirportContextService,
     AirportImportSink,
     AirportRepository,
@@ -40,7 +41,7 @@ from flightsite.db.startup import DATABASE_SUBSYSTEM
 from flightsite.demo import DEFAULT_CENTER, DemoAdapter, demo_enabled
 from flightsite.diagnostics.errors import error_ring, secrets_from_settings
 from flightsite.enrichment import EnrichmentService, RouteCacheRepository
-from flightsite.enrichment.service import build_provider
+from flightsite.enrichment.service import build_economy, build_provider
 from flightsite.ingest import IngestionService, Position
 from flightsite.ingest.health import AdapterHealth
 from flightsite.live import LiveStore
@@ -221,6 +222,56 @@ def _alert_radius(app: FastAPI) -> Callable[[], float | None]:
     def probe() -> float | None:
         settings: Settings = app.state.settings
         return settings.alert_radius_nm
+
+    return probe
+
+
+def _display_radius(app: FastAPI) -> Callable[[], float | None]:
+    """Read ``display_radius_nm`` when something needs it (slice 070).
+
+    The same shape and the same reason as :func:`_alert_radius`: enrichment
+    ranks its pending lookups by whether an aircraft is inside the radius the
+    map is showing, and a captured value would rank them by a radius the user
+    has since changed.
+    """
+
+    def probe() -> float | None:
+        settings: Settings = app.state.settings
+        return settings.display_radius_nm
+
+    return probe
+
+
+def _aircraft_is_alerting(app: FastAPI) -> Callable[[str], bool]:
+    """Ask the alert engine whether an aircraft is matching a rule right now.
+
+    A closure rather than a dependency, so enrichment ranks its queue against
+    live alert state without holding the engine — the same reading
+    ``GET /api/v1/aircraft/interesting`` takes, through the same in-memory
+    call, and ``False`` for any aircraft the engine has no state for.
+    """
+
+    def probe(icao: str) -> bool:
+        alerts: AlertService | None = getattr(app.state, "alerts", None)
+        return alerts is not None and alerts.engine.interesting(icao) is not None
+
+    return probe
+
+
+def _airport_context(app: FastAPI) -> Callable[[str], AirportContext | None]:
+    """Read the airport-context service's latched answer for one aircraft.
+
+    Enrichment's consistency check (slice 070) needs to know where an aircraft
+    is departing from or arriving at, and that is already computed, in memory,
+    once per observation by
+    :class:`~flightsite.airports.service.AirportContextService`. Reading it
+    through a closure rather than wiring the two services together keeps the
+    dependency one-way and costs a dictionary lookup.
+    """
+
+    def probe(icao: str) -> AirportContext | None:
+        airports: AirportContextService | None = getattr(app.state, "airports", None)
+        return None if airports is None else airports.context_for(icao)
 
     return probe
 
@@ -740,11 +791,19 @@ def create_app(data_dir: str | os.PathLike[str] | None = None) -> FastAPI:
     # runtime and the guarantee above holds at every instant, not just at this
     # one.
     route_cache = RouteCacheRepository(app.state.database)
+    # The two probes are closures over `app.state`, in the `_alert_radius`
+    # style: enrichment ranks its pending lookups against live alert state and
+    # the configured display radius, and checks a cached route against the
+    # airport-context service's latched phase, without holding either service.
     app.state.enrichment = EnrichmentService(
         live=app.state.live,
         persistence=app.state.persistence,
         cache=route_cache,
         provider=build_provider(settings),
+        economy=build_economy(settings),
+        alerting=_aircraft_is_alerting(app),
+        airport_context=_airport_context(app),
+        display_radius_nm=_display_radius(app),
     )
     # Database maintenance (SPEC §70, slice 044): a sixth low-frequency task
     # running the integrity check, retention pruning, `PRAGMA optimize`, WAL

--- a/backend/src/flightsite/config/models.py
+++ b/backend/src/flightsite/config/models.py
@@ -157,15 +157,33 @@ class EnrichmentSettings(_ConfigModel):
     written to ``config.yaml`` and never serialized by
     :meth:`Settings.dump_public`.
 
-    Both fields apply on save. ``PUT /api/internal/config`` rebuilds the
-    provider from them and hands it to
+    Every field applies on save. ``PUT /api/internal/config`` rebuilds the
+    provider *and* the spending plan from them and hands both to
     :meth:`~flightsite.enrichment.EnrichmentService.apply_provider`, so
-    enabling, disabling and re-keying all take effect in the running process
-    (issue #161).
+    enabling, disabling, re-keying and re-budgeting all take effect in the
+    running process (issues #161 and #167).
+
+    The two numbers are the credit economy of slice 070, and they bound
+    spending from opposite ends. ``route_ttl_days`` decides how *often* a
+    callsign may be asked about; ``daily_lookup_budget`` decides how many
+    callsigns may be asked about at all, whatever their TTLs say. Neither is a
+    rate limit — the 10/minute burst limiter is separate and unchanged.
     """
 
     aerodatabox_enabled: bool = False
     aerodatabox_api_key: SecretStr | None = None
+    #: Days a found route stays cached. The measured saving: a scheduled
+    #: callsign heard on most days costs one lookup a week instead of one or
+    #: two a day. The default and the bounds are spelled here as literals
+    #: rather than imported from :mod:`flightsite.enrichment.cache`, which
+    #: imports this module — the same constraint ``db.models`` works under for
+    #: its ``CHECK`` vocabularies, and as there a test asserts the two agree.
+    route_ttl_days: int = Field(default=7, ge=1, le=30)
+    #: Provider lookups allowed per UTC day. ``0`` — the default — is uncapped,
+    #: which is the behaviour every install had before this setting existed;
+    #: setting it is how an owner whose feeder earns a fixed number of credits
+    #: a day stops enrichment outspending them.
+    daily_lookup_budget: int = Field(default=0, ge=0)
 
     @model_validator(mode="after")
     def _key_required_when_enabled(self) -> Self:

--- a/backend/src/flightsite/db/migrations/versions/rev_0006_route_cache.py
+++ b/backend/src/flightsite/db/migrations/versions/rev_0006_route_cache.py
@@ -30,12 +30,18 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 
-from flightsite.db.models import ROUTE_CACHE_STATUS_CHECK
-
 revision: str = "0006"
 down_revision: str | None = "0005"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
+
+#: The vocabulary **this** revision created, spelled out rather than imported
+#: from :data:`flightsite.db.models.ROUTE_CACHE_STATUS_CHECK`. A migration is a
+#: record of what an install actually ran: importing the live constant meant
+#: that when 0014 added ``restricted`` to it, a database freshly migrated to
+#: 0006 got a constraint no 0006 install ever had, and the upgrade path stopped
+#: being the one real installs take.
+_STATUS_CHECK = "status IN ('ok', 'not_found', 'error')"
 
 
 def upgrade() -> None:
@@ -48,7 +54,7 @@ def upgrade() -> None:
         sa.Column("payload_json", sa.Text(), nullable=True),
         sa.Column("fetched_ms", sa.Integer(), nullable=False),
         sa.Column("expires_ms", sa.Integer(), nullable=False),
-        sa.CheckConstraint(ROUTE_CACHE_STATUS_CHECK, name="ck_route_cache_status"),
+        sa.CheckConstraint(_STATUS_CHECK, name="ck_route_cache_status"),
         sa.PrimaryKeyConstraint("cache_key"),
         sqlite_with_rowid=False,
     )

--- a/backend/src/flightsite/db/migrations/versions/rev_0014_route_cache_economy.py
+++ b/backend/src/flightsite/db/migrations/versions/rev_0014_route_cache_economy.py
@@ -1,0 +1,128 @@
+"""Learned schedules and the restricted status on ``route_cache``.
+
+Slice 070 turns the route cache from a per-day ledger into a per-callsign one
+(``docs/DATA_MODEL.md`` §7), and two of those changes are schema:
+
+* **``confirmations`` and ``first_fetched_ms``.** A refresh that returns the
+  same pair of airports on a *different* calendar day increments the count, and
+  at three the row's expiry is pushed 30 days out. That makes a scheduled
+  service cost one lookup a month rather than one a week, and it is a fact
+  about the row, so it is stored on the row.
+* **``restricted`` joins the status vocabulary.** An HTTP 451 is the provider
+  answering that a flight is legally withheld (issue #165); before this it had
+  nowhere to be recorded, so one business jet was re-requested nine times in
+  twelve minutes and tripped the circuit breaker twice.
+
+Why the table is rebuilt rather than altered
+--------------------------------------------
+
+SQLite cannot alter a ``CHECK`` constraint in place, and ``route_cache`` is
+``WITHOUT ROWID`` — which Alembic's batch mode reconstructs from *reflection*,
+where neither the ``WITHOUT ROWID`` clause nor the check predicate survives
+reliably. So the rebuild is spelled out: create the new shape, copy every row
+into it, drop the old table, rename. The copy is a plain ``INSERT ... SELECT``
+over a table bounded by expiry-pruning to at most a few thousand rows.
+
+The rows carried over keep their day-bucketed keys (``DAL1234:2026-09-03``).
+They are deliberately not rewritten: they expire within hours of the upgrade
+and the reader never asks for them again, whereas a rewrite would have to
+choose which of a callsign's several dated rows became the undated one.
+
+Revision ID: 0014
+Revises: 0013
+Created: 2026-09-04
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0014"
+down_revision: str | None = "0013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "route_cache"
+_TEMPORARY = "route_cache_rebuild"
+_INDEX = "ix_route_cache_expiry"
+
+#: The vocabulary this revision installs, and the one it restores on the way
+#: down. Both are spelled out rather than imported from
+#: :data:`flightsite.db.models.ROUTE_CACHE_STATUS_CHECK`: a migration records
+#: what an install ran, so a later slice adding a status must not retroactively
+#: change what this one created. A drift test at head keeps the two in step.
+_STATUS_CHECK = "status IN ('ok', 'not_found', 'restricted', 'error')"
+_PREVIOUS_STATUS_CHECK = "status IN ('ok', 'not_found', 'error')"
+
+#: Columns every version of the table shares, in the order both copies use.
+_CARRIED = (
+    "cache_key",
+    "status",
+    "origin_ident",
+    "destination_ident",
+    "payload_json",
+    "fetched_ms",
+    "expires_ms",
+)
+
+
+def _create(name: str, *, status_check: str, learned: bool) -> None:
+    """Create one shape of ``route_cache`` under ``name``."""
+    columns: list[Any] = [
+        sa.Column("cache_key", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("origin_ident", sa.Text(), nullable=True),
+        sa.Column("destination_ident", sa.Text(), nullable=True),
+        sa.Column("payload_json", sa.Text(), nullable=True),
+        sa.Column("fetched_ms", sa.Integer(), nullable=False),
+        sa.Column("expires_ms", sa.Integer(), nullable=False),
+    ]
+    if learned:
+        columns.extend(
+            (
+                sa.Column(
+                    "confirmations", sa.Integer(), nullable=False, server_default=sa.text("0")
+                ),
+                sa.Column("first_fetched_ms", sa.Integer(), nullable=True),
+            )
+        )
+    op.create_table(
+        name,
+        *columns,
+        sa.CheckConstraint(status_check, name="ck_route_cache_status"),
+        sa.PrimaryKeyConstraint("cache_key"),
+        sqlite_with_rowid=False,
+    )
+
+
+def _copy(source: str, destination: str) -> None:
+    """Move every row of ``source`` into ``destination``, shared columns only."""
+    carried = ", ".join(_CARRIED)
+    op.execute(f"INSERT INTO {destination} ({carried}) SELECT {carried} FROM {source}")
+
+
+def _replace(*, status_check: str, learned: bool) -> None:
+    """Rebuild ``route_cache`` into the requested shape, keeping its rows."""
+    op.drop_index(_INDEX, table_name=_TABLE)
+    _create(_TEMPORARY, status_check=status_check, learned=learned)
+    _copy(_TABLE, _TEMPORARY)
+    op.drop_table(_TABLE)
+    op.rename_table(_TEMPORARY, _TABLE)
+    op.create_index(_INDEX, _TABLE, ["expires_ms"])
+
+
+def upgrade() -> None:
+    _replace(status_check=_STATUS_CHECK, learned=True)
+
+
+def downgrade() -> None:
+    # A `restricted` row cannot exist under the older CHECK, and it is a cache
+    # entry: deleting it costs one lookup the next time that callsign is heard,
+    # which is exactly what the build being downgraded to would have done with
+    # the 451 anyway.
+    op.execute(f"DELETE FROM {_TABLE} WHERE status = 'restricted'")
+    _replace(status_check=_PREVIOUS_STATUS_CHECK, learned=False)

--- a/backend/src/flightsite/db/models.py
+++ b/backend/src/flightsite/db/models.py
@@ -136,18 +136,21 @@ METADATA_SOURCE_STATUS_CHECK: Final[str] = "status IN ('never_run', 'ok', 'faile
 #: The ``route_cache.status`` vocabulary of ``docs/DATA_MODEL.md`` §7, spelled
 #: as the SQL ``CHECK`` predicate.
 #:
-#: All three values are constrained from birth. Slice 026 writes ``ok`` and
-#: ``not_found``: it never records a *provider unavailability* — a timeout, a
-#: 429, a 5xx, an open circuit — because those say nothing about the callsign
-#: and caching them would turn one bad minute into hours of false "no route".
-#: ``error`` is the shape reserved for the different case of a provider that
-#: answers definitively and unusably for a particular key, the same way
-#: :data:`CLOSURE_REASON_CHECK` carried values before the code that writes them
-#: existed. The runtime enum is
+#: Every value is constrained from birth. Slice 026 wrote ``ok`` and
+#: ``not_found``, and slice 070 added ``restricted``: what none of them records
+#: is a *provider unavailability* — a timeout, a 429, a 5xx, an open circuit —
+#: because those say nothing about the callsign and caching them would turn one
+#: bad minute into hours of false "no route". ``restricted`` is the opposite
+#: case and belongs here for exactly that reason: an HTTP 451 is the provider
+#: answering, definitively, that this flight is legally withheld (issue #165),
+#: so it is cached like any other answer. ``error`` remains the shape reserved
+#: for a provider answering definitively and unusably for a particular key, the
+#: same way :data:`CLOSURE_REASON_CHECK` carried values before the code that
+#: writes them existed. The runtime enum is
 #: :class:`flightsite.enrichment.model.RouteCacheStatus`; as with
 #: :data:`CLOSURE_REASON_CHECK` it cannot be imported here (``enrichment``
 #: depends on ``db``, not the reverse), so a test asserts the two agree.
-ROUTE_CACHE_STATUS_CHECK: Final[str] = "status IN ('ok', 'not_found', 'error')"
+ROUTE_CACHE_STATUS_CHECK: Final[str] = "status IN ('ok', 'not_found', 'restricted', 'error')"
 
 #: The ``watchlist_entries.kind`` vocabulary of ``docs/DATA_MODEL.md`` §4.1 /
 #: SPEC §42, spelled as the SQL ``CHECK`` predicate.
@@ -727,14 +730,20 @@ class RouteCache(Base):
     about at most once per key, however many sightings, restarts or aircraft
     ask about it.
 
-    The key is a **normalized callsign plus a UTC date bucket** (§7). The date
-    is part of the key rather than an implicit TTL because the fact being cached
-    is a fact about a *flight on a day* — ``DAL1234`` flies a different pair of
-    airports next week — so a key that omitted it would eventually serve a
-    correct answer to the wrong question. ``expires_ms`` then bounds staleness
-    *within* a day, and is shorter for a negative result than for a positive
-    one: "no route yet" is often a schedule that has not been filed, and is
-    worth re-asking about later in the day.
+    The key is the **normalized callsign**, and nothing else (§7). It carried a
+    UTC date bucket until slice 070 measured what that cost on the owner's
+    receiver: 62 % of a day's airline callsigns had been seen the previous day,
+    so a dated key was buying the same answer again every morning at ~190
+    lookups an hour. ``expires_ms`` is now the whole of the staleness rule —
+    ``enrichment.route_ttl_days`` (default 7) for an answer, 24 h for a
+    "no route yet" that is often just an unfiled schedule.
+
+    ``confirmations`` counts the separate calendar days a refresh has returned
+    the *same* pair of airports; at three the row is frozen for 30 days, which
+    is how a scheduled service earns its place without being re-bought weekly.
+    ``first_fetched_ms`` records when the answer now stored was first seen, so
+    that run of confirmations is legible after the fact. A differing answer
+    resets both.
 
     ``WITHOUT ROWID`` with the text key as the primary key: every access is a
     point lookup by that key, and the table is small — one row per airline
@@ -761,6 +770,14 @@ class RouteCache(Base):
     payload_json: Mapped[str | None] = mapped_column(Text)
     fetched_ms: Mapped[int] = mapped_column(Integer, nullable=False)
     expires_ms: Mapped[int] = mapped_column(Integer, nullable=False)
+    #: Separate calendar days a refresh has confirmed the stored answer.
+    confirmations: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    #: When the answer now stored was first reported. Nullable because rows
+    #: written before revision 0014 have no such record and inventing one
+    #: would be a claim about a past this build did not observe.
+    first_fetched_ms: Mapped[int | None] = mapped_column(Integer)
 
     def __repr__(self) -> str:  # pragma: no cover - debugging aid
         return f"RouteCache(cache_key={self.cache_key!r}, status={self.status!r})"

--- a/backend/src/flightsite/diagnostics/service.py
+++ b/backend/src/flightsite/diagnostics/service.py
@@ -436,8 +436,21 @@ def _websocket_section(app: FastAPI, counter_values: Mapping[str, int]) -> dict[
     }
 
 
-def _enrichment_section(app: FastAPI, counter_values: Mapping[str, int]) -> dict[str, Any]:
-    """SPEC §67: enrichment failures."""
+def _enrichment_section(
+    app: FastAPI, counter_values: Mapping[str, int], now: datetime
+) -> dict[str, Any]:
+    """SPEC §67: enrichment failures, and what the day's credits went on.
+
+    ``budget`` and ``cache`` were added by slice 070 for the Health page's
+    enrichment card. Both are read from the service's own memory — the budget
+    ledger is refreshed from ``route_cache`` at start and at midnight, not per
+    request — so this stays what the endpoint promises to be: no query, no
+    writer session, nothing a diagnostics poll can make expensive.
+
+    ``limit`` and ``remaining`` are ``null`` on an uncapped install, which is
+    the default and is not the same as ``0``: one means "no ceiling", the other
+    would mean "no lookups left today".
+    """
     service = _state(app, "enrichment")
     return {
         "enabled": bool(getattr(service, "enabled", False)),
@@ -447,7 +460,45 @@ def _enrichment_section(app: FastAPI, counter_values: Mapping[str, int]) -> dict
         "dropped": int(getattr(service, "dropped", 0)),
         "pending": int(getattr(service, "pending", 0)),
         "failures": counter_values.get("enrichment_failures", 0),
+        "budget": _enrichment_budget(getattr(service, "budget", None), now),
+        "cache": _enrichment_cache(getattr(service, "cache_stats", None)),
     }
+
+
+def _enrichment_budget(budget: Any, now: datetime) -> dict[str, Any]:
+    """The daily lookup budget, or an uncapped one when there is no service."""
+    if budget is None:
+        return {
+            "limit": None,
+            "used_today": 0,
+            "remaining": None,
+            "resets_at": _iso(_next_utc_midnight(now)),
+        }
+    limit = budget.limit
+    remaining = budget.remaining
+    return {
+        "limit": None if limit is None else int(limit),
+        "used_today": int(budget.used_today),
+        "remaining": None if remaining is None else int(remaining),
+        "resets_at": _iso_from_ms(budget.resets_at_ms),
+    }
+
+
+def _enrichment_cache(stats: Any) -> dict[str, int]:
+    """Cache hits, misses and learned schedules."""
+    if stats is None:
+        return {"hits": 0, "misses": 0, "learned": 0}
+    return {
+        "hits": int(stats.hits),
+        "misses": int(stats.misses),
+        "learned": int(stats.learned),
+    }
+
+
+def _next_utc_midnight(now: datetime) -> datetime:
+    """The next 00:00 UTC after ``now``."""
+    midnight = now.astimezone(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    return midnight + timedelta(days=1)
 
 
 def _error_payload(entry: RecentError) -> dict[str, Any]:
@@ -558,7 +609,7 @@ async def collect_diagnostics(
         },
         "metadata": metadata,
         "notifications": _notifications_section(settings),
-        "enrichment": _enrichment_section(app, counter_values),
+        "enrichment": _enrichment_section(app, counter_values, moment),
         "websocket": _websocket_section(app, counter_values),
         "counters": dict(counter_values),
         "recent_errors": _recent_errors(buffer),

--- a/backend/src/flightsite/enrichment/__init__.py
+++ b/backend/src/flightsite/enrichment/__init__.py
@@ -19,7 +19,7 @@ Module map:
 ========================================== =====================================
 Module                                     Responsibility
 ========================================== =====================================
-:mod:`~flightsite.enrichment.model`        the three answers a lookup can give
+:mod:`~flightsite.enrichment.model`        the four answers a lookup can give
 :mod:`~flightsite.enrichment.policy`       who may be looked up, under what key
 :mod:`~flightsite.enrichment.provider`     the ``RouteEnrichmentProvider`` protocol
 :mod:`~flightsite.enrichment.aerodatabox`  the one implementation, and the key
@@ -42,7 +42,8 @@ the database through
 persistence worker's cycle rather than opening a writer session of their own.
 
 **It never invents a route.** A provider that cannot be reached, answers with
-an error, or reports no airports leaves the sighting's route columns ``NULL``.
+an error, withholds a flight for legal reasons, or reports no airports leaves
+the sighting's route columns ``NULL``.
 There is exactly one place a route can be written from
 (:meth:`~flightsite.enrichment.service.EnrichmentService._apply`) and exactly
 one thing it can write: what the provider said. SPEC §28's *Unknown when
@@ -68,10 +69,14 @@ from flightsite.enrichment.aerodatabox import (
     parse_route,
 )
 from flightsite.enrichment.cache import (
+    DEFAULT_ROUTE_TTL_DAYS,
+    LEARNED_CONFIRMATIONS,
+    LEARNED_TTL_S,
     NEGATIVE_TTL_S,
     POSITIVE_TTL_S,
     CachedRoute,
     RouteCacheRepository,
+    RouteWrite,
 )
 from flightsite.enrichment.limits import (
     DEFAULT_COOLDOWN_S,
@@ -86,31 +91,49 @@ from flightsite.enrichment.model import (
     RouteInfo,
     RouteLookup,
     RouteNotFound,
+    RouteRestricted,
     RouteUnavailable,
 )
-from flightsite.enrichment.policy import cache_key, eligible_callsign, normalize_callsign
+from flightsite.enrichment.policy import (
+    cache_key,
+    contradicts_route,
+    eligible_callsign,
+    normalize_callsign,
+)
 from flightsite.enrichment.provider import RouteEnrichmentProvider
 from flightsite.enrichment.service import (
+    BUDGET_EXHAUSTED_EVENT,
     ENRICHMENT_FAILURES_COUNTER,
+    BudgetStatus,
+    CacheStats,
+    EnrichmentEconomy,
     EnrichmentService,
+    build_economy,
     build_provider,
 )
 
 __all__ = [
     "API_BASE_URL",
     "API_KEY_HEADER",
+    "BUDGET_EXHAUSTED_EVENT",
     "DEFAULT_COOLDOWN_S",
     "DEFAULT_FAILURE_THRESHOLD",
     "DEFAULT_RATE_PER_MINUTE",
+    "DEFAULT_ROUTE_TTL_DAYS",
     "ENRICHMENT_FAILURES_COUNTER",
     "FLIGHT_BY_CALLSIGN_PATH",
+    "LEARNED_CONFIRMATIONS",
+    "LEARNED_TTL_S",
     "NEGATIVE_TTL_S",
     "POSITIVE_TTL_S",
     "REQUEST_TIMEOUT_S",
     "ROUTE_SOURCE_AERODATABOX",
     "AeroDataBoxProvider",
+    "BudgetStatus",
+    "CacheStats",
     "CachedRoute",
     "CircuitBreaker",
+    "EnrichmentEconomy",
     "EnrichmentService",
     "RouteCacheRepository",
     "RouteCacheStatus",
@@ -118,10 +141,14 @@ __all__ = [
     "RouteInfo",
     "RouteLookup",
     "RouteNotFound",
+    "RouteRestricted",
     "RouteUnavailable",
+    "RouteWrite",
     "TokenBucket",
+    "build_economy",
     "build_provider",
     "cache_key",
+    "contradicts_route",
     "eligible_callsign",
     "normalize_callsign",
     "parse_route",

--- a/backend/src/flightsite/enrichment/aerodatabox.py
+++ b/backend/src/flightsite/enrichment/aerodatabox.py
@@ -31,7 +31,10 @@ tell the user which kind of key they hold.
 The response is a **bare JSON array** of flight objects. Departure and arrival
 are top-level siblings, each with an ``airport`` carrying ``icao`` and ``iata``.
 ``204 No Content`` means no flight matched; a ``200`` with an empty array means
-the same thing and is treated identically.
+the same thing and is treated identically. ``451`` means the flight is legally
+withheld, which is an answer about that callsign rather than a failure of the
+API, and is reported as :class:`~flightsite.enrichment.model.RouteRestricted`
+(issue #165).
 
 What is sent, and what is not
 -----------------------------
@@ -66,6 +69,7 @@ from flightsite.enrichment.model import (
     RouteInfo,
     RouteLookup,
     RouteNotFound,
+    RouteRestricted,
     RouteUnavailable,
 )
 
@@ -96,6 +100,14 @@ CONNECT_TIMEOUT_S: Final = 5.0
 
 #: HTTP statuses this provider treats as "asked and answered, no route".
 _NOT_FOUND_STATUSES: Final[frozenset[int]] = frozenset({204, 404})
+
+#: ``451 Unavailable For Legal Reasons``: AeroDataBox withholds some flights —
+#: private and government movements under national blocking programmes. It is a
+#: *definitive* answer about one callsign, and issue #165 is what happened while
+#: it was read as a server error: one business jet was re-requested nine times
+#: in twelve minutes and tripped the circuit breaker twice, because a fact about
+#: that flight was being counted as evidence about the provider.
+_RESTRICTED_STATUS: Final = 451
 
 #: Extras kept in ``route_cache.payload_json`` for diagnostics: what the
 #: provider called the flight, and what state it said it was in.
@@ -253,6 +265,11 @@ class AeroDataBoxProvider:
 
         if response.status_code in _NOT_FOUND_STATUSES:
             return RouteNotFound()
+        if response.status_code == _RESTRICTED_STATUS:
+            # Logged like an unavailability so the line is findable, and
+            # returned as its own answer so nothing downstream treats it as one.
+            logger.info("enrichment_lookup_restricted", reason="restricted", callsign=callsign)
+            return RouteRestricted()
         if response.status_code == httpx.codes.TOO_MANY_REQUESTS:
             return self._unavailable("rate_limited", callsign)
         if response.status_code >= httpx.codes.BAD_REQUEST:

--- a/backend/src/flightsite/enrichment/cache.py
+++ b/backend/src/flightsite/enrichment/cache.py
@@ -25,30 +25,57 @@ holding the write lock across anything.
 TTLs
 ----
 
-The cache key already carries a UTC date (:mod:`flightsite.enrichment.policy`),
-so an expiry is not what stops yesterday's route being served for today. What
-it does is bound staleness *within* a day, and it is deliberately asymmetric:
+The key is the callsign alone (:mod:`flightsite.enrichment.policy`), so the
+expiry is the *whole* of the staleness rule — not, as it was until slice 070, a
+bound on drift within a day whose date the key already carried. It is
+deliberately asymmetric, and the asymmetry is now measured rather than assumed:
 
-* A **found** route is stable — a filed flight rarely changes airports mid-day
-  — so :data:`POSITIVE_TTL_S` is long, and the row is usually still valid for
-  every later sighting of that flight.
-* A **missing** route is often a schedule that has not been published yet, so
-  :data:`NEGATIVE_TTL_S` is short enough that the same flight is worth asking
-  about again later in the day, and long enough that a fleet of sightings of
-  one callsign costs one request rather than dozens.
+* A **found** route holds for :data:`DEFAULT_ROUTE_TTL_DAYS` days
+  (``enrichment.route_ttl_days``, 1-30). A scheduled service flies the same
+  pair of airports for a season, and on the owner's receiver 62 % of a day's
+  airline callsigns had already been heard the day before — so a week-long
+  answer turns roughly two lookups a day into one a week for the same flight.
+* A **missing** route is often a schedule that has not been filed yet, so
+  :data:`NEGATIVE_TTL_S` is a day: long enough that a callsign nobody has a
+  route for costs one request rather than dozens, short enough that the
+  schedule is worth re-asking about tomorrow.
+* A **restricted** route (HTTP 451, issue #165) takes the *positive* TTL. It is
+  an answer about the flight — the law does not change between sightings — and
+  treating it as a failure is what let one business jet be re-requested nine
+  times in twelve minutes.
+
+Learned schedules
+-----------------
+
+A refresh that returns the same pair of airports as the stored row, on a
+**different calendar day**, increments ``confirmations``. At
+:data:`LEARNED_CONFIRMATIONS` the row is frozen for :data:`LEARNED_TTL_S` — 30
+days — because three separate days agreeing is evidence of a schedule rather
+than of a one-off, and re-buying it weekly is spending credits to learn what
+FlightSite already knows. A *differing* answer resets the count to zero and the
+row goes back to the ordinary TTL: the schedule changed, and the evidence for
+the old one is worthless. Provenance never changes — the answer is still
+AeroDataBox's, confirmed against itself, not FlightSite's own inference.
 
 An expired row is not deleted on read. It is simply not returned, and the next
 successful lookup overwrites it; :meth:`RouteCacheRepository.prune` clears the
 accumulated dead rows when maintenance asks it to.
+:meth:`RouteCacheRepository.invalidate` is the one place a *live* row is
+deleted, and it exists for the consistency check
+(:func:`flightsite.enrichment.policy.contradicts_route`): an aircraft that
+lands somewhere its cached route does not name has disproved the row, and
+waiting out the TTL would serve a wrong answer for a week.
 """
 
 from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any, Final
 
 from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from flightsite.db.engine import Database
 from flightsite.db.models import RouteCache
@@ -59,14 +86,39 @@ from flightsite.enrichment.model import (
     RouteNotFound,
 )
 
-#: How long a found route stays valid. Twelve hours: comfortably the length of
-#: any single flight, so every sighting of one flight shares one lookup, while
-#: still bounded well inside the day the key already names.
-POSITIVE_TTL_S: Final = 12 * 60 * 60
+SECONDS_PER_DAY: Final = 24 * 60 * 60
 
-#: How long a "no route" answer stays valid. One hour — see the module
+#: Default days a found route stays valid — ``enrichment.route_ttl_days``.
+#: Seven, because a scheduled flight number flies the same pair of airports for
+#: a season and the receiver hears two thirds of its callsigns again the next
+#: day; a week is long enough to collect that saving and short enough that a
+#: retimed service is corrected within one.
+DEFAULT_ROUTE_TTL_DAYS: Final = 7
+
+#: Bounds the setting accepts. Below a day the cache stops being a cache; above
+#: a month the confirmation freeze below is the better instrument.
+MIN_ROUTE_TTL_DAYS: Final = 1
+MAX_ROUTE_TTL_DAYS: Final = 30
+
+#: How long a found route stays valid when no TTL is given.
+POSITIVE_TTL_S: Final = DEFAULT_ROUTE_TTL_DAYS * SECONDS_PER_DAY
+
+#: How long a "no route" answer stays valid. Twenty-four hours — see the module
 #: docstring for the asymmetry.
-NEGATIVE_TTL_S: Final = 60 * 60
+NEGATIVE_TTL_S: Final = SECONDS_PER_DAY
+
+#: Separate calendar days of agreement that make a route a learned schedule.
+#: Three: two consecutive days is a flight that ran twice, three is a pattern,
+#: and each one costs a lookup, so the bar is set where the evidence starts
+#: being worth more than the credits proving it.
+LEARNED_CONFIRMATIONS: Final = 3
+
+#: How long a learned route holds. Thirty days: an airline schedule season is
+#: measured in months, and a month's freeze still re-checks every route often
+#: enough that a retimed service is caught within one billing period — while
+#: the consistency check catches a *changed* one the moment the aircraft flies
+#: it (:func:`flightsite.enrichment.policy.contradicts_route`).
+LEARNED_TTL_S: Final = 30 * SECONDS_PER_DAY
 
 #: Cap on the JSON kept in ``payload_json``. Provider extras are two or three
 #: short strings; anything larger is a response shape this build does not
@@ -85,15 +137,23 @@ class CachedRoute:
     destination_ident: str | None
     fetched_ms: int
     expires_ms: int
+    confirmations: int = 0
+    first_fetched_ms: int | None = None
+
+    @property
+    def learned(self) -> bool:
+        """True once enough separate days have confirmed this answer."""
+        return self.confirmations >= LEARNED_CONFIRMATIONS
 
     def as_lookup(self) -> RouteLookup:
         """The cached answer in the vocabulary a provider would have used.
 
         A stored :attr:`~flightsite.enrichment.model.RouteCacheStatus.ERROR` —
-        which this slice never writes, but which a database written by a later
-        build could hold — is reported as "no route", not as an unavailability:
-        the row records that the provider *answered*, and the honest display of
-        an answer FlightSite cannot use is Unknown (``docs/API.md`` §2.7).
+        which no slice writes, but which a database written by a later build
+        could hold — and a stored ``RESTRICTED`` are both reported as "no
+        route", not as an unavailability: the row records that the provider
+        *answered*, and the honest display of an answer FlightSite cannot use
+        is Unknown (``docs/API.md`` §2.7).
         """
         if self.status is RouteCacheStatus.OK and not (
             self.origin_ident is None and self.destination_ident is None
@@ -102,6 +162,24 @@ class CachedRoute:
                 origin_ident=self.origin_ident, destination_ident=self.destination_ident
             )
         return RouteNotFound()
+
+
+@dataclass(frozen=True, slots=True)
+class RouteWrite:
+    """What storing a route did to the row that was already there.
+
+    Returned so the service can count learned rows for diagnostics without
+    re-reading the table, and so the confirmation rule has exactly one
+    implementation — the one that had the old row in hand.
+    """
+
+    #: Separate calendar days that have now confirmed this answer.
+    confirmations: int
+    #: True when the row is frozen at :data:`LEARNED_TTL_S`.
+    learned: bool
+    #: True when *this* write is what made it learned. The transition, so a
+    #: counter can be incremented without double-counting later refreshes.
+    newly_learned: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,24 +198,45 @@ class RouteCacheRepository:
             row = await session.get(RouteCache, cache_key)
             if row is None or row.expires_ms <= now_ms:
                 return None
-            return CachedRoute(
-                status=RouteCacheStatus(row.status),
-                origin_ident=row.origin_ident,
-                destination_ident=row.destination_ident,
-                fetched_ms=row.fetched_ms,
-                expires_ms=row.expires_ms,
-            )
+            return _as_cached(row)
 
-    async def store_route(self, cache_key: str, route: RouteInfo, *, now_ms: int) -> None:
-        """Record a found route, replacing whatever was filed under the key."""
-        await self._write(
-            cache_key,
-            status=RouteCacheStatus.OK,
-            origin_ident=route.origin_ident,
-            destination_ident=route.destination_ident,
-            payload_json=_encode_extras(route.extras),
-            now_ms=now_ms,
-            ttl_s=POSITIVE_TTL_S,
+    async def store_route(
+        self, cache_key: str, route: RouteInfo, *, now_ms: int, ttl_s: int = POSITIVE_TTL_S
+    ) -> RouteWrite:
+        """Record a found route, and count the days that have confirmed it.
+
+        The confirmation rule lives here because this is the one place holding
+        both the new answer and the old row. An answer identical to the stored
+        one, first seen on a *different* UTC day, advances ``confirmations``;
+        the same answer twice in one day advances nothing, because one day
+        agreeing with itself is not a second day's evidence. A different answer
+        resets the count and the first-seen moment — the schedule changed, and
+        what was learned about the old one no longer applies.
+        """
+        async with self.database.writer_session() as session:
+            row = await session.get(RouteCache, cache_key)
+            origin = route.origin_ident
+            destination = route.destination_ident
+            was_learned = row is not None and row.confirmations >= LEARNED_CONFIRMATIONS
+            confirmations, first_fetched_ms = _confirm(row, origin, destination, now_ms=now_ms)
+            learned = confirmations >= LEARNED_CONFIRMATIONS
+            self._put(
+                session,
+                row,
+                cache_key=cache_key,
+                status=RouteCacheStatus.OK,
+                origin_ident=origin,
+                destination_ident=destination,
+                payload_json=_encode_extras(route.extras),
+                now_ms=now_ms,
+                ttl_s=LEARNED_TTL_S if learned else ttl_s,
+                confirmations=confirmations,
+                first_fetched_ms=first_fetched_ms,
+            )
+        return RouteWrite(
+            confirmations=confirmations,
+            learned=learned,
+            newly_learned=learned and not was_learned,
         )
 
     async def store_not_found(self, cache_key: str, *, now_ms: int) -> None:
@@ -155,6 +254,64 @@ class RouteCacheRepository:
             now_ms=now_ms,
             ttl_s=NEGATIVE_TTL_S,
         )
+
+    async def store_restricted(
+        self, cache_key: str, *, now_ms: int, ttl_s: int = POSITIVE_TTL_S
+    ) -> None:
+        """Record that this flight is legally withheld (HTTP 451, issue #165).
+
+        Filed at the *positive* TTL: a restriction is a property of the flight,
+        not a bad minute on the network, so it is cached as firmly as a route.
+        The row holds no idents, which is what makes the sighting read Unknown.
+        """
+        await self._write(
+            cache_key,
+            status=RouteCacheStatus.RESTRICTED,
+            origin_ident=None,
+            destination_ident=None,
+            payload_json=None,
+            now_ms=now_ms,
+            ttl_s=ttl_s,
+        )
+
+    async def invalidate(self, cache_key: str) -> bool:
+        """Delete one row outright; ``True`` if there was one.
+
+        The consistency check's only write. Unlike :meth:`prune` this deletes a
+        row that has *not* expired, because the aircraft it describes has just
+        contradicted it — see
+        :func:`flightsite.enrichment.policy.contradicts_route`.
+        """
+        statement = (
+            delete(RouteCache)
+            .where(RouteCache.cache_key == cache_key)
+            .returning(RouteCache.cache_key)
+        )
+        async with self.database.writer_session() as session:
+            return (await session.scalars(statement)).first() is not None
+
+    async def count_fetched_since(self, since_ms: int) -> int:
+        """Rows fetched at or after ``since_ms``. The daily budget's ledger.
+
+        Counted from the table rather than from a process-local tally so that
+        "lookups spent today" survives a restart: an install restarted at noon
+        must not be handed a fresh day's budget.
+        """
+        statement = (
+            select(func.count()).select_from(RouteCache).where(RouteCache.fetched_ms >= since_ms)
+        )
+        async with self.database.read_session() as session:
+            return int(await session.scalar(statement) or 0)
+
+    async def count_learned(self) -> int:
+        """Rows confirmed on enough separate days to be frozen. Diagnostics."""
+        statement = (
+            select(func.count())
+            .select_from(RouteCache)
+            .where(RouteCache.confirmations >= LEARNED_CONFIRMATIONS)
+        )
+        async with self.database.read_session() as session:
+            return int(await session.scalar(statement) or 0)
 
     async def prune(self, *, now_ms: int) -> int:
         """Delete every expired row; returns how many went.
@@ -201,28 +358,103 @@ class RouteCacheRepository:
         now_ms: int,
         ttl_s: int,
     ) -> None:
-        expires_ms = now_ms + ttl_s * MS_PER_SECOND
+        """Store an answer that carries no confirmation history of its own."""
         async with self.database.writer_session() as session:
             row = await session.get(RouteCache, cache_key)
-            if row is None:
-                session.add(
-                    RouteCache(
-                        cache_key=cache_key,
-                        status=status.value,
-                        origin_ident=origin_ident,
-                        destination_ident=destination_ident,
-                        payload_json=payload_json,
-                        fetched_ms=now_ms,
-                        expires_ms=expires_ms,
-                    )
+            self._put(
+                session,
+                row,
+                cache_key=cache_key,
+                status=status,
+                origin_ident=origin_ident,
+                destination_ident=destination_ident,
+                payload_json=payload_json,
+                now_ms=now_ms,
+                ttl_s=ttl_s,
+                confirmations=0,
+                first_fetched_ms=now_ms,
+            )
+
+    @staticmethod
+    def _put(
+        session: AsyncSession,
+        row: RouteCache | None,
+        *,
+        cache_key: str,
+        status: RouteCacheStatus,
+        origin_ident: str | None,
+        destination_ident: str | None,
+        payload_json: str | None,
+        now_ms: int,
+        ttl_s: int,
+        confirmations: int,
+        first_fetched_ms: int,
+    ) -> None:
+        """Insert or overwrite one row inside an open writer session."""
+        expires_ms = now_ms + ttl_s * MS_PER_SECOND
+        if row is None:
+            session.add(
+                RouteCache(
+                    cache_key=cache_key,
+                    status=status.value,
+                    origin_ident=origin_ident,
+                    destination_ident=destination_ident,
+                    payload_json=payload_json,
+                    fetched_ms=now_ms,
+                    expires_ms=expires_ms,
+                    confirmations=confirmations,
+                    first_fetched_ms=first_fetched_ms,
                 )
-                return
-            row.status = status.value
-            row.origin_ident = origin_ident
-            row.destination_ident = destination_ident
-            row.payload_json = payload_json
-            row.fetched_ms = now_ms
-            row.expires_ms = expires_ms
+            )
+            return
+        row.status = status.value
+        row.origin_ident = origin_ident
+        row.destination_ident = destination_ident
+        row.payload_json = payload_json
+        row.fetched_ms = now_ms
+        row.expires_ms = expires_ms
+        row.confirmations = confirmations
+        row.first_fetched_ms = first_fetched_ms
+
+
+def _as_cached(row: RouteCache) -> CachedRoute:
+    """One ORM row as the immutable value the service reads."""
+    return CachedRoute(
+        status=RouteCacheStatus(row.status),
+        origin_ident=row.origin_ident,
+        destination_ident=row.destination_ident,
+        fetched_ms=row.fetched_ms,
+        expires_ms=row.expires_ms,
+        confirmations=row.confirmations,
+        first_fetched_ms=row.first_fetched_ms,
+    )
+
+
+def utc_day_start_ms(epoch_ms: int) -> int:
+    """Midnight UTC of the day ``epoch_ms`` falls in, in epoch milliseconds.
+
+    The boundary both the daily budget and the confirmation rule are measured
+    against, in one place so the two cannot disagree about when a day begins.
+    """
+    moment = datetime.fromtimestamp(epoch_ms / MS_PER_SECOND, UTC)
+    midnight = moment.replace(hour=0, minute=0, second=0, microsecond=0)
+    return int(midnight.timestamp() * MS_PER_SECOND)
+
+
+def _confirm(
+    row: RouteCache | None, origin: str | None, destination: str | None, *, now_ms: int
+) -> tuple[int, int]:
+    """The ``(confirmations, first_fetched_ms)`` a route write should store."""
+    if row is None or row.status != RouteCacheStatus.OK.value:
+        return 0, now_ms
+    if (row.origin_ident, row.destination_ident) != (origin, destination):
+        return 0, now_ms
+    first_fetched_ms = row.first_fetched_ms if row.first_fetched_ms is not None else row.fetched_ms
+    if utc_day_start_ms(row.fetched_ms) == utc_day_start_ms(now_ms):
+        # The same day agreeing with itself. Nothing was learned, and the row
+        # keeps the count it already had.
+        return row.confirmations, first_fetched_ms
+    return row.confirmations + 1, first_fetched_ms
 
 
 def _encode_extras(extras: dict[str, str]) -> str | None:
@@ -256,11 +488,19 @@ def decode_extras(payload_json: str | None) -> dict[str, Any]:
 
 
 __all__ = [
+    "DEFAULT_ROUTE_TTL_DAYS",
+    "LEARNED_CONFIRMATIONS",
+    "LEARNED_TTL_S",
     "MAX_PAYLOAD_BYTES",
+    "MAX_ROUTE_TTL_DAYS",
+    "MIN_ROUTE_TTL_DAYS",
     "MS_PER_SECOND",
     "NEGATIVE_TTL_S",
     "POSITIVE_TTL_S",
+    "SECONDS_PER_DAY",
     "CachedRoute",
     "RouteCacheRepository",
+    "RouteWrite",
     "decode_extras",
+    "utc_day_start_ms",
 ]

--- a/backend/src/flightsite/enrichment/model.py
+++ b/backend/src/flightsite/enrichment/model.py
@@ -5,10 +5,14 @@ because the difference between them decides what happens next and a
 ``None``-returning function would erase it:
 
 * :class:`RouteInfo` — the provider named at least one airport. Applied to the
-  sighting and cached until the day's key expires.
+  sighting and cached for ``enrichment.route_ttl_days``.
 * :class:`RouteNotFound` — the provider answered, and has no route for this
   flight. Negative-cached, so a scheduled-but-unfiled callsign is asked about
   once rather than once per sighting.
+* :class:`RouteRestricted` — the provider answered ``451``: this flight is
+  legally withheld and no amount of asking will change that. Cached for the
+  *positive* TTL, because it is an answer about the flight rather than about
+  the network (issue #165).
 * :class:`RouteUnavailable` — the provider could not be asked, or could not
   answer: a timeout, a 429, a 5xx, an open circuit, a response that did not
   parse. **Never cached.** It is a statement about the network, not about the
@@ -40,16 +44,20 @@ ROUTE_SOURCE_AERODATABOX: Final = "aerodatabox"
 class RouteCacheStatus(StrEnum):
     """``route_cache.status`` (``docs/DATA_MODEL.md`` §7).
 
-    :attr:`ERROR` is part of the storage contract and is not written by this
-    slice — see :data:`flightsite.db.models.ROUTE_CACHE_STATUS_CHECK` for why
-    the vocabulary is fixed before the code that would write it exists, and why
-    an unavailable provider is deliberately not one of these.
+    :attr:`ERROR` is part of the storage contract and is not written by any
+    slice yet — see :data:`flightsite.db.models.ROUTE_CACHE_STATUS_CHECK` for
+    why the vocabulary is fixed before the code that would write it exists, and
+    why an unavailable provider is deliberately not one of these.
     """
 
     #: The provider named a route; :class:`RouteInfo` round-trips through it.
     OK = "ok"
     #: The provider answered and has no route for this flight.
     NOT_FOUND = "not_found"
+    #: The provider answered ``451``: this flight is legally restricted and it
+    #: will not name its airports (issue #165). An answer, not a failure — so
+    #: it is cached for the positive TTL and never fed to the circuit breaker.
+    RESTRICTED = "restricted"
     #: Reserved: a provider answering definitively and unusably for one key.
     ERROR = "error"
 
@@ -83,6 +91,24 @@ class RouteNotFound:
 
 
 @dataclass(frozen=True, slots=True)
+class RouteRestricted:
+    """The provider answered ``451``: this flight is legally withheld.
+
+    A distinct answer rather than a flavour of
+    :class:`RouteUnavailable`, because the two ask for opposite handling and
+    conflating them is the whole of issue #165: a restricted business jet was
+    retried nine times in twelve minutes and tripped the circuit breaker twice,
+    because a definitive answer about *one flight* was being counted as
+    evidence that *the provider* was failing.
+
+    So this is cached for the positive TTL, never counted in
+    ``enrichment_failures``, and never fed to the breaker. The sighting keeps
+    its ``NULL`` route columns and renders as Unknown, which is the honest
+    display of "the law says no" as much as of "nobody knows".
+    """
+
+
+@dataclass(frozen=True, slots=True)
 class RouteUnavailable:
     """The provider could not be asked, or could not answer.
 
@@ -96,8 +122,8 @@ class RouteUnavailable:
 
 
 #: What :meth:`~flightsite.enrichment.provider.RouteEnrichmentProvider.lookup`
-#: returns. Exhaustive: a caller matching all three has handled every case.
-RouteLookup = RouteInfo | RouteNotFound | RouteUnavailable
+#: returns. Exhaustive: a caller matching all four has handled every case.
+RouteLookup = RouteInfo | RouteNotFound | RouteRestricted | RouteUnavailable
 
 
 __all__ = [
@@ -106,5 +132,6 @@ __all__ = [
     "RouteInfo",
     "RouteLookup",
     "RouteNotFound",
+    "RouteRestricted",
     "RouteUnavailable",
 ]

--- a/backend/src/flightsite/enrichment/policy.py
+++ b/backend/src/flightsite/enrichment/policy.py
@@ -30,18 +30,29 @@ the pattern is the strict one.
 The cache key
 -------------
 
-``docs/DATA_MODEL.md`` §7 keys the cache on the normalized callsign **plus a
-date bucket**. The date is not decoration: ``DAL1234`` is a different pair of
-airports next month, so a key without it would eventually answer a question
-nobody asked. The bucket is the UTC day of the observation, which is the same
-day the provider's own schedule lookup defaults to.
+``docs/DATA_MODEL.md`` §7 keys the cache on the normalized callsign, and on
+nothing else. It carried a UTC date bucket until slice 070, on the reasoning
+that ``DAL1234`` is a different pair of airports next month — which is true,
+and was the wrong bound. Measured on the owner's receiver: 2,200-2,650 distinct
+airline callsigns a day at ~190 lookups an hour, of which **62 % had been seen
+the previous day** after only four days of history. A dated key was therefore
+re-buying two thirds of yesterday's answers every morning, to protect against a
+schedule change that happens on the scale of an airline season.
+
+So the drift is now bounded by an *expiry* rather than by the key —
+``enrichment.route_ttl_days`` (default 7) — and by two things the date bucket
+could never do: a refresh that agrees on three separate days freezes the row
+for 30 days, and an aircraft that departs or lands somewhere the cached route
+does not name invalidates it immediately
+(:func:`contradicts_route`). Rows written under the old dated keys are left to
+expire; nothing reads them again.
 """
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from typing import Final
 
+from flightsite.airports.model import AirportContext, InferredPhase
 from flightsite.classification.operators import CALLSIGN_PATTERN
 
 #: Longest callsign a decoder can legitimately transmit (ADS-B flight id is
@@ -83,22 +94,58 @@ def airline_designator(callsign: str) -> str | None:
     return None if match is None else match.group(1)
 
 
-def cache_key(callsign: str, at: datetime) -> str:
-    """The ``route_cache.cache_key`` for ``callsign`` observed at ``at``.
+def cache_key(callsign: str) -> str:
+    """The ``route_cache.cache_key`` for ``callsign``.
 
-    ``at`` must be timezone-aware; the bucket is its UTC calendar day, so two
-    observations either side of local midnight in different zones still share
-    one key when they share a UTC day.
+    The normalized callsign itself. A function rather than the bare string
+    because the key is a storage contract with one place that decides it: the
+    lookup, the write and the invalidation must agree on the spelling, and
+    three call sites normalizing on their own is how they come to disagree.
     """
-    if at.tzinfo is None:
-        raise ValueError("refusing to bucket a naive datetime; timestamps must be UTC")
-    return f"{callsign}:{at.astimezone(UTC).strftime('%Y-%m-%d')}"
+    return callsign.strip().upper()
+
+
+def contradicts_route(
+    context: AirportContext | None,
+    *,
+    origin_ident: str | None,
+    destination_ident: str | None,
+) -> bool:
+    """True when an aircraft's own behaviour disproves its cached route.
+
+    The consistency check of slice 070, and the one thing that catches a
+    changed schedule faster than the TTL does. Two readings count, both from
+    the airport-context service's *latched* phase
+    (:mod:`flightsite.airports.service`), which is an inference the trend gate
+    has already committed to:
+
+    * a **departure** from a field the cached route does not call the origin;
+    * an **arrival** at a field it does not call the destination.
+
+    Everything else is silence. A phase inferred for an unnamed half of the
+    route (a route with only a destination, say) contradicts nothing, because
+    the cache never claimed anything about that end — and a route being right
+    about one airport is not evidence against the other, which is why each
+    reading is checked against its own end alone.
+
+    Idents are compared case-insensitively and nothing is derived: an IATA code
+    cached against an ICAO-identified field reads as a contradiction, which
+    costs one lookup and is the safe direction to be wrong in.
+    """
+    if context is None or context.phase is None:
+        return False
+    departing = context.phase is InferredPhase.DEPARTING
+    expected = origin_ident if departing else destination_ident
+    if expected is None:
+        return False
+    return expected.strip().upper() != context.ident.strip().upper()
 
 
 __all__ = [
     "MAX_CALLSIGN_LENGTH",
     "airline_designator",
     "cache_key",
+    "contradicts_route",
     "eligible_callsign",
     "normalize_callsign",
 ]

--- a/backend/src/flightsite/enrichment/service.py
+++ b/backend/src/flightsite/enrichment/service.py
@@ -39,7 +39,7 @@ the queue being too small.
 The gates
 ---------
 
-Each eligible observation walks four gates, cheapest first, and the first one
+Each eligible observation walks five gates, cheapest first, and the first one
 that answers ends the walk:
 
 1. **Configuration.** Disabled, or no key, and the service does not start at
@@ -47,15 +47,52 @@ that answers ends the walk:
    is an acceptance criterion and a test.
 2. **Eligibility** (:mod:`flightsite.enrichment.policy`). Only callsigns in the
    ICAO airline-flight form are ever looked up.
-3. **Answers already held**, in memory: the last few thousand keys this process
-   has resolved. This gate is what keeps a 1 Hz observation stream from costing
-   a database read per poll for an aircraft whose route is already known — or
-   already known not to exist.
+3. **Answers already held**, in memory: the last few thousand callsigns this
+   process has resolved, each with the expiry its cache row carries. This gate
+   is what keeps a 1 Hz observation stream from costing a database read per
+   poll for an aircraft whose route is already known — or already known not to
+   exist.
 4. **The cache table** (:mod:`flightsite.enrichment.cache`), which survives a
    restart and is shared across every aircraft flying the same number.
+5. **The daily budget**, if the owner set one. A day's lookups are counted from
+   ``route_cache`` rather than from a process counter, so a restart does not
+   hand the install a fresh allowance.
 
-Only what survives all four reaches the circuit breaker, the rate limiter and
+Only what survives all five reaches the circuit breaker, the rate limiter and
 the provider.
+
+Which lookup goes first
+-----------------------
+
+The pending queue drains in priority order rather than FIFO, because a bounded
+queue that is also budget-bounded has to answer *which* callsigns the day's
+credits buy:
+
+0. an aircraft **currently matching an alert rule** — the sky FlightSite was
+   asked to care about;
+1. an aircraft inside ``display_radius_nm`` — what the map is showing now;
+2. everything else;
+3. **refreshes** of routes this process already answered once and whose answer
+   has expired. The sighting reads correctly from the row that is about to be
+   replaced, so a refresh losing a race to a first answer costs nothing.
+
+The two probes are closures over ``app.state`` in the style of
+:func:`flightsite.app._alert_radius`, not services this module depends on: the
+question "is this aircraft alerting?" is asked of whatever the app holds *now*,
+and a service constructed without them simply treats everything as tier 2.
+
+Catching a schedule change early
+--------------------------------
+
+A cached route is a claim, and the aircraft flying it can disprove that claim
+faster than any TTL. When the airport-context service latches a *departure*
+from a field the cached route does not call the origin — or an *arrival* at one
+it does not call the destination — the row is invalidated and the next
+observation buys a fresh answer
+(:func:`flightsite.enrichment.policy.contradicts_route`). Once per callsign per
+process: a route that disagrees twice is a disagreement about idents, not a
+schedule change, and re-buying it on every observation would be the retry storm
+this slice exists to stop.
 
 Configured while it runs
 ------------------------
@@ -79,12 +116,17 @@ the **oldest** key on overflow, the same policy and for the same reason as the
 live event stream: the newest sky is the one worth enriching, and a queue that
 grew without bound would trade a missing route for memory. Shedding increments
 :attr:`EnrichmentService.dropped` and logs once per episode, never once per key.
+A spent budget changes nothing about that bound: the queue keeps filling and
+shedding exactly as it does under a slow provider, and midnight finds it
+holding the newest sky rather than a day-old backlog.
 
 Failures are values, never exceptions that escape a task. A provider that
 cannot answer increments ``enrichment_failures`` and feeds the circuit breaker;
 the sighting keeps its ``Unknown`` route, which is what SPEC §28 asks for and
-what ``docs/API.md`` §2.7 makes the display of. Nothing in this module can
-write a route the provider did not report.
+what ``docs/API.md`` §2.7 makes the display of. A *restricted* flight is not
+one of those: HTTP 451 is the provider answering, so it is cached, counted in
+neither the failures nor the breaker, and left Unknown (issue #165). Nothing in
+this module can write a route the provider did not report.
 """
 
 from __future__ import annotations
@@ -99,12 +141,22 @@ from typing import Final
 
 import structlog
 
+from flightsite.airports.model import AirportContext
 from flightsite.config import Settings
 from flightsite.counters import CounterRegistry
 from flightsite.counters import counters as default_counters
 from flightsite.db.clock import utc_now_ms
 from flightsite.enrichment.aerodatabox import AeroDataBoxProvider
-from flightsite.enrichment.cache import RouteCacheRepository
+from flightsite.enrichment.cache import (
+    DEFAULT_ROUTE_TTL_DAYS,
+    LEARNED_TTL_S,
+    MS_PER_SECOND,
+    NEGATIVE_TTL_S,
+    SECONDS_PER_DAY,
+    RouteCacheRepository,
+    RouteWrite,
+    utc_day_start_ms,
+)
 from flightsite.enrichment.limits import (
     DEFAULT_COOLDOWN_S,
     DEFAULT_FAILURE_THRESHOLD,
@@ -113,8 +165,8 @@ from flightsite.enrichment.limits import (
     MonotonicClock,
     TokenBucket,
 )
-from flightsite.enrichment.model import RouteInfo, RouteUnavailable
-from flightsite.enrichment.policy import cache_key, eligible_callsign
+from flightsite.enrichment.model import RouteInfo, RouteRestricted, RouteUnavailable
+from flightsite.enrichment.policy import cache_key, contradicts_route, eligible_callsign
 from flightsite.enrichment.provider import RouteEnrichmentProvider
 from flightsite.live.aircraft import LiveAircraft
 from flightsite.live.events import (
@@ -134,8 +186,27 @@ logger = structlog.get_logger(__name__)
 #: ``/api/v1/health``.
 ENRICHMENT_FAILURES_COUNTER: Final = "enrichment_failures"
 
+#: Logged once per UTC day, the first time the budget refuses a lookup. Once,
+#: because the refusal repeats for every eligible callsign until midnight and a
+#: line per refusal would be a log flood describing one decision.
+BUDGET_EXHAUSTED_EVENT: Final = "enrichment_budget_exhausted"
+
 #: A source of UTC epoch milliseconds, injected for tests.
 EpochClock = Callable[[], int]
+
+#: "Is this aircraft matching an alert rule right now?" — a closure over
+#: ``app.state`` (:func:`flightsite.app._alert_radius`'s pattern), so the answer
+#: follows a rule list the user edits without this service holding the engine.
+AlertProbe = Callable[[str], bool]
+
+#: "What field is this aircraft at, and what is it doing there?" — the airport
+#: context service's own in-memory answer, read through a closure for the same
+#: reason.
+ContextProbe = Callable[[str], AirportContext | None]
+
+#: "How far out is the map showing?" — ``display_radius_nm``, read per drain so
+#: a saved change applies without a restart.
+RadiusProbe = Callable[[], float | None]
 
 #: Live events buffered for this service before the store sheds the oldest.
 #: Smaller than the persistence worker's: recovery from a shed event costs one
@@ -185,10 +256,45 @@ def build_provider(settings: Settings) -> RouteEnrichmentProvider | None:
     return AeroDataBoxProvider(api_key=enrichment.aerodatabox_api_key)
 
 
-def _same_configuration(
+@dataclass(frozen=True, slots=True)
+class EnrichmentEconomy:
+    """How much the owner is willing to spend, and how long an answer lasts.
+
+    The two numbers of ``enrichment.*`` that are not about *whether* to enrich
+    but about *how much*. Kept as one value object so a save carries them
+    together and :func:`_same_configuration` can compare a whole configuration
+    rather than a provider and two loose integers.
+    """
+
+    #: Days a found route stays cached (``enrichment.route_ttl_days``).
+    route_ttl_days: int = DEFAULT_ROUTE_TTL_DAYS
+    #: Provider lookups allowed per UTC day; ``0`` is uncapped.
+    daily_lookup_budget: int = 0
+
+    @property
+    def route_ttl_s(self) -> int:
+        """The positive TTL in seconds, as the cache repository takes it."""
+        return self.route_ttl_days * SECONDS_PER_DAY
+
+
+def build_economy(settings: Settings) -> EnrichmentEconomy:
+    """The spending plan the configuration describes.
+
+    The sibling of :func:`build_provider`, and called in the same two places
+    for the same reason: the running install and its next boot must not read
+    one configuration two different ways.
+    """
+    enrichment = settings.enrichment
+    return EnrichmentEconomy(
+        route_ttl_days=enrichment.route_ttl_days,
+        daily_lookup_budget=enrichment.daily_lookup_budget,
+    )
+
+
+def _same_provider(
     current: RouteEnrichmentProvider | None, candidate: RouteEnrichmentProvider | None
 ) -> bool:
-    """True when replacing ``current`` with ``candidate`` would change nothing.
+    """True when ``candidate`` would make exactly the requests ``current`` does.
 
     Configuration, not identity. Every save calls :func:`build_provider`, which
     returns a fresh object, so identity would report a change on every save of
@@ -208,18 +314,84 @@ def _same_configuration(
     return current is candidate
 
 
+def _same_configuration(
+    current: RouteEnrichmentProvider | None,
+    candidate: RouteEnrichmentProvider | None,
+    current_economy: EnrichmentEconomy,
+    candidate_economy: EnrichmentEconomy,
+) -> bool:
+    """True when applying this save would change nothing at all.
+
+    The whole configuration, not just the provider: since slice 070 a save can
+    change the TTL or the daily budget while leaving the key alone, and a
+    comparison that ignored those would quietly discard the change the owner
+    just made. What it must *not* do is conflate the two halves — a new budget
+    is a number the running worker adopts in place, while a new key is a
+    provider swap — so :meth:`EnrichmentService.apply_provider` asks
+    :func:`_same_provider` separately before it decides to restart anything.
+    """
+    return _same_provider(current, candidate) and current_economy == candidate_economy
+
+
 @dataclass(slots=True)
 class _PendingLookup:
     """One queued callsign and the aircraft waiting on its answer.
 
-    Several aircraft can share one key across a day — a flight number flown by
-    a substituted airframe, or the same flight seen twice either side of a
-    closure gap — and every sighting that was waiting deserves the answer the
-    single request bought.
+    Several aircraft can share one key — a flight number flown by a substituted
+    airframe, or the same flight seen twice either side of a closure gap — and
+    every sighting that was waiting deserves the answer the single request
+    bought.
+
+    ``refresh`` marks a lookup whose answer this process already had and has
+    since expired. It is the lowest priority precisely because it is the least
+    urgent kind of miss: something correct is already on file, and the aircraft
+    waiting on it is reading that.
     """
 
     callsign: str
     icaos: set[str] = field(default_factory=set)
+    refresh: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class _Answer:
+    """A route this process holds, and when it stops being worth holding.
+
+    The in-memory gate needed no expiry while the cache key carried a UTC date:
+    the key itself rotated at midnight and yesterday's answers were simply
+    never asked for again. With a callsign-only key it does — without one, a
+    long-running process would serve its first answer for a callsign forever
+    and the TTL would apply to the table but not to the memory in front of it.
+    """
+
+    route: RouteInfo | None
+    expires_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetStatus:
+    """What the daily lookup budget has left. Read by diagnostics."""
+
+    #: Lookups allowed today, or ``None`` when uncapped.
+    limit: int | None
+    #: Rows fetched so far in the current UTC day.
+    used_today: int
+    #: What is left, or ``None`` when uncapped. Never negative.
+    remaining: int | None
+    #: The next UTC midnight, when ``used_today`` returns to zero.
+    resets_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class CacheStats:
+    """How the cache is doing, as diagnostics reports it."""
+
+    #: Lookups answered from the table or from memory since start.
+    hits: int
+    #: Lookups that had to reach the provider since start.
+    misses: int
+    #: Rows currently frozen as learned schedules.
+    learned: int
 
 
 class EnrichmentService:
@@ -238,6 +410,13 @@ class EnrichmentService:
         cooldown_s: how long the circuit stays open.
         queue_size: bounded live-event subscription capacity.
         pending_limit: bounded pending-lookup queue capacity.
+        economy: the TTL and the daily budget this install is configured with.
+        alerting: "is this aircraft matching an alert rule right now?" — a
+            closure over app state, injected rather than depended on, so the
+            service needs no alert engine to run and tests need no alerts.
+        airport_context: the airport-context service's latched answer for an
+            aircraft, read the same way and used for the consistency check.
+        display_radius_nm: the configured map radius, read per drain.
         clock: UTC epoch milliseconds, injected for tests.
         monotonic: monotonic seconds for the limiter and breaker, injected so
             their rules are proved in microseconds rather than minutes.
@@ -245,24 +424,36 @@ class EnrichmentService:
     """
 
     __slots__ = (
+        "_airport_context",
+        "_alerting",
         "_answer_limit",
         "_answers",
         "_breaker",
+        "_budget_announced",
+        "_budget_day_ms",
+        "_budget_used",
         "_cache",
         "_clock",
         "_counters",
         "_dropped",
+        "_economy",
+        "_hits",
         "_idle",
         "_inflight",
+        "_invalidated",
+        "_invalidating",
+        "_learned",
         "_limiter",
         "_live",
         "_lookups",
+        "_misses",
         "_overflowed",
         "_pending",
         "_pending_limit",
         "_persistence",
         "_provider",
         "_queue_size",
+        "_radius_nm",
         "_reader",
         "_started",
         "_subscription",
@@ -276,6 +467,10 @@ class EnrichmentService:
         persistence: PersistenceWorker,
         cache: RouteCacheRepository,
         provider: RouteEnrichmentProvider | None,
+        economy: EnrichmentEconomy | None = None,
+        alerting: AlertProbe | None = None,
+        airport_context: ContextProbe | None = None,
+        display_radius_nm: RadiusProbe | None = None,
         rate_per_minute: float = DEFAULT_RATE_PER_MINUTE,
         failure_threshold: int = DEFAULT_FAILURE_THRESHOLD,
         cooldown_s: float = DEFAULT_COOLDOWN_S,
@@ -294,6 +489,10 @@ class EnrichmentService:
         self._persistence = persistence
         self._cache = cache
         self._provider = provider
+        self._economy = economy if economy is not None else EnrichmentEconomy()
+        self._alerting = alerting
+        self._airport_context = airport_context
+        self._radius_nm = display_radius_nm
         self._queue_size = queue_size
         self._pending_limit = pending_limit
         self._answer_limit = answer_limit
@@ -316,14 +515,31 @@ class EnrichmentService:
         #: Queued keys, oldest first. An ordered mapping rather than a queue so
         #: two observations of one flight coalesce into a single lookup.
         self._pending: OrderedDict[str, _PendingLookup] = OrderedDict()
-        #: Answers this process already holds, keyed as the cache is.
-        #: ``None`` means "asked, and there is no route" — remembered as firmly
-        #: as a route, because it is the answer that saves the most requests.
-        self._answers: OrderedDict[str, RouteInfo | None] = OrderedDict()
+        #: Answers this process already holds, keyed as the cache is. A
+        #: :class:`_Answer` whose ``route`` is ``None`` means "asked, and there
+        #: is no route" — remembered as firmly as a route, because it is the
+        #: answer that saves the most requests.
+        self._answers: OrderedDict[str, _Answer] = OrderedDict()
+        #: Keys whose cache row is to be deleted before the next request,
+        #: because the aircraft contradicted it.
+        self._invalidating: set[str] = set()
+        #: Keys already invalidated once this process. Bounded like the answers
+        #: and for the same reason; membership is what makes the consistency
+        #: check fire once rather than on every observation.
+        self._invalidated: OrderedDict[str, None] = OrderedDict()
         self._inflight: str | None = None
         self._dropped = 0
         self._overflowed = False
         self._lookups = 0
+        self._hits = 0
+        self._misses = 0
+        self._learned = 0
+        #: Start of the UTC day the budget count belongs to, or ``None`` before
+        #: the first read of the table. Not "today": the day the *count* was
+        #: taken for, which is what makes a midnight rollover detectable.
+        self._budget_day_ms: int | None = None
+        self._budget_used = 0
+        self._budget_announced = False
         self._idle = asyncio.Event()
         self._idle.set()
 
@@ -359,6 +575,33 @@ class EnrichmentService:
         """True while the breaker is refusing requests."""
         return self._breaker.is_open
 
+    @property
+    def economy(self) -> EnrichmentEconomy:
+        """The TTL and daily budget currently in force."""
+        return self._economy
+
+    @property
+    def budget(self) -> BudgetStatus:
+        """What the day's lookup budget has spent and has left.
+
+        Read from memory: the count is taken from ``route_cache`` at start and
+        at each midnight rollover and incremented as rows are written, so this
+        is a property read rather than a query on the diagnostics path.
+        """
+        limit = self._economy.daily_lookup_budget
+        used = self._budget_used
+        return BudgetStatus(
+            limit=limit or None,
+            used_today=used,
+            remaining=max(0, limit - used) if limit else None,
+            resets_at_ms=self._next_midnight_ms(),
+        )
+
+    @property
+    def cache_stats(self) -> CacheStats:
+        """Hits, misses and learned rows, as diagnostics reports them."""
+        return CacheStats(hits=self._hits, misses=self._misses, learned=self._learned)
+
     async def wait_idle(self) -> None:
         """Wait until the worker task finishes the lookup it is in.
 
@@ -382,6 +625,9 @@ class EnrichmentService:
         provider = self._provider
         if provider is None or self.running:
             return
+        # Before the first event, so an install restarted at noon knows what it
+        # has already spent today rather than being handed a fresh allowance.
+        await self._refresh_ledger()
         self._subscription = self._live.subscribe("enrichment", maxsize=self._queue_size)
         self._reader = asyncio.create_task(self._read_loop(), name="flightsite-enrichment-read")
         self._worker = asyncio.create_task(self._lookup_loop(), name="flightsite-enrichment")
@@ -397,11 +643,16 @@ class EnrichmentService:
         self._started = False
         await self._halt()
 
-    async def apply_provider(self, provider: RouteEnrichmentProvider | None) -> None:
+    async def apply_provider(
+        self,
+        provider: RouteEnrichmentProvider | None,
+        economy: EnrichmentEconomy | None = None,
+    ) -> None:
         """Reconcile the running service with a just-saved configuration (#161).
 
         ``provider`` is whatever :func:`build_provider` made of the settings the
-        save installed, and this method makes the service match it. Before it
+        save installed, ``economy`` what :func:`build_economy` made of the same
+        settings, and this method makes the service match both. Before it
         existed the provider was read exactly once, in ``create_app``, so an
         owner who enabled enrichment and pasted a key into the Settings page
         got a saved file and nothing else until the backend was restarted —
@@ -429,6 +680,15 @@ class EnrichmentService:
           stopped and closed before the new one is installed, so two clients
           never exist at once.
 
+        A fifth case was added with the budget and the TTL (slice 070), and it
+        is deliberately none of the above: **re-budgeted**. A save that changes
+        only ``route_ttl_days`` or ``daily_lookup_budget`` adopts the new
+        numbers in place — no teardown, no lost queue, no resubscription — and
+        re-reads the day's ledger, so raising a spent budget resumes lookups on
+        the save rather than at midnight. That is why the equality check that
+        decides "nothing changed" is over the whole configuration while the one
+        that decides "restart" is over the provider alone.
+
         Restarting is conditional on the lifespan being open, not on the
         service having been running: enrichment that was *off* at boot has no
         tasks to speak of, and starting it is the entire point of the fix. A
@@ -437,7 +697,8 @@ class EnrichmentService:
         come and would otherwise start it twice.
         """
         current = self._provider
-        if _same_configuration(current, provider):
+        candidate_economy = economy if economy is not None else self._economy
+        if _same_configuration(current, provider, self._economy, candidate_economy):
             # Constructing a provider opens nothing, so the candidate this call
             # declines has nothing to leak; closing it anyway keeps that true
             # of a provider that one day acquires something in its constructor.
@@ -445,6 +706,37 @@ class EnrichmentService:
                 await provider.aclose()
             return
 
+        if not _same_provider(current, provider):
+            await self._swap_provider(provider, candidate_economy)
+            return
+
+        # Only the numbers changed. The worker keeps its tasks, its
+        # subscription, its remembered answers and its place in the queue.
+        await self._adopt_economy(candidate_economy)
+        if provider is not None and provider is not current:
+            await provider.aclose()
+
+    async def _adopt_economy(self, economy: EnrichmentEconomy) -> None:
+        """Take a new TTL and budget without disturbing anything running."""
+        self._economy = economy
+        # A budget that was spent may not be any more, and one that was
+        # uncapped may now be spent already: re-read rather than reason about
+        # which, so the next drain sees the truth either way.
+        self._budget_day_ms = None
+        if self._started:
+            await self._refresh_ledger()
+        logger.info(
+            "enrichment_economy_applied",
+            route_ttl_days=economy.route_ttl_days,
+            daily_lookup_budget=economy.daily_lookup_budget,
+            used_today=self._budget_used,
+        )
+
+    async def _swap_provider(
+        self, provider: RouteEnrichmentProvider | None, economy: EnrichmentEconomy
+    ) -> None:
+        """Install a different provider, stopping what the old one was doing."""
+        current = self._provider
         if self.running:
             await self._halt()
         elif current is not None:
@@ -453,6 +745,7 @@ class EnrichmentService:
             await current.aclose()
 
         self._provider = provider
+        self._economy = economy
         self._reset_provider_state()
         if self._started and provider is not None:
             await self.start()
@@ -477,15 +770,18 @@ class EnrichmentService:
         observation of the flight queues it again, which is a retry paced by
         the sky rather than by a loop.
 
-        Two things deliberately survive. Remembered answers are facts about
+        Four things deliberately survive. Remembered answers are facts about
         flights, not about the provider that reported them — ``route_cache``
         keeps them across a restart already, and re-asking would spend quota to
-        learn what FlightSite knows. And the rate limiter describes the plan
-        rather than the object: refilling its bucket here would make saving the
+        learn what FlightSite knows; the cache counters describe those same
+        facts. The day's budget ledger is a count of rows in a table, which a
+        new key does not refund. And the rate limiter describes the plan rather
+        than the object: refilling its bucket here would make saving the
         Settings page a way to buy requests per minute.
         """
         self._breaker.reset()
         self._pending.clear()
+        self._invalidating.clear()
         self._overflowed = False
         self._dropped = 0
         self._lookups = 0
@@ -558,14 +854,28 @@ class EnrichmentService:
         callsign = eligible_callsign(record.callsign)
         if callsign is None:
             return
-        key = cache_key(callsign, record.last_seen)
+        key = cache_key(callsign)
 
-        if key in self._answers:
+        held = self._answers.get(key)
+        if held is not None and held.expires_ms <= self._clock():
+            # The memory gate has the same expiry the row it came from has.
+            # What follows is a refresh, and it is the lowest priority there is.
+            del self._answers[key]
+            held = None
+            refresh = True
+        else:
+            refresh = False
+
+        if held is not None:
+            if self._contradicted(key, (record.icao,), held.route):
+                self._invalidate_later(key, callsign, record.icao)
+                return
             # Already answered this process. Applying is idempotent, so this
-            # also covers the second aircraft to fly the number today and the
+            # also covers the second aircraft to fly the number and the
             # sighting that reopened after a gap.
             self._answers.move_to_end(key)
-            self._apply(key, self._answers[key], (record.icao,))
+            self._hits += 1
+            self._apply(key, held.route, (record.icao,))
             return
         if key == self._inflight:
             # A lookup for this key is in the provider right now; ride it.
@@ -576,8 +886,49 @@ class EnrichmentService:
         if existing is not None:
             existing.icaos.add(record.icao)
             return
-        self._pending[key] = _PendingLookup(callsign, {record.icao})
+        self._pending[key] = _PendingLookup(callsign, {record.icao}, refresh=refresh)
         self._shed_if_full()
+
+    def _invalidate_later(self, key: str, callsign: str, icao: str) -> None:
+        """Queue a re-fetch of a route the aircraft has just disproved.
+
+        The row is deleted on the worker's task rather than here, for the
+        reason the whole read side exists: this runs on the reader, which must
+        never await a database write while live events queue behind it.
+        """
+        self._invalidating.add(key)
+        self._remember_invalidation(key)
+        self._answers.pop(key, None)
+        pending = self._pending.setdefault(key, _PendingLookup(callsign, refresh=True))
+        pending.icaos.add(icao)
+        self._shed_if_full()
+        logger.info("enrichment_route_invalidated", callsign=callsign, icao=icao)
+
+    def _contradicted(self, key: str, icaos: tuple[str, ...], route: RouteInfo | None) -> bool:
+        """True when an aircraft's latched airport phase disproves ``route``.
+
+        Once per callsign per process: a key already invalidated is never
+        invalidated again, so a route the provider keeps reporting the same way
+        cannot become a request per observation. ``None`` — the provider has no
+        route — can be contradicted by nothing, because it claims nothing.
+        """
+        probe = self._airport_context
+        if route is None or probe is None or key in self._invalidated:
+            return False
+        return any(
+            contradicts_route(
+                probe(icao),
+                origin_ident=route.origin_ident,
+                destination_ident=route.destination_ident,
+            )
+            for icao in icaos
+        )
+
+    def _remember_invalidation(self, key: str) -> None:
+        self._invalidated[key] = None
+        self._invalidated.move_to_end(key)
+        while len(self._invalidated) > self._answer_limit:
+            self._invalidated.popitem(last=False)
 
     def _shed_if_full(self) -> None:
         """Drop the oldest queued lookup once the bound is exceeded.
@@ -605,17 +956,17 @@ class EnrichmentService:
                 await asyncio.sleep(IDLE_POLL_S)
 
     async def drain_once(self) -> bool:
-        """Advance the head of the queue one step; ``True`` if it did anything.
+        """Advance the most deserving queued lookup one step.
 
-        The whole of the lookup side's decision, in the order the gates are
-        cheapest: an answer already held, then the cache table, then the
-        circuit, then the limiter, then a request. Public so tests step it one
-        call at a time instead of racing a background task.
+        ``True`` if it did anything. The whole of the lookup side's decision,
+        in the order the gates are cheapest: an answer already held, then the
+        cache table, then the budget, then the circuit, then the limiter, then
+        a request. Public so tests step it one call at a time instead of racing
+        a background task.
         """
         if not self._pending:
             return False
-        key = next(iter(self._pending))
-        lookup = self._pending[key]
+        key, lookup = self._select()
 
         self._idle.clear()
         self._inflight = key
@@ -625,22 +976,93 @@ class EnrichmentService:
             self._inflight = None
             self._idle.set()
 
+    def _select(self) -> tuple[str, _PendingLookup]:
+        """The queued lookup the day's next request should buy.
+
+        ``min`` returns the *first* minimal element, and ``_pending`` is
+        insertion-ordered, so within one priority the queue is still FIFO —
+        priority reorders tiers, it does not shuffle a tier. The scan is over a
+        queue bounded at a few hundred entries and runs once per drain, which
+        is cheaper than maintaining four queues that all have to be kept
+        consistent with one another.
+        """
+        return min(self._pending.items(), key=lambda item: self._priority(item[1]))
+
+    def _priority(self, lookup: _PendingLookup) -> int:
+        """Which tier a pending lookup belongs to; lower goes first.
+
+        See the module docstring for the tiers. Computed at selection time
+        rather than stored at enqueue time because every input to it changes
+        while the entry waits: an aircraft starts matching a rule, flies inside
+        the display radius, or leaves.
+        """
+        alerting = self._alerting
+        if alerting is not None and any(alerting(icao) for icao in lookup.icaos):
+            return 0
+        if self._within_display_radius(lookup.icaos):
+            return 1
+        return 3 if lookup.refresh else 2
+
+    def _within_display_radius(self, icaos: set[str]) -> bool:
+        """True when any waiting aircraft is inside the configured radius.
+
+        An aircraft with no computed distance — no position yet, or no receiver
+        location configured — is not *outside* the radius, it is unmeasured,
+        and unmeasured is not a reason to promote it above the sky the map is
+        actually showing.
+        """
+        probe = self._radius_nm
+        radius_nm = probe() if probe is not None else None
+        if radius_nm is None:
+            return False
+        for icao in icaos:
+            record = self._live.get(icao)
+            if (
+                record is not None
+                and record.distance_nm is not None
+                and (record.distance_nm <= radius_nm)
+            ):
+                return True
+        return False
+
     async def _advance(self, key: str, lookup: _PendingLookup) -> bool:
         # A queued key is never one this process has already answered:
         # `_enqueue` applies a remembered answer instead of queueing, and
         # `_finish` — the only writer of `_answers` — takes the key off the
         # queue in the same call. So the memory gate is upstream of here and
         # this method starts at the cache.
-        #
+        now_ms = self._clock()
+        if key in self._invalidating:
+            # An aircraft disproved this row on the reader's task; deleting it
+            # is this task's work, and it happens before the read below so the
+            # request that follows cannot be answered by what was disproved.
+            self._invalidating.discard(key)
+            await self._cache.invalidate(key)
+
         # The cache before the limits: a hit spends no request, and a route
         # already on disk is worth applying even while the circuit is open —
         # ``docs/ARCHITECTURE.md`` §"Degradation" keeps cached enrichment
         # working through an outage.
-        cached = await self._cache.get(key, now_ms=self._clock())
+        cached = await self._cache.get(key, now_ms=now_ms)
         if cached is not None:
             answer = cached.as_lookup()
-            self._finish(key, answer if isinstance(answer, RouteInfo) else None)
-            return True
+            route = answer if isinstance(answer, RouteInfo) else None
+            if self._contradicted(key, tuple(lookup.icaos), route):
+                # The restart case: the row outlived the process that fetched
+                # it, so the contradiction is met here rather than at the
+                # memory gate. Same remedy, one step later.
+                self._remember_invalidation(key)
+                await self._cache.invalidate(key)
+                logger.info("enrichment_route_invalidated", callsign=lookup.callsign)
+            else:
+                self._hits += 1
+                self._finish(key, route, expires_ms=cached.expires_ms)
+                return True
+
+        if not await self._may_spend(now_ms):
+            # The budget is spent. The key keeps its place, as it does under
+            # the rate limiter: what stops is asking, not queueing.
+            return False
 
         if not self._breaker.allow():
             # Silently absent while the circuit is open, and dropped rather
@@ -661,6 +1083,7 @@ class EnrichmentService:
         if provider is None:  # pragma: no cover - the loop only runs when enabled
             return
         self._lookups += 1
+        self._misses += 1
         result = await provider.lookup(lookup.callsign)
         now_ms = self._clock()
 
@@ -673,17 +1096,42 @@ class EnrichmentService:
             self._pending.pop(key, None)
             return
 
+        # Everything below is the provider *answering*, so the breaker closes
+        # on all three — including 451. Issue #165 is what happens when a
+        # definitive answer about one flight is read as a failing provider.
         self._breaker.record_success()
+        await self._spend(now_ms)
+        ttl_s = self._economy.route_ttl_s
         if isinstance(result, RouteInfo):
-            await self._cache.store_route(key, result, now_ms=now_ms)
-            self._finish(key, result)
+            write = await self._cache.store_route(key, result, now_ms=now_ms, ttl_s=ttl_s)
+            if write.newly_learned:
+                self._learned += 1
+                logger.info(
+                    "enrichment_route_learned",
+                    callsign=lookup.callsign,
+                    confirmations=write.confirmations,
+                )
+            self._finish(
+                key,
+                result,
+                expires_ms=now_ms + self._stored_ttl_s(write) * MS_PER_SECOND,
+            )
+        elif isinstance(result, RouteRestricted):
+            # Cached like an answer, because it is one, and for the positive
+            # TTL: a flight withheld by law is withheld on the next sighting.
+            await self._cache.store_restricted(key, now_ms=now_ms, ttl_s=ttl_s)
+            self._finish(key, None, expires_ms=now_ms + ttl_s * MS_PER_SECOND)
         else:
             await self._cache.store_not_found(key, now_ms=now_ms)
-            self._finish(key, None)
+            self._finish(key, None, expires_ms=now_ms + NEGATIVE_TTL_S * MS_PER_SECOND)
 
-    def _finish(self, key: str, answer: RouteInfo | None) -> None:
+    def _stored_ttl_s(self, write: RouteWrite) -> int:
+        """How long the row just written will live."""
+        return LEARNED_TTL_S if write.learned else self._economy.route_ttl_s
+
+    def _finish(self, key: str, answer: RouteInfo | None, *, expires_ms: int) -> None:
         """Remember an answer, apply it, and take the key off the queue."""
-        self._remember(key, answer)
+        self._remember(key, answer, expires_ms=expires_ms)
         lookup = self._pending.pop(key, None)
         if lookup is not None:
             self._apply(key, answer, tuple(sorted(lookup.icaos)))
@@ -709,20 +1157,87 @@ class EnrichmentService:
             self._persistence.apply_route(icao, route, at_ms=at_ms)
         logger.debug("enrichment_applied", cache_key=key, aircraft=len(icaos))
 
-    def _remember(self, key: str, answer: RouteInfo | None) -> None:
-        self._answers[key] = answer
+    def _remember(self, key: str, answer: RouteInfo | None, *, expires_ms: int) -> None:
+        self._answers[key] = _Answer(route=answer, expires_ms=expires_ms)
         self._answers.move_to_end(key)
         while len(self._answers) > self._answer_limit:
             self._answers.popitem(last=False)
 
+    # ----------------------------------------------------------- the budget
+
+    async def _may_spend(self, now_ms: int) -> bool:
+        """Whether a lookup may be bought right now (issue #167).
+
+        Uncapped installs — the default, and every install before this setting
+        existed — take the first branch and never touch the table.
+        """
+        limit = self._economy.daily_lookup_budget
+        if limit <= 0:
+            return True
+        if self._budget_day_ms != utc_day_start_ms(now_ms):
+            # Either the first drain of this process or the first after
+            # midnight. Both want the same thing: what the table says.
+            await self._refresh_ledger(now_ms)
+        if self._budget_used < limit:
+            return True
+        if not self._budget_announced:
+            self._budget_announced = True
+            logger.warning(
+                BUDGET_EXHAUSTED_EVENT,
+                limit=limit,
+                used_today=self._budget_used,
+                pending=len(self._pending),
+                resets_at_ms=self._next_midnight_ms(now_ms),
+            )
+        return False
+
+    async def _spend(self, now_ms: int) -> None:
+        """Count a lookup that is about to write a row.
+
+        Only answers are counted, because the ledger this mirrors is
+        ``COUNT(*)`` over rows fetched today — and an unavailable provider
+        writes no row. That is the honest join between the in-memory count and
+        the one a restart re-reads, and it errs the right way: a failed request
+        that bought nothing does not consume the day's allowance.
+
+        The re-read is the midnight rollover an uncapped install would
+        otherwise never take: a capped one has already refreshed in
+        :meth:`_may_spend`, so this costs a query once a day at most.
+        """
+        if self._budget_day_ms != utc_day_start_ms(now_ms):
+            await self._refresh_ledger(now_ms)
+        self._budget_used += 1
+
+    async def _refresh_ledger(self, now_ms: int | None = None) -> None:
+        """Re-read the day's spend and the learned-row count from the table."""
+        moment = now_ms if now_ms is not None else self._clock()
+        day_ms = utc_day_start_ms(moment)
+        self._budget_used = await self._cache.count_fetched_since(day_ms)
+        self._learned = await self._cache.count_learned()
+        self._budget_day_ms = day_ms
+        self._budget_announced = False
+
+    def _next_midnight_ms(self, now_ms: int | None = None) -> int:
+        """The next 00:00 UTC, when the day's allowance returns."""
+        moment = now_ms if now_ms is not None else self._clock()
+        return utc_day_start_ms(moment) + SECONDS_PER_DAY * MS_PER_SECOND
+
 
 __all__ = [
+    "BUDGET_EXHAUSTED_EVENT",
     "DEFAULT_ANSWER_LIMIT",
     "DEFAULT_PENDING_LIMIT",
     "DEFAULT_QUEUE_SIZE",
     "ENRICHMENT_FAILURES_COUNTER",
     "IDLE_POLL_S",
+    "AlertProbe",
+    "BudgetStatus",
+    "CacheStats",
+    "ContextProbe",
+    "EnrichmentEconomy",
     "EnrichmentService",
     "EpochClock",
+    "RadiusProbe",
+    "build_economy",
     "build_provider",
 ]

--- a/backend/tests/airports/test_api.py
+++ b/backend/tests/airports/test_api.py
@@ -132,7 +132,8 @@ def test_the_inference_and_the_reported_route_are_different_fields() -> None:
         airport=KBFI,
     )
 
-    assert payload["route"] == {"origin": "KATL", "destination": "KSLC"}
+    assert payload["route"]["origin"] == "KATL"
+    assert payload["route"]["destination"] == "KSLC"
     assert payload["nearest_airport"]["ident"] == "KBFI"
     assert payload["provenance"]["route"] == "aerodatabox"
     assert payload["provenance"]["nearest_airport"] == "heuristic"
@@ -142,7 +143,12 @@ def test_an_inference_never_becomes_a_route() -> None:
     """The failure mode the two fields exist to make impossible."""
     payload = aircraft_payload(record(), airport=KBFI)
 
-    assert payload["route"] == {"origin": None, "destination": None}
+    assert payload["route"] == {
+        "origin": None,
+        "origin_name": None,
+        "destination": None,
+        "destination_name": None,
+    }
     assert "route" not in payload["provenance"]
 
 
@@ -229,7 +235,12 @@ async def test_the_live_endpoint_serves_the_inference(isolated_data_dir: Path) -
     assert block["phase"] == "arriving"
     assert aircraft[ICAO]["provenance"]["nearest_airport"] == "heuristic"
     # And the enrichment half stays empty on an install with no provider.
-    assert aircraft[ICAO]["route"] == {"origin": None, "destination": None}
+    assert aircraft[ICAO]["route"] == {
+        "origin": None,
+        "origin_name": None,
+        "destination": None,
+        "destination_name": None,
+    }
 
 
 async def test_the_live_endpoint_is_null_on_an_install_with_no_dataset(

--- a/backend/tests/airports/test_index.py
+++ b/backend/tests/airports/test_index.py
@@ -290,3 +290,42 @@ def test_a_repeated_ident_collapses_to_one_airport() -> None:
     assert found is not None
     assert found.name == "Second"
     assert index.size == 1
+
+
+# ---------------------------------------------------------- names by ident
+
+
+def test_a_known_ident_names_its_field(index: AirportIndex) -> None:
+    """The lookup behind ``route.origin_name`` (``docs/API.md`` §2.6)."""
+    assert index.name_for("KBFI") == "Boeing Field"
+
+
+def test_an_ident_the_dataset_does_not_carry_names_nothing(index: AirportIndex) -> None:
+    assert index.name_for("ZZZZ") is None
+
+
+def test_an_empty_index_names_nothing() -> None:
+    """The state of every install until an airports import has run."""
+    assert AirportIndex().name_for("KBFI") is None
+
+
+def test_an_iata_code_is_a_fallback_key(index: AirportIndex) -> None:
+    """A route ident is ICAO where the provider had one and IATA otherwise
+    (:mod:`flightsite.enrichment.aerodatabox`), so both have to answer."""
+    assert index.name_for("BFI") == "Boeing Field"
+
+
+def test_an_ident_is_matched_case_insensitively(index: AirportIndex) -> None:
+    assert index.name_for("kbfi") == "Boeing Field"
+
+
+def test_a_duplicated_iata_code_resolves_to_the_first_row_loaded() -> None:
+    """Deterministic across rebuilds — the repository loads in ident order."""
+    duplicated = AirportIndex(
+        [
+            airport("AAAA", 10.0, 10.0, name="First", iata="DUP"),
+            airport("BBBB", 11.0, 11.0, name="Second", iata="DUP"),
+        ]
+    )
+
+    assert duplicated.name_for("DUP") == "First"

--- a/backend/tests/airports/test_service.py
+++ b/backend/tests/airports/test_service.py
@@ -581,3 +581,38 @@ async def test_an_unusable_queue_size_is_refused(
         AirportContextService(
             live=live, persistence=worker, repository=repository, queue_size=queue_size
         )
+
+
+# -------------------------------------------------- naming somebody else's ident
+
+
+async def test_the_service_names_an_ident_from_the_imported_dataset(
+    service: AirportContextService,
+) -> None:
+    """``route.origin_name`` (``docs/API.md`` §2.6) is answered from the same
+    index the nearest-airport inference uses, and makes no claim of its own."""
+    assert service.name_for("KBFI") == "Boeing Field"
+    assert service.name_for("ZZZZ") is None
+
+
+async def test_the_service_names_nothing_before_an_import(
+    live: LiveStore, worker: PersistenceWorker, repository: AirportRepository
+) -> None:
+    """A stock install: every name is null and no payload changes shape for it."""
+    unseeded = AirportContextService(live=live, persistence=worker, repository=repository)
+
+    assert unseeded.known_airports == 0
+    assert unseeded.name_for("KBFI") is None
+
+
+async def test_a_reimport_renames_a_field(
+    service: AirportContextService, repository: AirportRepository
+) -> None:
+    """The index swap is what makes a name current, exactly as it is for the
+    nearest-airport answers built from the same reference."""
+    await seed_index(repository, service, [airport("KBFI", *BOEING_FIELD, name="Old Name")])
+    assert service.name_for("KBFI") == "Old Name"
+
+    await seed_index(repository, service, [airport("KBFI", *BOEING_FIELD, name="New Name")])
+
+    assert service.name_for("KBFI") == "New Name"

--- a/backend/tests/api/test_route_names.py
+++ b/backend/tests/api/test_route_names.py
@@ -1,0 +1,412 @@
+"""``route.origin_name`` / ``route.destination_name`` — ``docs/API.md`` §2.6.
+
+A route arrives from the enrichment provider as two idents and nothing else, so
+a client that wants to show *Atlanta* rather than *KATL* has to resolve them.
+Slice 070 resolves them **locally**, against the ``airports`` table slice 027
+already imports and already holds in memory, and publishes the answer beside the
+ident rather than in place of it.
+
+Three properties are pinned here, because each is a way this could go wrong
+without failing loudly:
+
+* **The shape is stable.** Four keys, always, on every payload that carries a
+  ``route`` — the same §2.7 bargain the two idents already keep. A name is
+  ``null`` for an ident the local dataset does not carry and for an ident that
+  is itself ``null``, and those two look identical on the wire on purpose.
+* **The lookup is injected.** The serializer never reaches for application
+  state, so these tests hand it a dictionary and a counter rather than an index.
+  That is also how the "one call per ident, and none for an ident that is not
+  there" claim in :func:`~flightsite.api.serializers.route_block`'s docstring
+  gets checked rather than merely written down: it is the live path's cost.
+* **Every surface agrees.** REST, the WebSocket's frames and the sighting detail
+  all read the same block, because they call the same function with the same
+  lookup.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from httpx import AsyncClient
+from sqlalchemy.engine import RowMapping
+
+from flightsite.airports.records import AirportRecord
+from flightsite.airports.repository import AirportRepository
+from flightsite.api.schemas import AircraftView, RouteView, SightingDetail
+from flightsite.api.serializers import (
+    aircraft_payload,
+    no_airport_names,
+    route_block,
+    sighting_detail_payload,
+)
+from flightsite.ingest import Position
+from flightsite.live import LiveAircraft, appear
+from flightsite.sightings.state import SightingRoute
+
+from ..live.conftest import make_update
+from .aircraft_history_fixtures import SeedAircraft
+from .conftest import LiveApp, open_probe
+from .test_sightings_api import BASE_MS, MINUTE_MS, closed_sighting, seed
+
+ICAO = "ae1463"
+NEARBY = Position(latitude=47.6205, longitude=-122.3493)
+
+#: The two fields every case below routes between, and the names the local
+#: dataset carries for them.
+ORIGIN = "KATL"
+ORIGIN_NAME = "Hartsfield Jackson Atlanta International Airport"
+DESTINATION = "KSEA"
+DESTINATION_NAME = "Seattle Tacoma International Airport"
+
+#: An ident no import here ever produced — "the provider named a field this
+#: install does not have", the ordinary case on a partial dataset.
+UNKNOWN_IDENT = "ZZZZ"
+
+NAMES: dict[str, str] = {ORIGIN: ORIGIN_NAME, DESTINATION: DESTINATION_NAME}
+
+AIRCRAFT = [SeedAircraft(icao24=ICAO, first_seen_ms=BASE_MS, last_seen_ms=BASE_MS)]
+
+
+def names(ident: str) -> str | None:
+    """A fake :data:`~flightsite.api.serializers.AirportNameLookup`."""
+    return NAMES.get(ident)
+
+
+class CountingNames:
+    """A lookup that records every ident it was asked about."""
+
+    def __init__(self) -> None:
+        self.asked: list[str] = []
+
+    def __call__(self, ident: str) -> str | None:
+        self.asked.append(ident)
+        return NAMES.get(ident)
+
+
+def record() -> LiveAircraft:
+    """One positioned live record to hang a route on."""
+    update = make_update(ICAO, position=NEARBY, callsign="DAL2401", altitude_ft=31_000)
+    return appear(update, now=1_000.0, receiver=NEARBY)
+
+
+def route(origin: str | None = ORIGIN, destination: str | None = DESTINATION) -> SightingRoute:
+    return SightingRoute(origin_ident=origin, destination_ident=destination, source="aerodatabox")
+
+
+def airport(ident: str, name: str) -> AirportRecord:
+    """One row of the local dataset. Position is irrelevant here — this is the
+    name lookup, not the nearest-airport inference."""
+    return AirportRecord(
+        ident=ident,
+        name=name,
+        type="large_airport",
+        lat=0.0,
+        lon=0.0,
+        elevation_ft=None,
+        iata=None,
+        upstream_id=None,
+    )
+
+
+async def seed_airports(live_app: LiveApp, *records: AirportRecord) -> None:
+    """Put ``records`` in the table and rebuild the running service's index.
+
+    The production path — repository write, then the service's own
+    :meth:`~flightsite.airports.service.AirportContextService.reload` — because
+    a name that appeared only through a shortcut would prove nothing about the
+    index the live path actually reads.
+    """
+    repository = AirportRepository(live_app.app.state.database)
+    await repository.replace_all(
+        list(records), source="airports", at_ms=BASE_MS, dataset_version="fixture"
+    )
+    await live_app.app.state.airports.reload()
+
+
+# ------------------------------------------------------------------- the block
+
+
+def test_a_known_ident_is_named() -> None:
+    block = route_block(ORIGIN, DESTINATION, names)
+
+    assert block == {
+        "origin": ORIGIN,
+        "origin_name": ORIGIN_NAME,
+        "destination": DESTINATION,
+        "destination_name": DESTINATION_NAME,
+    }
+
+
+def test_an_ident_the_local_dataset_does_not_carry_is_named_null() -> None:
+    """§2.7: the ident is still published, so a client renders the code."""
+    block = route_block(UNKNOWN_IDENT, DESTINATION, names)
+
+    assert block["origin"] == UNKNOWN_IDENT
+    assert block["origin_name"] is None
+    assert block["destination_name"] == DESTINATION_NAME
+
+
+def test_a_null_ident_has_a_null_name() -> None:
+    block = route_block(None, None, names)
+
+    assert block == {
+        "origin": None,
+        "origin_name": None,
+        "destination": None,
+        "destination_name": None,
+    }
+
+
+def test_the_lookup_is_never_asked_about_an_ident_that_is_not_there() -> None:
+    """The hot-path claim: at most one call per ident, none for a null."""
+    counting = CountingNames()
+
+    route_block(ORIGIN, None, counting)
+
+    assert counting.asked == [ORIGIN]
+
+
+def test_an_install_with_no_airport_dataset_names_nothing() -> None:
+    """The default lookup is what a stock install answers with."""
+    block = route_block(ORIGIN, DESTINATION, no_airport_names)
+
+    assert block["origin"] == ORIGIN
+    assert block["origin_name"] is None
+    assert block["destination_name"] is None
+
+
+def test_the_published_model_carries_all_four_members() -> None:
+    """A client codes against ``/api/v1/openapi.json``, so it has to be in it."""
+    assert set(RouteView.model_json_schema()["properties"]) == {
+        "origin",
+        "origin_name",
+        "destination",
+        "destination_name",
+    }
+
+
+# ------------------------------------------------------------ the live payload
+
+
+def test_the_live_payload_names_a_known_route() -> None:
+    payload = aircraft_payload(record(), route=route(), airport_names=names)
+
+    assert payload["route"]["origin_name"] == ORIGIN_NAME
+    assert payload["route"]["destination_name"] == DESTINATION_NAME
+    AircraftView.model_validate(payload)
+
+
+def test_the_live_payload_names_an_unknown_ident_null() -> None:
+    payload = aircraft_payload(record(), route=route(origin=UNKNOWN_IDENT), airport_names=names)
+
+    assert payload["route"]["origin"] == UNKNOWN_IDENT
+    assert payload["route"]["origin_name"] is None
+    assert payload["route"]["destination_name"] == DESTINATION_NAME
+
+
+def test_the_live_payload_has_the_keys_before_there_is_any_route() -> None:
+    """§2.7 again: unknown is a null under a stable key, never a missing key."""
+    payload = aircraft_payload(record(), airport_names=names)
+
+    assert payload["route"] == {
+        "origin": None,
+        "origin_name": None,
+        "destination": None,
+        "destination_name": None,
+    }
+
+
+def test_a_name_is_not_attributed_separately_from_its_route() -> None:
+    """§2.6: the ``route`` entry names where the route came from; a name is a
+    local label for it, not a second claim with a second source."""
+    payload = aircraft_payload(record(), route=route(), airport_names=names)
+
+    assert payload["provenance"]["route"] == "aerodatabox"
+    assert "origin_name" not in payload["provenance"]
+    assert "destination_name" not in payload["provenance"]
+
+
+# --------------------------------------------------------- the sighting detail
+
+
+def detail_row(**overrides: Any) -> RowMapping:
+    """The columns :func:`sighting_detail_payload` reads, as a plain mapping.
+
+    Cast rather than queried: this is a serializer test, and the columns
+    themselves are pinned by ``tests/api/test_sightings_api.py`` against the
+    real query.
+    """
+    row: dict[str, Any] = {
+        "id": 1,
+        "icao24": ICAO,
+        "callsign_last": "DAL2401",
+        "squawk_last": "1200",
+        "started_ms": BASE_MS,
+        "ended_ms": BASE_MS + MINUTE_MS,
+        "duration_ms": MINUTE_MS,
+        "closure_reason": "gap_timeout",
+        "origin_ident": ORIGIN,
+        "destination_ident": DESTINATION,
+        "route_source": "aerodatabox",
+        "rssi_peak_db": None,
+        "rssi_avg_db": None,
+        "rssi_min_db": None,
+        "msg_count": 1,
+        "pos_count": 1,
+        "pos_time_pct": None,
+        "closest_approach_nm": None,
+        "max_range_nm": None,
+        "lowest_alt_ft": None,
+        "highest_alt_ft": None,
+    }
+    row.update(overrides)
+    return cast(RowMapping, row)
+
+
+def test_the_sighting_detail_names_a_stored_route() -> None:
+    payload = sighting_detail_payload(detail_row(), events=(), path=(), airport_names=names)
+
+    assert payload["route"]["origin_name"] == ORIGIN_NAME
+    assert payload["route"]["destination_name"] == DESTINATION_NAME
+
+
+def test_the_sighting_detail_names_an_unknown_ident_null() -> None:
+    payload = sighting_detail_payload(
+        detail_row(origin_ident=UNKNOWN_IDENT), events=(), path=(), airport_names=names
+    )
+
+    assert payload["route"]["origin"] == UNKNOWN_IDENT
+    assert payload["route"]["origin_name"] is None
+
+
+def test_the_sighting_detail_names_nothing_for_a_sighting_with_no_route() -> None:
+    payload = sighting_detail_payload(
+        detail_row(origin_ident=None, destination_ident=None, route_source=None),
+        events=(),
+        path=(),
+        airport_names=names,
+    )
+
+    assert payload["route"] == {
+        "origin": None,
+        "origin_name": None,
+        "destination": None,
+        "destination_name": None,
+    }
+
+
+# ---------------------------------------------------------------- end to end
+
+
+async def test_the_sighting_detail_endpoint_serves_the_names(
+    live_app: LiveApp, rest: AsyncClient
+) -> None:
+    """Through the real app: a seeded airport names a stored route ident."""
+    await seed_airports(
+        live_app, airport(ORIGIN, ORIGIN_NAME), airport(DESTINATION, DESTINATION_NAME)
+    )
+    seeded = await seed(
+        live_app,
+        closed_sighting(
+            ICAO,
+            origin_ident=ORIGIN,
+            destination_ident=UNKNOWN_IDENT,
+            route_source="aerodatabox",
+        ),
+        aircraft=AIRCRAFT,
+    )
+
+    body = (await rest.get(f"/api/v1/sightings/{seeded[0]}")).json()
+
+    detail = SightingDetail.model_validate(body)
+    assert detail.route.origin == ORIGIN
+    assert detail.route.origin_name == ORIGIN_NAME
+    # The provider named a field this install has not imported.
+    assert detail.route.destination == UNKNOWN_IDENT
+    assert detail.route.destination_name is None
+
+
+async def test_the_sighting_detail_endpoint_is_unnamed_before_an_import(
+    live_app: LiveApp, rest: AsyncClient
+) -> None:
+    """A stock install: the idents are published, the names are all null."""
+    seeded = await seed(
+        live_app,
+        closed_sighting(
+            ICAO, origin_ident=ORIGIN, destination_ident=DESTINATION, route_source="aerodatabox"
+        ),
+        aircraft=AIRCRAFT,
+    )
+
+    body = (await rest.get(f"/api/v1/sightings/{seeded[0]}")).json()
+
+    assert body["route"] == {
+        "origin": ORIGIN,
+        "origin_name": None,
+        "destination": DESTINATION,
+        "destination_name": None,
+    }
+
+
+async def enrich_open_sighting(live_app: LiveApp) -> None:
+    """Feed one aircraft, let its sighting open, and attach a route to it.
+
+    The route reaches the live payload through the persistence worker's
+    accumulator, exactly as slice 026's enrichment worker delivers one — there
+    is no other way in, and a test that injected the block directly would not be
+    exercising the path a running install uses.
+    """
+    live_app.feed(make_update(ICAO, position=NEARBY, callsign="DAL2401"))
+    await live_app.app.state.persistence.process_pending()
+    assert live_app.app.state.persistence.apply_route(ICAO, route(), at_ms=BASE_MS)
+
+
+async def test_the_live_endpoint_serves_the_names(live_app: LiveApp, rest: AsyncClient) -> None:
+    await seed_airports(
+        live_app, airport(ORIGIN, ORIGIN_NAME), airport(DESTINATION, DESTINATION_NAME)
+    )
+    await enrich_open_sighting(live_app)
+
+    body = (await rest.get("/api/v1/aircraft/current")).json()
+
+    aircraft = {item["icao"]: item for item in body["items"]}
+    assert aircraft[ICAO]["route"] == {
+        "origin": ORIGIN,
+        "origin_name": ORIGIN_NAME,
+        "destination": DESTINATION,
+        "destination_name": DESTINATION_NAME,
+    }
+
+
+async def test_a_websocket_delta_carries_the_same_named_route(live_app: LiveApp) -> None:
+    """§4.3 frames are the §3.3 object, so they carry the names too."""
+    await seed_airports(
+        live_app, airport(ORIGIN, ORIGIN_NAME), airport(DESTINATION, DESTINATION_NAME)
+    )
+    probe, _snapshot = await open_probe(live_app)
+    try:
+        await enrich_open_sighting(live_app)
+        await live_app.broadcast()
+
+        delta = await probe.frame()
+        updated = delta["data"]["updated"]
+        assert updated[0]["route"]["origin_name"] == ORIGIN_NAME
+        assert updated[0]["route"]["destination_name"] == DESTINATION_NAME
+        AircraftView.model_validate(updated[0])
+    finally:
+        await probe.disconnect()
+
+
+async def test_a_websocket_snapshot_carries_the_names(live_app: LiveApp) -> None:
+    await seed_airports(live_app, airport(ORIGIN, ORIGIN_NAME))
+    await enrich_open_sighting(live_app)
+
+    probe, snapshot = await open_probe(live_app)
+    try:
+        aircraft = snapshot["data"]["aircraft"]
+        assert aircraft[0]["route"]["origin_name"] == ORIGIN_NAME
+        # A real ident this install has not imported: published, unnamed.
+        assert aircraft[0]["route"]["destination"] == DESTINATION
+        assert aircraft[0]["route"]["destination_name"] is None
+    finally:
+        await probe.disconnect()

--- a/backend/tests/api/test_sightings_api.py
+++ b/backend/tests/api/test_sightings_api.py
@@ -415,7 +415,12 @@ async def test_detail_reports_no_route_provenance_when_there_is_no_route(
 
     body = (await rest.get(f"/api/v1/sightings/{seeded[0]}")).json()
 
-    assert body["route"] == {"origin": None, "destination": None}
+    assert body["route"] == {
+        "origin": None,
+        "origin_name": None,
+        "destination": None,
+        "destination_name": None,
+    }
     assert "route" not in body["provenance"]
 
 

--- a/backend/tests/diagnostics/test_service.py
+++ b/backend/tests/diagnostics/test_service.py
@@ -345,6 +345,78 @@ class TestMetadataAge:
         assert payload["status"] == STATUS_OK
 
 
+class TestEnrichmentSection:
+    """The Health page's enrichment card reads these keys and no others."""
+
+    #: 2026-08-31T00:00:00Z — the midnight after :data:`NOW`.
+    MIDNIGHT_MS = 1_788_134_400_000
+
+    @classmethod
+    def _service(cls, **overrides: Any) -> Any:
+        state: dict[str, Any] = {
+            "enabled": True,
+            "running": True,
+            "circuit_open": False,
+            "lookups": 308,
+            "dropped": 0,
+            "pending": 2,
+            "budget": SimpleNamespace(
+                limit=500, used_today=137, remaining=363, resets_at_ms=cls.MIDNIGHT_MS
+            ),
+            "cache_stats": SimpleNamespace(hits=4_112, misses=308, learned=57),
+        }
+        state.update(overrides)
+        return SimpleNamespace(**state)
+
+    @pytest.mark.asyncio
+    async def test_the_budget_and_cache_counters_reach_the_payload(self) -> None:
+        app = _app(enrichment=self._service())
+
+        payload = await collect_diagnostics(
+            app, counters=CounterRegistry(), ring=ErrorRing(), now=NOW
+        )
+
+        assert payload["enrichment"]["budget"] == {
+            "limit": 500,
+            "used_today": 137,
+            "remaining": 363,
+            "resets_at": "2026-08-31T00:00:00.000Z",
+        }
+        assert payload["enrichment"]["cache"] == {"hits": 4_112, "misses": 308, "learned": 57}
+
+    @pytest.mark.asyncio
+    async def test_an_uncapped_budget_reports_null_rather_than_zero(self) -> None:
+        """``null`` means "no ceiling"; ``0`` would mean "nothing left today"."""
+        service = self._service(
+            budget=SimpleNamespace(
+                limit=None, used_today=12, remaining=None, resets_at_ms=self.MIDNIGHT_MS
+            )
+        )
+
+        payload = await collect_diagnostics(
+            _app(enrichment=service), counters=CounterRegistry(), ring=ErrorRing(), now=NOW
+        )
+
+        budget = payload["enrichment"]["budget"]
+        assert (budget["limit"], budget["remaining"]) == (None, None)
+        assert budget["used_today"] == 12
+
+    @pytest.mark.asyncio
+    async def test_a_process_with_no_enrichment_service_still_answers(self) -> None:
+        """Every section degrades rather than failing — including this one."""
+        payload = await collect_diagnostics(
+            _app(), counters=CounterRegistry(), ring=ErrorRing(), now=NOW
+        )
+
+        assert payload["enrichment"]["budget"] == {
+            "limit": None,
+            "used_today": 0,
+            "remaining": None,
+            "resets_at": "2026-09-01T00:00:00.000Z",
+        }
+        assert payload["enrichment"]["cache"] == {"hits": 0, "misses": 0, "learned": 0}
+
+
 class TestCountersAndErrors:
     @pytest.mark.asyncio
     async def test_counter_values_reach_their_sections(self) -> None:

--- a/backend/tests/enrichment/conftest.py
+++ b/backend/tests/enrichment/conftest.py
@@ -55,8 +55,9 @@ from tests.conftest import SECRET_SENTINEL
 BASE_TIME = datetime(2026, 8, 30, 22, 0, 0, tzinfo=UTC)
 BASE_EPOCH_MS = to_epoch_ms(BASE_TIME)
 
-#: The UTC day :data:`BASE_TIME` falls in — the date half of every cache key
-#: the fixtures produce.
+#: The UTC day :data:`BASE_TIME` falls in. No longer part of a cache key —
+#: slice 070 made the key the callsign alone — but still the day the
+#: confirmation and budget rules are measured against.
 BASE_DATE = "2026-08-30"
 
 SEATTLE = Position(latitude=47.4502, longitude=-122.3088)

--- a/backend/tests/enrichment/test_app_wiring.py
+++ b/backend/tests/enrichment/test_app_wiring.py
@@ -110,4 +110,9 @@ def test_the_published_schema_documents_the_route_block(isolated_data_dir: Path)
         schemas = client.get("/api/v1/openapi.json").json()["components"]["schemas"]
 
     assert "route" in schemas["AircraftView"]["properties"]
-    assert set(schemas["RouteView"]["properties"]) == {"origin", "destination"}
+    assert set(schemas["RouteView"]["properties"]) == {
+        "origin",
+        "origin_name",
+        "destination",
+        "destination_name",
+    }

--- a/backend/tests/enrichment/test_cache.py
+++ b/backend/tests/enrichment/test_cache.py
@@ -10,12 +10,17 @@ import pytest
 
 from flightsite.db import Database, RouteCache
 from flightsite.enrichment.cache import (
+    LEARNED_CONFIRMATIONS,
+    LEARNED_TTL_S,
     MAX_PAYLOAD_BYTES,
     MS_PER_SECOND,
     NEGATIVE_TTL_S,
     POSITIVE_TTL_S,
+    SECONDS_PER_DAY,
     RouteCacheRepository,
+    RouteWrite,
     decode_extras,
+    utc_day_start_ms,
 )
 from flightsite.enrichment.model import (
     RouteCacheStatus,
@@ -23,8 +28,13 @@ from flightsite.enrichment.model import (
     RouteNotFound,
 )
 
-KEY = "DAL1234:2026-08-30"
-NOW_MS = 1_756_600_000_000
+KEY = "DAL1234"
+#: 2026-08-30T21:06:40Z - a fixed instant well inside a UTC day, so "the same
+#: day" and "the next day" are exact rather than nearly.
+NOW_MS = 1_756_588_000_000
+NEXT_DAY_MS = NOW_MS + SECONDS_PER_DAY * MS_PER_SECOND
+ROUTE = RouteInfo("KATL", "KSLC")
+OTHER_ROUTE = RouteInfo("KSEA", "KPDX")
 
 
 async def row_of(database: Database, key: str) -> RouteCache | None:
@@ -72,7 +82,7 @@ async def test_a_negative_result_is_cached_and_reads_back_as_not_found(
 async def test_a_negative_expires_sooner_than_a_route(
     cache: RouteCacheRepository, database: Database
 ) -> None:
-    """The asymmetry: an unfiled schedule is worth re-asking about today."""
+    """The asymmetry: an unfiled schedule is worth re-asking about tomorrow."""
     await cache.store_route(KEY, RouteInfo("KATL", "KSLC"), now_ms=NOW_MS)
     positive = await row_of(database, KEY)
     await cache.store_not_found(KEY, now_ms=NOW_MS)
@@ -234,3 +244,213 @@ async def test_an_ok_row_with_no_idents_reads_as_no_route(
 
     assert found is not None
     assert found.as_lookup() == RouteNotFound()
+
+
+# ------------------------------------------------------ the TTL is a setting
+
+
+async def test_the_positive_ttl_comes_from_the_caller(
+    cache: RouteCacheRepository, database: Database
+) -> None:
+    """``enrichment.route_ttl_days``: the repository stores what it is given.
+
+    The default is a week, but the number belongs to the configuration, so the
+    repository takes it per write rather than reading a setting of its own.
+    """
+    ttl_s = 3 * SECONDS_PER_DAY
+    await cache.store_route(KEY, ROUTE, now_ms=NOW_MS, ttl_s=ttl_s)
+    row = await row_of(database, KEY)
+
+    assert row is not None
+    assert row.expires_ms == NOW_MS + ttl_s * MS_PER_SECOND
+
+
+async def test_the_default_positive_ttl_is_a_week(
+    cache: RouteCacheRepository, database: Database
+) -> None:
+    await cache.store_route(KEY, ROUTE, now_ms=NOW_MS)
+    row = await row_of(database, KEY)
+
+    assert row is not None
+    assert row.expires_ms == NOW_MS + 7 * SECONDS_PER_DAY * MS_PER_SECOND
+
+
+async def test_a_missing_route_is_cached_for_a_day(
+    cache: RouteCacheRepository, database: Database
+) -> None:
+    """Twenty-four hours: an unfiled schedule is worth one ask per day."""
+    await cache.store_not_found(KEY, now_ms=NOW_MS)
+    row = await row_of(database, KEY)
+
+    assert NEGATIVE_TTL_S == SECONDS_PER_DAY
+    assert row is not None
+    assert row.expires_ms == NOW_MS + SECONDS_PER_DAY * MS_PER_SECOND
+
+
+# --------------------------------------------------------- restricted (#165)
+
+
+async def test_a_restricted_flight_is_cached_like_an_answer(
+    cache: RouteCacheRepository, database: Database
+) -> None:
+    """Issue #165: 451 is a fact about the flight, so it takes the long TTL."""
+    await cache.store_restricted(KEY, now_ms=NOW_MS)
+    row = await row_of(database, KEY)
+
+    assert row is not None
+    assert row.status == RouteCacheStatus.RESTRICTED.value
+    assert row.expires_ms == NOW_MS + POSITIVE_TTL_S * MS_PER_SECOND
+
+
+async def test_a_restricted_row_reads_as_no_route(cache: RouteCacheRepository) -> None:
+    """The law saying no is Unknown to the user: not a route, not an error."""
+    await cache.store_restricted(KEY, now_ms=NOW_MS)
+    found = await cache.get(KEY, now_ms=NOW_MS)
+
+    assert found is not None
+    assert found.status is RouteCacheStatus.RESTRICTED
+    assert found.as_lookup() == RouteNotFound()
+
+
+# ---------------------------------------------------------- learned schedules
+
+
+async def test_the_same_answer_on_a_later_day_confirms_the_row(
+    cache: RouteCacheRepository,
+) -> None:
+    first = await cache.store_route(KEY, ROUTE, now_ms=NOW_MS)
+    second = await cache.store_route(KEY, ROUTE, now_ms=NEXT_DAY_MS)
+
+    assert (first.confirmations, second.confirmations) == (0, 1)
+    assert not second.learned
+
+
+async def test_the_same_answer_twice_in_one_day_confirms_nothing(
+    cache: RouteCacheRepository,
+) -> None:
+    """One day agreeing with itself is not a second day of evidence."""
+    await cache.store_route(KEY, ROUTE, now_ms=NOW_MS)
+    again = await cache.store_route(KEY, ROUTE, now_ms=NOW_MS + 60 * MS_PER_SECOND)
+
+    assert again.confirmations == 0
+
+
+async def test_three_confirming_days_freeze_the_row_for_a_month(
+    cache: RouteCacheRepository, database: Database
+) -> None:
+    """The acceptance criterion: after three confirmations, expiry is 30 days."""
+    writes = [
+        await cache.store_route(KEY, ROUTE, now_ms=NOW_MS + day * SECONDS_PER_DAY * MS_PER_SECOND)
+        for day in range(LEARNED_CONFIRMATIONS + 1)
+    ]
+    last_ms = NOW_MS + LEARNED_CONFIRMATIONS * SECONDS_PER_DAY * MS_PER_SECOND
+    row = await row_of(database, KEY)
+
+    assert [write.confirmations for write in writes] == [0, 1, 2, 3]
+    assert [write.learned for write in writes] == [False, False, False, True]
+    assert [write.newly_learned for write in writes] == [False, False, False, True]
+    assert row is not None
+    assert row.expires_ms == last_ms + LEARNED_TTL_S * MS_PER_SECOND
+
+
+async def test_a_learned_row_stays_learned_without_counting_twice(
+    cache: RouteCacheRepository,
+) -> None:
+    """``newly_learned`` is the transition, so a counter cannot double-count."""
+    write = RouteWrite(confirmations=0, learned=False, newly_learned=False)
+    for day in range(LEARNED_CONFIRMATIONS + 2):
+        write = await cache.store_route(
+            KEY, ROUTE, now_ms=NOW_MS + day * SECONDS_PER_DAY * MS_PER_SECOND
+        )
+
+    assert write.learned is True
+    assert write.newly_learned is False
+
+
+async def test_a_differing_answer_resets_the_confirmations(
+    cache: RouteCacheRepository, database: Database
+) -> None:
+    """The schedule changed; what was learned about the old one is worthless."""
+    for day in range(LEARNED_CONFIRMATIONS + 1):
+        await cache.store_route(KEY, ROUTE, now_ms=NOW_MS + day * SECONDS_PER_DAY * MS_PER_SECOND)
+    changed_ms = NOW_MS + (LEARNED_CONFIRMATIONS + 1) * SECONDS_PER_DAY * MS_PER_SECOND
+
+    write = await cache.store_route(KEY, OTHER_ROUTE, now_ms=changed_ms)
+    row = await row_of(database, KEY)
+
+    assert write == RouteWrite(confirmations=0, learned=False, newly_learned=False)
+    assert row is not None
+    assert row.confirmations == 0
+    assert row.first_fetched_ms == changed_ms
+    assert row.expires_ms == changed_ms + POSITIVE_TTL_S * MS_PER_SECOND
+
+
+async def test_the_first_fetch_is_remembered_across_confirmations(
+    cache: RouteCacheRepository, database: Database
+) -> None:
+    await cache.store_route(KEY, ROUTE, now_ms=NOW_MS)
+    await cache.store_route(KEY, ROUTE, now_ms=NEXT_DAY_MS)
+    row = await row_of(database, KEY)
+
+    assert row is not None
+    assert (row.first_fetched_ms, row.fetched_ms) == (NOW_MS, NEXT_DAY_MS)
+
+
+async def test_a_negative_answer_does_not_confirm_a_route(
+    cache: RouteCacheRepository, database: Database
+) -> None:
+    """A day the provider had no route is not a day it agreed with itself."""
+    await cache.store_route(KEY, ROUTE, now_ms=NOW_MS)
+    await cache.store_not_found(KEY, now_ms=NEXT_DAY_MS)
+    write = await cache.store_route(KEY, ROUTE, now_ms=NEXT_DAY_MS + MS_PER_SECOND)
+    row = await row_of(database, KEY)
+
+    assert write.confirmations == 0
+    assert row is not None
+    assert row.confirmations == 0
+
+
+async def test_learned_rows_are_counted(cache: RouteCacheRepository) -> None:
+    """What diagnostics reports as ``cache.learned``."""
+    for day in range(LEARNED_CONFIRMATIONS + 1):
+        await cache.store_route(KEY, ROUTE, now_ms=NOW_MS + day * SECONDS_PER_DAY * MS_PER_SECOND)
+    await cache.store_route("UAL9", ROUTE, now_ms=NOW_MS)
+
+    assert await cache.count_learned() == 1
+
+
+# ---------------------------------------------------- invalidation and ledger
+
+
+async def test_invalidation_deletes_a_live_row(
+    cache: RouteCacheRepository, database: Database
+) -> None:
+    """The consistency check's remedy: not "expire it" but "it is wrong"."""
+    await cache.store_route(KEY, ROUTE, now_ms=NOW_MS)
+
+    assert await cache.invalidate(KEY) is True
+    assert await row_of(database, KEY) is None
+    assert await cache.get(KEY, now_ms=NOW_MS) is None
+
+
+async def test_invalidating_nothing_is_not_an_error(cache: RouteCacheRepository) -> None:
+    assert await cache.invalidate(KEY) is False
+
+
+async def test_rows_fetched_today_are_counted(cache: RouteCacheRepository) -> None:
+    """The budget's ledger, which is what makes it survive a restart."""
+    day_ms = utc_day_start_ms(NOW_MS)
+    await cache.store_route("DAL1", ROUTE, now_ms=day_ms - MS_PER_SECOND)
+    await cache.store_route("DAL2", ROUTE, now_ms=day_ms)
+    await cache.store_not_found("DAL3", now_ms=NOW_MS)
+
+    assert await cache.count_fetched_since(day_ms) == 2
+
+
+def test_a_utc_day_starts_at_midnight() -> None:
+    """One definition of "a day", shared by the budget and the confirmations."""
+    day_ms = utc_day_start_ms(NOW_MS)
+
+    assert day_ms <= NOW_MS
+    assert NOW_MS - day_ms < SECONDS_PER_DAY * MS_PER_SECOND
+    assert utc_day_start_ms(NEXT_DAY_MS) == day_ms + SECONDS_PER_DAY * MS_PER_SECOND

--- a/backend/tests/enrichment/test_economy.py
+++ b/backend/tests/enrichment/test_economy.py
@@ -1,0 +1,763 @@
+"""The credit economy: what gets bought, in what order, and how much (#167).
+
+Slice 070's measurements on the owner's receiver are the whole argument for
+this file, so they are worth restating: 2,200-2,650 distinct airline callsigns
+a day at ~190 lookups an hour, 62 % of a day's callsigns already heard the day
+before, 1 % transient contacts, and one restricted business jet (EJM99) retried
+nine times in twelve minutes that tripped the circuit breaker twice (#165).
+Enrichment was spending AeroDataBox credits faster than the feeder earned them.
+
+Everything here is driven through the real service with an injected clock and a
+scripted provider, exactly as ``test_service.py`` does: a budget measured in
+days and a confirmation rule measured in calendar days are provable in
+microseconds that way, and untestable any other way.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from flightsite.airports.model import AirportContext, InferredPhase
+from flightsite.counters import counters
+from flightsite.db import Database
+from flightsite.enrichment import (
+    EnrichmentEconomy,
+    EnrichmentService,
+    RouteCacheRepository,
+    RouteInfo,
+)
+from flightsite.enrichment.cache import MS_PER_SECOND, SECONDS_PER_DAY
+from flightsite.enrichment.model import RouteCacheStatus, RouteRestricted
+from flightsite.enrichment.service import BUDGET_EXHAUSTED_EVENT, ENRICHMENT_FAILURES_COUNTER
+from flightsite.ingest import Position
+from flightsite.live import LiveStore
+from flightsite.sightings import PersistenceWorker
+from tests.enrichment.conftest import (
+    AIRLINE_CALLSIGN,
+    DESTINATION,
+    ICAO,
+    ORIGIN,
+    SEATTLE,
+    FakeProvider,
+    SimulatedTime,
+    build_service,
+    feed,
+    observe,
+    only_sighting,
+    pump,
+    route_answer,
+)
+
+KEY = AIRLINE_CALLSIGN
+
+#: Enough to cross the UTC midnight after :data:`~tests.enrichment.conftest.
+#: BASE_TIME` (22:00 UTC) with room to spare.
+TO_TOMORROW_S = 3 * 60 * 60
+
+#: A position a few miles from the receiver, and one on the far side of the
+#: continent — inside and outside any sane display radius.
+NEAR_RECEIVER = Position(latitude=SEATTLE.latitude + 0.05, longitude=SEATTLE.longitude)
+FAR_AWAY = Position(latitude=25.79, longitude=-80.29)
+
+
+def arriving_at(ident: str) -> AirportContext:
+    """The airport-context service's latched answer for an aircraft landing."""
+    return AirportContext(ident=ident, name=ident, distance_nm=3.0, phase=InferredPhase.ARRIVING)
+
+
+def departing_from(ident: str) -> AirportContext:
+    return AirportContext(ident=ident, name=ident, distance_nm=2.0, phase=InferredPhase.DEPARTING)
+
+
+class RecordedLogs:
+    """A stand-in for the service's module logger.
+
+    Substituted for it rather than captured through structlog: by the time this
+    suite reaches here another test has usually built the real application,
+    which configures structlog with cached bound loggers — and a cached logger
+    is one ``structlog.testing.capture_logs`` cannot intercept. Replacing the
+    name is exact, and it is the same seam the service itself uses.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def _record(self, event: str, **fields: Any) -> None:
+        self.events.append((event, fields))
+
+    debug = info = warning = error = _record
+
+    def named(self, event: str) -> list[dict[str, Any]]:
+        return [fields for name, fields in self.events if name == event]
+
+
+@pytest.fixture
+def logs(monkeypatch: pytest.MonkeyPatch) -> RecordedLogs:
+    """Every structured event the enrichment service emitted."""
+    recorder = RecordedLogs()
+    monkeypatch.setattr("flightsite.enrichment.service.logger", recorder)
+    return recorder
+
+
+class Probes:
+    """The two closures the app injects, as a test can drive them.
+
+    Mutable on purpose: an aircraft starts matching an alert rule, or lands
+    somewhere unexpected, *while* its lookup is queued, and both probes are
+    read at the moment the decision is made rather than at enqueue time.
+    """
+
+    def __init__(self) -> None:
+        self.alerting: set[str] = set()
+        self.contexts: dict[str, AirportContext] = {}
+        self.radius_nm: float | None = None
+
+    def is_alerting(self, icao: str) -> bool:
+        return icao in self.alerting
+
+    def context_for(self, icao: str) -> AirportContext | None:
+        return self.contexts.get(icao)
+
+    def display_radius_nm(self) -> float | None:
+        return self.radius_nm
+
+
+@pytest.fixture
+def probes() -> Probes:
+    return Probes()
+
+
+def economy_service(
+    *,
+    live: LiveStore,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    provider: object,
+    clock: SimulatedTime,
+    probes: Probes,
+    **overrides: Any,
+) -> EnrichmentService:
+    """A service wired to the probes, as ``create_app`` wires the real one."""
+    return build_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        alerting=probes.is_alerting,
+        airport_context=probes.context_for,
+        display_radius_nm=probes.display_radius_nm,
+        **overrides,
+    )
+
+
+# ------------------------------------------------------------ restricted (#165)
+
+
+async def test_a_restricted_flight_is_cached_and_never_asked_about_again(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    database: Database,
+) -> None:
+    """EJM99's nine retries in twelve minutes, as one request and one row."""
+    provider = FakeProvider(default=RouteRestricted())
+    service = build_service(live=live, worker=worker, cache=cache, provider=provider, clock=clock)
+
+    for _ in range(9):
+        clock.advance(80.0)
+        observe(live, clock)
+        await worker.process_pending()
+        feed(service, live)
+        await pump(service)
+        await worker.process_pending()
+
+    row = await cache.get(KEY, now_ms=clock.epoch_ms())
+    assert provider.calls == [AIRLINE_CALLSIGN]
+    assert row is not None
+    assert row.status is RouteCacheStatus.RESTRICTED
+    sighting = await only_sighting(database)
+    assert (sighting.origin_ident, sighting.destination_ident) == (None, None)
+
+
+async def test_a_restricted_answer_leaves_the_breaker_and_the_counter_alone(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+) -> None:
+    """The defect itself: an answer about one flight is not provider failure.
+
+    ``failure_threshold=1`` makes the assertion sharp — one counted failure
+    would open the circuit, and the circuit stays closed.
+    """
+    provider = FakeProvider(default=RouteRestricted())
+    service = build_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        failure_threshold=1,
+    )
+
+    for index in range(3):
+        clock.advance(1.0)
+        observe(live, clock, f"a0000{index:x}", callsign=f"EJM9{index}")
+        feed(service, live)
+        await pump(service)
+
+    assert len(provider.calls) == 3
+    assert service.circuit_open is False
+    assert counters.snapshot().get(ENRICHMENT_FAILURES_COUNTER, 0) == 0
+
+
+# --------------------------------------------------------------- the budget
+
+
+async def test_the_budget_stops_lookups_once_it_is_spent(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    probes: Probes,
+) -> None:
+    """``daily_lookup_budget: 5``: the sixth callsign of the day is not asked."""
+    provider = FakeProvider(default=route_answer())
+    service = economy_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        probes=probes,
+        economy=EnrichmentEconomy(daily_lookup_budget=5),
+    )
+
+    for index in range(8):
+        clock.advance(1.0)
+        observe(live, clock, f"a0000{index:x}", callsign=f"DAL{index}00")
+    feed(service, live)
+    for _ in range(12):
+        await service.drain_once()
+
+    assert len(provider.calls) == 5
+    assert service.budget.limit == 5
+    assert service.budget.used_today == 5
+    assert service.budget.remaining == 0
+    # Queued, not dropped: the bound on the queue is still the queue's own.
+    assert service.pending == 3
+    assert await service.drain_once() is False
+
+
+async def test_an_uncapped_install_reports_no_ceiling(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    provider: FakeProvider,
+) -> None:
+    """``0`` is the default, and ``null`` is not ``0`` remaining."""
+    service = build_service(live=live, worker=worker, cache=cache, provider=provider, clock=clock)
+    observe(live, clock)
+    feed(service, live)
+    await pump(service)
+
+    budget = service.budget
+    assert (budget.limit, budget.remaining) == (None, None)
+    assert budget.used_today == 1
+
+
+async def test_the_days_spend_survives_a_restart(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    probes: Probes,
+) -> None:
+    """Counted from ``route_cache``, so a restart is not a fresh allowance."""
+    for index in range(3):
+        await cache.store_route(
+            f"DAL{index}", RouteInfo(ORIGIN, DESTINATION), now_ms=clock.epoch_ms()
+        )
+    provider = FakeProvider(default=route_answer())
+    service = economy_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        probes=probes,
+        economy=EnrichmentEconomy(daily_lookup_budget=3),
+    )
+
+    observe(live, clock)
+    feed(service, live)
+    await pump(service)
+
+    assert provider.calls == []
+    assert service.budget.used_today == 3
+    assert service.budget.remaining == 0
+
+
+async def test_the_next_utc_day_buys_again(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    probes: Probes,
+) -> None:
+    """Midnight UTC, on the injected clock rather than on a real one."""
+    provider = FakeProvider(default=route_answer())
+    service = economy_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        probes=probes,
+        economy=EnrichmentEconomy(daily_lookup_budget=1),
+    )
+    observe(live, clock, "a00001", callsign="DAL100")
+    feed(service, live)
+    await pump(service)
+    clock.advance(1.0)
+    observe(live, clock, "a00002", callsign="DAL200")
+    feed(service, live)
+    await pump(service)
+    assert provider.calls == ["DAL100"]
+
+    clock.advance(TO_TOMORROW_S)
+    observe(live, clock, "a00002", callsign="DAL200")
+    feed(service, live)
+    await pump(service)
+
+    # The callsign yesterday's budget refused is the new day's first purchase.
+    assert provider.calls == ["DAL100", "DAL200"]
+    assert service.budget.used_today == 1
+
+
+async def test_the_exhausted_budget_is_logged_once_a_day(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    probes: Probes,
+    logs: RecordedLogs,
+) -> None:
+    """One line per day, not one per refused callsign.
+
+    The refusal repeats for every eligible callsign until midnight, so a line
+    per refusal would be a log flood describing a single decision.
+    """
+    provider = FakeProvider(default=route_answer())
+    service = economy_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        probes=probes,
+        economy=EnrichmentEconomy(daily_lookup_budget=1),
+    )
+
+    for index in range(5):
+        clock.advance(1.0)
+        observe(live, clock, f"a0000{index:x}", callsign=f"DAL{index}00")
+        feed(service, live)
+        await pump(service)
+
+    exhausted = logs.named(BUDGET_EXHAUSTED_EVENT)
+    assert len(exhausted) == 1
+    assert exhausted[0]["limit"] == 1
+    assert exhausted[0]["used_today"] == 1
+
+
+async def test_the_next_day_may_report_an_exhausted_budget_again(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    probes: Probes,
+    logs: RecordedLogs,
+) -> None:
+    """Once *per day*: a second day of the same refusal is worth saying."""
+    provider = FakeProvider(default=route_answer())
+    service = economy_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        probes=probes,
+        economy=EnrichmentEconomy(daily_lookup_budget=1),
+    )
+
+    for day in range(2):
+        for index in range(3):
+            clock.advance(1.0)
+            observe(live, clock, f"a{day}000{index:x}", callsign=f"DAL{day}{index}0")
+            feed(service, live)
+            await pump(service)
+        clock.advance(TO_TOMORROW_S)
+
+    assert len(logs.named(BUDGET_EXHAUSTED_EVENT)) == 2
+
+
+async def test_a_cached_answer_costs_nothing_against_the_budget(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    probes: Probes,
+) -> None:
+    """The budget bounds *requests*; the cache is what makes it go far."""
+    await cache.store_route(KEY, RouteInfo(ORIGIN, DESTINATION), now_ms=clock.epoch_ms())
+    provider = FakeProvider(default=route_answer())
+    service = economy_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        probes=probes,
+        economy=EnrichmentEconomy(daily_lookup_budget=1),
+    )
+
+    observe(live, clock)
+    await worker.process_pending()
+    feed(service, live)
+    await pump(service)
+
+    assert provider.calls == []
+    assert worker.route_for(ICAO) is not None
+
+
+# ------------------------------------------------------------- the priority
+
+
+async def test_an_alerting_aircraft_is_asked_about_first(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    probes: Probes,
+) -> None:
+    """The acceptance criterion: one alert match among ten ordinary callsigns."""
+    provider = FakeProvider(default=route_answer())
+    service = economy_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        probes=probes,
+    )
+    for index in range(10):
+        clock.advance(1.0)
+        observe(live, clock, f"a0000{index:x}", callsign=f"DAL{index}00")
+    clock.advance(1.0)
+    observe(live, clock, "b00001", callsign="AAL9999")
+    probes.alerting.add("b00001")
+    feed(service, live)
+
+    await service.drain_once()
+
+    assert provider.calls == ["AAL9999"]
+
+
+async def test_an_aircraft_inside_the_display_radius_outranks_the_rest(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    probes: Probes,
+) -> None:
+    """What the map is showing beats what it is not."""
+    provider = FakeProvider(default=route_answer())
+    probes.radius_nm = 50.0
+    service = economy_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        probes=probes,
+    )
+    observe(live, clock, "a00001", callsign="DAL100", position=FAR_AWAY)
+    clock.advance(1.0)
+    observe(live, clock, "a00002", callsign="DAL200")
+    clock.advance(1.0)
+    observe(live, clock, "a00003", callsign="DAL300", position=NEAR_RECEIVER)
+    feed(service, live)
+
+    await service.drain_once()
+
+    assert provider.calls == ["DAL300"]
+
+
+async def test_a_refresh_of_a_known_route_goes_last(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    probes: Probes,
+) -> None:
+    """Something correct is already on file for a refresh; nothing is for a miss."""
+    provider = FakeProvider(default=route_answer())
+    service = economy_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        probes=probes,
+        economy=EnrichmentEconomy(route_ttl_days=1),
+    )
+    observe(live, clock, "a00001", callsign="DAL100")
+    feed(service, live)
+    await pump(service)
+    assert provider.calls == ["DAL100"]
+
+    # A day later the answer has expired, so DAL100 queues as a refresh — and
+    # a callsign nobody has an answer for queues behind it, and goes first.
+    clock.advance(SECONDS_PER_DAY + 60.0)
+    observe(live, clock, "a00001", callsign="DAL100")
+    clock.advance(1.0)
+    observe(live, clock, "a00002", callsign="DAL200")
+    feed(service, live)
+    await service.drain_once()
+
+    assert provider.calls == ["DAL100", "DAL200"]
+
+
+async def test_within_a_priority_the_queue_is_still_first_in_first_out(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    probes: Probes,
+) -> None:
+    """Priority reorders tiers; it does not shuffle the aircraft in one."""
+    provider = FakeProvider(default=route_answer())
+    service = economy_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        probes=probes,
+    )
+    for index in range(3):
+        clock.advance(1.0)
+        observe(live, clock, f"a0000{index:x}", callsign=f"DAL{index}00")
+    feed(service, live)
+
+    for _ in range(3):
+        await service.drain_once()
+
+    assert provider.calls == ["DAL000", "DAL100", "DAL200"]
+
+
+# ------------------------------------------------------ consistency (the latch)
+
+
+async def test_a_landing_somewhere_else_invalidates_the_cached_route(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    probes: Probes,
+) -> None:
+    """The aircraft disproves the row, and the next observation re-buys it."""
+    await cache.store_route(KEY, RouteInfo(ORIGIN, DESTINATION), now_ms=clock.epoch_ms())
+    provider = FakeProvider({AIRLINE_CALLSIGN: RouteInfo("KSEA", "KPDX")})
+    service = economy_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        probes=probes,
+    )
+    probes.contexts[ICAO] = arriving_at("KPDX")
+
+    observe(live, clock)
+    feed(service, live)
+    await pump(service)
+    await worker.process_pending()
+
+    assert provider.calls == [AIRLINE_CALLSIGN]
+    row = await cache.get(KEY, now_ms=clock.epoch_ms())
+    assert row is not None
+    assert (row.origin_ident, row.destination_ident) == ("KSEA", "KPDX")
+
+
+async def test_a_departure_from_the_cached_origin_invalidates_nothing(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    probes: Probes,
+) -> None:
+    """The check must be cheap *and* quiet, or it is just a second lookup."""
+    await cache.store_route(KEY, RouteInfo(ORIGIN, DESTINATION), now_ms=clock.epoch_ms())
+    provider = FakeProvider(default=route_answer())
+    service = economy_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        probes=probes,
+    )
+    probes.contexts[ICAO] = departing_from(ORIGIN)
+
+    observe(live, clock)
+    feed(service, live)
+    await pump(service)
+
+    assert provider.calls == []
+
+
+async def test_a_contradicted_route_is_re_bought_once_and_not_in_a_loop(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    probes: Probes,
+) -> None:
+    """A provider that keeps saying the same thing must not be asked forever.
+
+    The invalidation fires once per callsign per process. Without that bound a
+    route the aircraft permanently disagrees with — an IATA code against an
+    ICAO-identified field, say — would be a request per observation, which is
+    the shape of the retry storm this slice exists to stop.
+    """
+    await cache.store_route(KEY, RouteInfo(ORIGIN, DESTINATION), now_ms=clock.epoch_ms())
+    provider = FakeProvider({AIRLINE_CALLSIGN: RouteInfo(ORIGIN, DESTINATION)})
+    service = economy_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        probes=probes,
+    )
+    probes.contexts[ICAO] = arriving_at("KPDX")
+
+    for _ in range(5):
+        clock.advance(1.0)
+        observe(live, clock)
+        feed(service, live)
+        await pump(service)
+
+    assert provider.calls == [AIRLINE_CALLSIGN]
+
+
+async def test_an_answer_already_in_memory_is_invalidated_too(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    probes: Probes,
+) -> None:
+    """The memory gate sits in front of the table, so it checks as well."""
+    provider = FakeProvider({AIRLINE_CALLSIGN: RouteInfo(ORIGIN, DESTINATION)})
+    service = economy_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        probes=probes,
+    )
+    observe(live, clock)
+    await worker.process_pending()
+    feed(service, live)
+    await pump(service)
+    assert provider.calls == [AIRLINE_CALLSIGN]
+
+    provider.answers[AIRLINE_CALLSIGN] = RouteInfo("KSEA", "KPDX")
+    probes.contexts[ICAO] = arriving_at("KPDX")
+    clock.advance(1.0)
+    observe(live, clock)
+    feed(service, live)
+    await pump(service)
+    await worker.process_pending()
+
+    assert provider.calls == [AIRLINE_CALLSIGN, AIRLINE_CALLSIGN]
+    route = worker.route_for(ICAO)
+    assert route is not None
+    assert (route.origin_ident, route.destination_ident) == ("KSEA", "KPDX")
+
+
+# ------------------------------------------------------------- learned rows
+
+
+async def test_a_confirmed_route_is_frozen_and_counted(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    probes: Probes,
+    database: Database,
+) -> None:
+    """Three days of the same answer, through the service that buys them."""
+    provider = FakeProvider(default=route_answer())
+    service = economy_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        probes=probes,
+        economy=EnrichmentEconomy(route_ttl_days=1),
+    )
+
+    for _ in range(4):
+        observe(live, clock)
+        feed(service, live)
+        await pump(service)
+        clock.advance(SECONDS_PER_DAY + 60.0)
+
+    row = await cache.get(KEY, now_ms=clock.epoch_ms())
+    assert len(provider.calls) == 4
+    assert row is not None
+    assert row.confirmations == 3
+    assert row.learned is True
+    # Thirty days out, not one: the row has earned its freeze.
+    assert row.expires_ms - row.fetched_ms == 30 * SECONDS_PER_DAY * MS_PER_SECOND
+    assert service.cache_stats.learned == 1
+    assert await cache.count_learned() == 1
+
+
+async def test_cache_hits_and_misses_are_counted_for_diagnostics(
+    live: LiveStore,
+    clock: SimulatedTime,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    probes: Probes,
+) -> None:
+    provider = FakeProvider(default=route_answer())
+    service = economy_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        probes=probes,
+    )
+
+    for _ in range(3):
+        clock.advance(1.0)
+        observe(live, clock)
+        feed(service, live)
+        await pump(service)
+
+    stats = service.cache_stats
+    assert stats.misses == 1
+    assert stats.hits == 2

--- a/backend/tests/enrichment/test_hot_apply.py
+++ b/backend/tests/enrichment/test_hot_apply.py
@@ -39,7 +39,14 @@ from fastapi.testclient import TestClient
 from pydantic import SecretStr
 
 from flightsite.app import create_app
-from flightsite.enrichment import AeroDataBoxProvider, EnrichmentService, RouteCacheRepository
+from flightsite.enrichment import (
+    AeroDataBoxProvider,
+    EnrichmentEconomy,
+    EnrichmentService,
+    RouteCacheRepository,
+    RouteInfo,
+)
+from flightsite.enrichment.cache import MS_PER_SECOND, SECONDS_PER_DAY
 from flightsite.enrichment.model import RouteUnavailable
 from flightsite.live import LiveStore
 from flightsite.sightings import PersistenceWorker
@@ -285,6 +292,143 @@ async def test_swapping_the_provider_resets_the_failure_circuit(
     assert failing.closed is True
 
 
+# --------------------------------------------------- applying a spending plan
+
+
+async def test_a_changed_budget_applies_without_restarting_the_worker(
+    live: LiveStore,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    clock: SimulatedTime,
+) -> None:
+    """Slice 070's numbers are adopted in place, not by a teardown.
+
+    A budget is not a provider: nothing about it invalidates the subscription,
+    the queue or the remembered answers, and restarting for it would shed a
+    queue of callsigns for a setting that does not change who is asked.
+    """
+    provider = AeroDataBoxProvider(api_key=SecretStr(SECRET_SENTINEL))
+    service = build_service(live=live, worker=worker, cache=cache, provider=provider, clock=clock)
+    await service.start()
+    tasks = (service._reader, service._worker)
+
+    await service.apply_provider(
+        AeroDataBoxProvider(api_key=SecretStr(SECRET_SENTINEL)),
+        EnrichmentEconomy(route_ttl_days=3, daily_lookup_budget=25),
+    )
+
+    try:
+        assert service.economy == EnrichmentEconomy(route_ttl_days=3, daily_lookup_budget=25)
+        assert service._provider is provider
+        assert (service._reader, service._worker) == tasks
+        assert service.budget.limit == 25
+    finally:
+        await service.stop()
+
+
+async def test_an_unchanged_budget_is_still_the_no_op_every_save_takes(
+    live: LiveStore,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    clock: SimulatedTime,
+) -> None:
+    """The whole configuration is compared, so an unrelated save changes nothing."""
+    economy = EnrichmentEconomy(route_ttl_days=3, daily_lookup_budget=25)
+    provider = AeroDataBoxProvider(api_key=SecretStr(SECRET_SENTINEL))
+    service = build_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        economy=economy,
+    )
+    await service.start()
+    tasks = (service._reader, service._worker)
+
+    await service.apply_provider(AeroDataBoxProvider(api_key=SecretStr(SECRET_SENTINEL)), economy)
+
+    try:
+        assert service._provider is provider
+        assert (service._reader, service._worker) == tasks
+    finally:
+        await service.stop()
+
+
+async def test_a_changed_ttl_is_used_by_the_next_answer_stored(
+    live: LiveStore,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    clock: SimulatedTime,
+) -> None:
+    """A setting that applied on the next restart would be a setting in a file."""
+    provider = FakeProvider({AIRLINE_CALLSIGN: route_answer()})
+    service = build_service(live=live, worker=worker, cache=cache, provider=provider, clock=clock)
+
+    await service.apply_provider(provider, EnrichmentEconomy(route_ttl_days=2))
+    observe(live, clock)
+    feed(service, live)
+    await pump(service)
+
+    row = await cache.get(AIRLINE_CALLSIGN, now_ms=clock.epoch_ms())
+    assert row is not None
+    assert row.expires_ms == clock.epoch_ms() + 2 * SECONDS_PER_DAY * MS_PER_SECOND
+
+
+async def test_raising_a_spent_budget_resumes_lookups_on_the_save(
+    live: LiveStore,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    clock: SimulatedTime,
+) -> None:
+    """Otherwise the owner who noticed the cap would wait until midnight."""
+    provider = FakeProvider(default=route_answer())
+    service = build_service(
+        live=live,
+        worker=worker,
+        cache=cache,
+        provider=provider,
+        clock=clock,
+        economy=EnrichmentEconomy(daily_lookup_budget=1),
+    )
+    for index in range(2):
+        clock.advance(1.0)
+        observe(live, clock, f"a0000{index:x}", callsign=f"DAL{index}00")
+        feed(service, live)
+        await pump(service)
+    assert provider.calls == ["DAL000"]
+
+    await service.apply_provider(provider, EnrichmentEconomy(daily_lookup_budget=5))
+    await pump(service)
+
+    assert provider.calls == ["DAL000", "DAL100"]
+    assert service.budget.used_today == 2
+    assert service.budget.remaining == 3
+
+
+async def test_lowering_the_budget_below_what_is_spent_stops_lookups(
+    live: LiveStore,
+    worker: PersistenceWorker,
+    cache: RouteCacheRepository,
+    clock: SimulatedTime,
+) -> None:
+    """``remaining`` is clamped at zero rather than going negative."""
+    await cache.store_route("DAL000", RouteInfo("KATL", "KSLC"), now_ms=clock.epoch_ms())
+    await cache.store_route("DAL100", RouteInfo("KATL", "KSLC"), now_ms=clock.epoch_ms())
+    provider = FakeProvider(default=route_answer())
+    service = build_service(live=live, worker=worker, cache=cache, provider=provider, clock=clock)
+    await service.start()
+
+    await service.apply_provider(provider, EnrichmentEconomy(daily_lookup_budget=1))
+    observe(live, clock, "a00003", callsign="DAL300")
+    feed(service, live)
+    await pump(service)
+    await service.stop()
+
+    assert provider.calls == []
+    assert service.budget.remaining == 0
+
+
 # ------------------------------------------------------- applying through PUT
 
 
@@ -366,6 +510,37 @@ def test_a_save_that_disables_enrichment_stops_the_worker(client: TestClient) ->
     assert service.enabled is False
     # The key is still stored — it is the flag that was turned off.
     assert response.json()["secrets_set"] == {"enrichment.aerodatabox_api_key": True}
+
+
+def test_a_saved_budget_and_ttl_reach_the_running_worker(client: TestClient) -> None:
+    """Issue #167 end to end: type two numbers, save, and they are in force."""
+    service = enrichment_of(client)
+    client.put("/api/internal/config", json=ENABLE)
+    provider, reader = service._provider, service._reader
+
+    response = client.put(
+        "/api/internal/config",
+        json={"enrichment": {"route_ttl_days": 14, "daily_lookup_budget": 500}},
+    )
+
+    assert response.status_code == 200
+    assert service.economy.route_ttl_days == 14
+    assert service.economy.daily_lookup_budget == 500
+    assert service.budget.limit == 500
+    # And the worker kept everything it was doing: a number is not a re-key.
+    assert service._provider is provider
+    assert service._reader is reader
+    assert service.running is True
+
+
+def test_the_budget_can_be_set_before_enrichment_is_enabled(client: TestClient) -> None:
+    """The Settings page can be filled in in any order, as it always could."""
+    service = enrichment_of(client)
+
+    client.put("/api/internal/config", json={"enrichment": {"daily_lookup_budget": 40}})
+
+    assert service.enabled is False
+    assert service.economy.daily_lookup_budget == 40
 
 
 def test_a_save_about_another_section_leaves_the_worker_untouched(client: TestClient) -> None:

--- a/backend/tests/enrichment/test_migration.py
+++ b/backend/tests/enrichment/test_migration.py
@@ -31,7 +31,10 @@ REVISION = "0006"
 PREVIOUS = "0005"
 TABLE = "route_cache"
 
-#: ``docs/DATA_MODEL.md`` §7, column for column.
+#: The table as **this revision** creates it. Later revisions add to it —
+#: 0014 adds the learned-schedule columns — so the shape assertions below
+#: upgrade to 0006 rather than to head, and stay a statement about what 0006
+#: is responsible for.
 EXPECTED_COLUMNS = {
     "cache_key": "TEXT",
     "status": "TEXT",
@@ -75,7 +78,7 @@ async def test_the_schema_at_head_matches_the_models(db_path: Path) -> None:
 
 
 async def test_the_table_matches_the_data_model(db_path: Path) -> None:
-    await upgrade_empty_database(db_path)
+    await upgrade_empty_database(db_path, REVISION)
 
     assert column_types(db_path, TABLE) == EXPECTED_COLUMNS
     assert primary_key_columns(db_path, TABLE) == ["cache_key"]
@@ -84,7 +87,7 @@ async def test_the_table_matches_the_data_model(db_path: Path) -> None:
 
 async def test_only_the_answer_columns_are_nullable(db_path: Path) -> None:
     """A cached row always knows *what* it is and *when* it expires."""
-    await upgrade_empty_database(db_path)
+    await upgrade_empty_database(db_path, REVISION)
 
     assert not_null_columns(db_path, TABLE) == {
         "cache_key",
@@ -96,7 +99,7 @@ async def test_only_the_answer_columns_are_nullable(db_path: Path) -> None:
 
 async def test_expiry_is_indexed_for_pruning(db_path: Path) -> None:
     """The one query that is not a point lookup."""
-    await upgrade_empty_database(db_path)
+    await upgrade_empty_database(db_path, REVISION)
 
     assert "ix_route_cache_expiry" in index_names(db_path, TABLE)
     assert "expires_ms" in index_sql(db_path, "ix_route_cache_expiry")
@@ -115,7 +118,12 @@ async def test_the_status_check_is_enforced_by_sqlite(db_path: Path) -> None:
 
 @pytest.mark.parametrize("status", list(RouteCacheStatus))
 async def test_every_vocabulary_value_is_accepted(db_path: Path, status: RouteCacheStatus) -> None:
-    """The runtime enum and the SQL ``CHECK`` name the same three values."""
+    """The runtime enum and the SQL ``CHECK`` name the same values.
+
+    At head, not at 0006: ``restricted`` joined the vocabulary in 0014, and the
+    claim worth testing is that the enum and the constraint the application
+    runs against agree.
+    """
     await upgrade_empty_database(db_path)
 
     with sqlite3.connect(db_path) as connection:

--- a/backend/tests/enrichment/test_migration_economy.py
+++ b/backend/tests/enrichment/test_migration_economy.py
@@ -1,0 +1,208 @@
+"""Migration 0014: learned-schedule columns, the ``restricted`` status, rollback.
+
+Same discipline as ``test_migration.py`` next door — every assertion reads the
+database file with stdlib ``sqlite3`` through :mod:`tests.db.harness`, so "the
+migration did this" cannot be satisfied by a model declaration alone. This
+revision also *rebuilds* ``route_cache`` rather than altering it, so the tests
+below care as much about what survived the rebuild as about what changed.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from flightsite.db import migrate
+from flightsite.db.models import ROUTE_CACHE_STATUS_CHECK
+from flightsite.enrichment.cache import LEARNED_CONFIRMATIONS
+from flightsite.enrichment.model import RouteCacheStatus
+from tests.db.harness import (
+    autogenerate_diffs,
+    column_types,
+    create_sql,
+    database_at,
+    index_names,
+    index_sql,
+    not_null_columns,
+    primary_key_columns,
+    upgrade_empty_database,
+)
+
+REVISION = "0014"
+PREVIOUS = "0013"
+TABLE = "route_cache"
+
+#: ``docs/DATA_MODEL.md`` §7 at this revision, column for column.
+EXPECTED_COLUMNS = {
+    "cache_key": "TEXT",
+    "status": "TEXT",
+    "origin_ident": "TEXT",
+    "destination_ident": "TEXT",
+    "payload_json": "TEXT",
+    "fetched_ms": "INTEGER",
+    "expires_ms": "INTEGER",
+    "confirmations": "INTEGER",
+    "first_fetched_ms": "INTEGER",
+}
+
+_INSERT = (
+    "INSERT INTO route_cache (cache_key, status, origin_ident, destination_ident, "
+    "fetched_ms, expires_ms) VALUES (?, ?, ?, ?, ?, ?)"
+)
+
+
+def _rows(db_path: Path) -> list[tuple[object, ...]]:
+    with sqlite3.connect(db_path) as connection:
+        return list(
+            connection.execute(
+                "SELECT cache_key, status, origin_ident, confirmations, first_fetched_ms "
+                "FROM route_cache ORDER BY cache_key"
+            )
+        )
+
+
+def test_this_revision_sits_directly_on_the_previous_head() -> None:
+    """The linear-history rule of ``docs/DEVELOPMENT.md`` §"Parallel migrations"."""
+    script = migrate.script_directory().get_revision(REVISION)
+
+    assert script.down_revision == PREVIOUS
+
+
+def test_it_is_the_only_head() -> None:
+    """One head, and it is this one — the rule a migration slice must leave true."""
+    assert [script.revision for script in migrate.script_directory().get_revisions("heads")] == [
+        REVISION
+    ]
+
+
+async def test_the_learned_columns_arrive_with_this_revision(db_path: Path) -> None:
+    async with database_at(db_path, PREVIOUS):
+        pass
+    before = column_types(db_path, TABLE)
+
+    async with database_at(db_path, REVISION) as database:
+        assert await database.current_revision() == REVISION
+
+    assert "confirmations" not in before
+    assert column_types(db_path, TABLE) == EXPECTED_COLUMNS
+
+
+async def test_the_rebuilt_table_keeps_its_shape(db_path: Path) -> None:
+    """``WITHOUT ROWID``, the text primary key and the expiry index all survive."""
+    await upgrade_empty_database(db_path)
+
+    assert primary_key_columns(db_path, TABLE) == ["cache_key"]
+    assert "WITHOUT ROWID" in create_sql(db_path, TABLE).upper()
+    assert "ix_route_cache_expiry" in index_names(db_path, TABLE)
+    assert "expires_ms" in index_sql(db_path, "ix_route_cache_expiry")
+
+
+async def test_the_confirmation_count_is_never_null(db_path: Path) -> None:
+    """Zero confirmations is a number; ``NULL`` would be a third state."""
+    await upgrade_empty_database(db_path)
+
+    assert "confirmations" in not_null_columns(db_path, TABLE)
+    assert "first_fetched_ms" not in not_null_columns(db_path, TABLE)
+
+
+async def test_existing_rows_survive_the_rebuild_with_no_confirmations(db_path: Path) -> None:
+    """An upgrade must not throw away a cache the install already paid for."""
+    async with database_at(db_path, PREVIOUS):
+        pass
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(_INSERT, ("DAL1234:2026-09-03", "ok", "KATL", "KSLC", 1, 2))
+
+    async with database_at(db_path, REVISION):
+        pass
+
+    assert _rows(db_path) == [("DAL1234:2026-09-03", "ok", "KATL", 0, None)]
+
+
+async def test_the_schema_at_head_matches_the_models(db_path: Path) -> None:
+    """Drift is checked at head, where the models describe the whole schema."""
+    async with database_at(db_path) as database:
+        assert await autogenerate_diffs(database) == []
+
+
+async def test_a_restricted_row_is_accepted_only_after_this_revision(db_path: Path) -> None:
+    """The ``CHECK`` is what makes ``restricted`` a vocabulary rather than a note."""
+    async with database_at(db_path, PREVIOUS):
+        pass
+    with sqlite3.connect(db_path) as connection, pytest.raises(sqlite3.IntegrityError):
+        connection.execute(_INSERT, ("EJM99", "restricted", None, None, 1, 2))
+
+    async with database_at(db_path, REVISION):
+        pass
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(_INSERT, ("EJM99", "restricted", None, None, 1, 2))
+
+
+async def test_an_unknown_status_is_still_refused(db_path: Path) -> None:
+    await upgrade_empty_database(db_path)
+
+    with sqlite3.connect(db_path) as connection, pytest.raises(sqlite3.IntegrityError):
+        connection.execute(_INSERT, ("DAL1", "maybe", None, None, 1, 2))
+
+
+async def test_the_confirmation_column_holds_what_the_cache_writes(db_path: Path) -> None:
+    """The learned threshold is a value in this column, not a separate flag."""
+    await upgrade_empty_database(db_path)
+
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(_INSERT, ("DAL1", "ok", "KATL", "KSLC", 1, 2))
+        connection.execute(
+            "UPDATE route_cache SET confirmations = ?, first_fetched_ms = ? WHERE cache_key = ?",
+            (LEARNED_CONFIRMATIONS, 1, "DAL1"),
+        )
+
+    assert _rows(db_path) == [("DAL1", "ok", "KATL", LEARNED_CONFIRMATIONS, 1)]
+
+
+async def test_the_revision_rolls_back(db_path: Path) -> None:
+    """A migration that cannot be undone is a one-way door.
+
+    The rollback drops the two columns and restores the older vocabulary, so a
+    ``restricted`` row cannot survive it — it is deleted rather than left to
+    break the constraint, and the callsign is simply looked up again.
+    """
+    await upgrade_empty_database(db_path)
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(_INSERT, ("DAL1", "ok", "KATL", "KSLC", 1, 2))
+        connection.execute(_INSERT, ("EJM99", "restricted", None, None, 1, 2))
+
+    async with database_at(db_path) as database:
+        await database.downgrade_to(PREVIOUS)
+        assert await database.current_revision() == PREVIOUS
+
+    columns = column_types(db_path, TABLE)
+    with sqlite3.connect(db_path) as connection:
+        remaining = list(connection.execute("SELECT cache_key FROM route_cache"))
+
+    assert "confirmations" not in columns
+    assert "first_fetched_ms" not in columns
+    assert remaining == [("DAL1",)]
+    assert "WITHOUT ROWID" in create_sql(db_path, TABLE).upper()
+    assert "ix_route_cache_expiry" in index_names(db_path, TABLE)
+
+
+async def test_the_models_predicate_is_the_one_in_the_file(db_path: Path) -> None:
+    """Autogenerate does not compare ``CHECK`` constraints, so this does.
+
+    The migrations spell their vocabularies out (each records what an install
+    ran), which is only safe while something asserts that the newest one still
+    matches the constant the application reasons about.
+    """
+    await upgrade_empty_database(db_path)
+
+    assert ROUTE_CACHE_STATUS_CHECK in create_sql(db_path, TABLE)
+
+
+async def test_the_runtime_vocabulary_and_the_constraint_agree(db_path: Path) -> None:
+    """Every member of the enum is a value SQLite will store at head."""
+    await upgrade_empty_database(db_path)
+
+    with sqlite3.connect(db_path) as connection:
+        for status in RouteCacheStatus:
+            connection.execute(_INSERT, (f"X{status.value}", status.value, None, None, 1, 2))

--- a/backend/tests/enrichment/test_policy.py
+++ b/backend/tests/enrichment/test_policy.py
@@ -1,4 +1,4 @@
-"""The eligibility matrix: who gets looked up, and under what key.
+"""The eligibility matrix: who gets looked up, under what key, and until when.
 
 The most consequential table in the slice. A false negative here costs one
 missing route; a false positive spends a request against the user's quota every
@@ -8,15 +8,15 @@ the cases are enumerated rather than sampled.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta, timezone
-
 import pytest
 
+from flightsite.airports.model import AirportContext, InferredPhase
 from flightsite.classification.operators import CALLSIGN_PATTERN
 from flightsite.enrichment.policy import (
     MAX_CALLSIGN_LENGTH,
     airline_designator,
     cache_key,
+    contradicts_route,
     eligible_callsign,
     normalize_callsign,
 )
@@ -93,36 +93,73 @@ def test_a_callsign_that_is_not_the_form_has_no_designator() -> None:
     assert airline_designator("N738AB") is None
 
 
-def test_the_cache_key_is_the_callsign_and_the_utc_day() -> None:
-    at = datetime(2026, 8, 30, 22, 14, 31, tzinfo=UTC)
-
-    assert cache_key("DAL1234", at) == "DAL1234:2026-08-30"
-
-
-def test_two_observations_of_one_flight_share_a_key() -> None:
-    """The whole point: one request per flight per day, not per sighting."""
-    morning = datetime(2026, 8, 30, 6, 0, tzinfo=UTC)
-    evening = datetime(2026, 8, 30, 23, 59, tzinfo=UTC)
-
-    assert cache_key("DAL1234", morning) == cache_key("DAL1234", evening)
+def test_the_cache_key_is_the_callsign_alone() -> None:
+    """Slice 070 dropped the date bucket; the key is the callsign (§7)."""
+    assert cache_key("DAL1234") == "DAL1234"
 
 
-def test_the_same_flight_number_tomorrow_is_a_different_key() -> None:
-    """A flight number is a fact about a *day*; the key says so."""
-    today = datetime(2026, 8, 30, 12, 0, tzinfo=UTC)
-    tomorrow = datetime(2026, 8, 31, 12, 0, tzinfo=UTC)
-
-    assert cache_key("DAL1234", today) != cache_key("DAL1234", tomorrow)
+def test_the_key_normalizes_what_a_decoder_transmits() -> None:
+    """A padded, lower-cased transmission must not file a second row."""
+    assert cache_key("  dal1234 ") == cache_key("DAL1234")
 
 
-def test_a_non_utc_timestamp_is_bucketed_by_its_utc_day() -> None:
-    """Two zones either side of local midnight still share one UTC key."""
-    tokyo = datetime(2026, 8, 31, 7, 0, tzinfo=timezone(timedelta(hours=9)))
+def test_two_observations_of_one_flight_share_a_key_across_days() -> None:
+    """The measured saving: 62 % of a day's callsigns were heard yesterday.
 
-    assert cache_key("DAL1234", tokyo) == "DAL1234:2026-08-30"
+    With a dated key those two observations were two rows and two requests.
+    Now they are one row, and the expiry decides when it is bought again.
+    """
+    assert cache_key("DAL1234") == cache_key("DAL1234")
 
 
-def test_a_naive_timestamp_is_refused() -> None:
-    """The same rule the storage layer applies: no timestamp is assumed UTC."""
-    with pytest.raises(ValueError, match="naive"):
-        cache_key("DAL1234", datetime(2026, 8, 30, 22, 0))
+# ------------------------------------------------------- the consistency check
+
+
+ARRIVING_AT_KSEA = AirportContext(
+    ident="KSEA", name="Seattle-Tacoma Intl", distance_nm=3.0, phase=InferredPhase.ARRIVING
+)
+DEPARTING_KSEA = AirportContext(
+    ident="KSEA", name="Seattle-Tacoma Intl", distance_nm=2.0, phase=InferredPhase.DEPARTING
+)
+NEAR_KSEA = AirportContext(ident="KSEA", name="Seattle-Tacoma Intl", distance_nm=4.0)
+
+
+def test_a_departure_from_somewhere_else_contradicts_the_origin() -> None:
+    """The schedule changed under the cached row; the aircraft says so."""
+    assert contradicts_route(DEPARTING_KSEA, origin_ident="KATL", destination_ident="KSLC")
+
+
+def test_an_arrival_somewhere_else_contradicts_the_destination() -> None:
+    assert contradicts_route(ARRIVING_AT_KSEA, origin_ident="KATL", destination_ident="KSLC")
+
+
+def test_a_departure_from_the_cached_origin_contradicts_nothing() -> None:
+    assert not contradicts_route(DEPARTING_KSEA, origin_ident="ksea", destination_ident="KSLC")
+
+
+def test_an_arrival_at_the_cached_destination_contradicts_nothing() -> None:
+    assert not contradicts_route(ARRIVING_AT_KSEA, origin_ident="KATL", destination_ident="KSEA")
+
+
+def test_a_departure_is_checked_against_the_origin_only() -> None:
+    """Being right about one end is not evidence against the other."""
+    assert not contradicts_route(DEPARTING_KSEA, origin_ident="KSEA", destination_ident="KATL")
+
+
+def test_an_unnamed_end_of_the_route_contradicts_nothing() -> None:
+    """The cache claimed nothing about that airport, so nothing is disproved."""
+    assert not contradicts_route(DEPARTING_KSEA, origin_ident=None, destination_ident="KSLC")
+
+
+@pytest.mark.parametrize(
+    "context",
+    [
+        pytest.param(None, id="no-context"),
+        pytest.param(NEAR_KSEA, id="near-a-field-with-no-phase"),
+    ],
+)
+def test_without_a_latched_phase_nothing_is_contradicted(
+    context: AirportContext | None,
+) -> None:
+    """SPEC §39: weak evidence produces no answer, and invalidates nothing."""
+    assert not contradicts_route(context, origin_ident="KATL", destination_ident="KSLC")

--- a/backend/tests/enrichment/test_provider.py
+++ b/backend/tests/enrichment/test_provider.py
@@ -25,6 +25,7 @@ from flightsite.enrichment import (
     AeroDataBoxProvider,
     RouteInfo,
     RouteNotFound,
+    RouteRestricted,
     RouteUnavailable,
     aerodatabox,
     parse_route,
@@ -260,7 +261,6 @@ async def test_the_provider_answering_nothing_is_not_found(status: int) -> None:
         pytest.param(429, "rate_limited", id="rate-limited"),
         pytest.param(401, "http_401", id="rejected-key"),
         pytest.param(400, "http_400", id="bad-request"),
-        pytest.param(451, "http_451", id="legal"),
         pytest.param(500, "http_500", id="server-error"),
         pytest.param(503, "http_503", id="unavailable"),
     ],
@@ -270,6 +270,44 @@ async def test_an_error_status_is_unavailable_not_a_missing_route(status: int, r
     provider, client = mock_provider(responder(httpx.Response(status, json={"error": "no"})))
     async with client:
         assert await provider.lookup(CALLSIGN) == RouteUnavailable(reason=reason)
+
+
+async def test_a_legally_restricted_flight_is_its_own_answer() -> None:
+    """Issue #165: HTTP 451 is a fact about the flight, not about the API.
+
+    Read as an error it was a failure the breaker counted, so one restricted
+    business jet was re-requested nine times in twelve minutes and opened the
+    circuit twice. The provider now names it, and the service caches it.
+    """
+    provider, client = mock_provider(responder(httpx.Response(451, json={"error": "no"})))
+    async with client:
+        assert await provider.lookup(CALLSIGN) == RouteRestricted()
+
+
+async def test_a_restricted_answer_is_logged_with_its_own_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A findable line, and one that never carries the request or the key.
+
+    The module logger is replaced rather than captured through structlog: any
+    test that has built the real application has configured structlog with
+    cached bound loggers, and a cached logger cannot be intercepted.
+    """
+    recorded: list[tuple[str, dict[str, Any]]] = []
+
+    class Recorder:
+        def info(self, event: str, **fields: Any) -> None:
+            recorded.append((event, fields))
+
+    monkeypatch.setattr(aerodatabox, "logger", Recorder())
+    provider, client = mock_provider(responder(httpx.Response(451)))
+    async with client:
+        await provider.lookup(CALLSIGN)
+
+    events = [fields for event, fields in recorded if event == "enrichment_lookup_restricted"]
+    assert events and events[0]["reason"] == "restricted"
+    assert events[0]["callsign"] == CALLSIGN
+    assert SECRET_SENTINEL not in str(events[0])
 
 
 async def test_a_timeout_is_unavailable() -> None:

--- a/backend/tests/enrichment/test_service.py
+++ b/backend/tests/enrichment/test_service.py
@@ -19,7 +19,7 @@ from flightsite.api.serializers import aircraft_payload
 from flightsite.counters import counters
 from flightsite.db import Database
 from flightsite.enrichment import EnrichmentService, RouteCacheRepository, RouteInfo
-from flightsite.enrichment.model import RouteNotFound, RouteUnavailable
+from flightsite.enrichment.model import RouteLookup, RouteNotFound, RouteUnavailable
 from flightsite.enrichment.service import ENRICHMENT_FAILURES_COUNTER
 from flightsite.live import LiveStore
 from flightsite.live.events import AircraftAppeared, AircraftRemoved, AircraftStale
@@ -27,7 +27,6 @@ from flightsite.sightings import PersistenceWorker
 from flightsite.sightings.vocabulary import SightingEventType
 from tests.enrichment.conftest import (
     AIRLINE_CALLSIGN,
-    BASE_DATE,
     DESTINATION,
     ICAO,
     ORIGIN,
@@ -44,7 +43,9 @@ from tests.enrichment.conftest import (
     route_answer,
 )
 
-KEY = f"{AIRLINE_CALLSIGN}:{BASE_DATE}"
+#: The cache key of the fixtures' callsign — the callsign itself since
+#: slice 070 dropped the date bucket (``docs/DATA_MODEL.md`` §7).
+KEY = AIRLINE_CALLSIGN
 
 
 async def enrich(service: EnrichmentService, live: LiveStore, worker: PersistenceWorker) -> None:
@@ -690,7 +691,7 @@ async def test_an_aircraft_seen_mid_lookup_rides_the_request_in_flight(
 
         service: EnrichmentService
 
-        async def lookup(self, callsign: str) -> RouteInfo | RouteNotFound | RouteUnavailable:
+        async def lookup(self, callsign: str) -> RouteLookup:
             record = live.get(OTHER_ICAO)
             assert record is not None
             self.service.consider(AircraftAppeared(aircraft=record, at=record.last_seen))

--- a/backend/tests/enrichment/test_service.py
+++ b/backend/tests/enrichment/test_service.py
@@ -143,7 +143,12 @@ async def test_the_live_payload_carries_the_route_and_its_provenance(
 
     payload = aircraft_payload(record, route=worker.route_for(ICAO))
 
-    assert payload["route"] == {"origin": ORIGIN, "destination": DESTINATION}
+    assert payload["route"] == {
+        "origin": ORIGIN,
+        "origin_name": None,
+        "destination": DESTINATION,
+        "destination_name": None,
+    }
     assert payload["provenance"]["route"] == "aerodatabox"
 
 
@@ -157,7 +162,12 @@ async def test_the_route_block_is_present_and_null_before_enrichment(
 
     payload = aircraft_payload(record)
 
-    assert payload["route"] == {"origin": None, "destination": None}
+    assert payload["route"] == {
+        "origin": None,
+        "origin_name": None,
+        "destination": None,
+        "destination_name": None,
+    }
     assert "route" not in payload["provenance"]
 
 
@@ -302,7 +312,9 @@ async def test_a_disabled_install_leaves_a_clean_unknown(
 
     assert aircraft_payload(record, route=worker.route_for(ICAO))["route"] == {
         "origin": None,
+        "origin_name": None,
         "destination": None,
+        "destination_name": None,
     }
 
 

--- a/backend/tests/maintenance/test_retention.py
+++ b/backend/tests/maintenance/test_retention.py
@@ -54,22 +54,23 @@ async def test_expired_rows_are_removed_and_fresh_ones_kept(
 ) -> None:
     """The asymmetric TTLs mean one instant can expire one row and not the other.
 
-    A negative answer lives an hour and a found route twelve, so a prune two
-    hours after both were written must take exactly one of them. That is a
-    sharper assertion than "expired rows go": it proves the pruner reads each
-    row's own ``expires_ms`` rather than applying one age to the whole table.
+    A negative answer lives a day and a found route a week (slice 070), so a
+    prune between the two must take exactly one of them. That is a sharper
+    assertion than "expired rows go": it proves the pruner reads each row's own
+    ``expires_ms`` rather than applying one age to the whole table.
     """
-    await route_cache.store_route("BAW117-2026-08-31", LHR_JFK, now_ms=BASE_MS)
-    await route_cache.store_not_found("XXX999-2026-08-31", now_ms=BASE_MS)
-    two_hours_later = BASE_MS + 2 * 60 * 60 * MS_PER_SECOND
+    await route_cache.store_route("BAW117", LHR_JFK, now_ms=BASE_MS)
+    await route_cache.store_not_found("XXX999", now_ms=BASE_MS)
+    assert NEGATIVE_TTL_S < POSITIVE_TTL_S
+    between_the_two = BASE_MS + (NEGATIVE_TTL_S + 60) * MS_PER_SECOND
 
-    pruned = await RouteCachePruner(route_cache).prune(now_ms=two_hours_later)
+    pruned = await RouteCachePruner(route_cache).prune(now_ms=between_the_two)
 
     assert pruned == 1
     assert await route_cache.size() == 1
     # Through the repository's own reader, which is the agreement that matters.
-    assert await route_cache.get("BAW117-2026-08-31", now_ms=two_hours_later) is not None
-    assert await route_cache.get("XXX999-2026-08-31", now_ms=two_hours_later) is None
+    assert await route_cache.get("BAW117", now_ms=between_the_two) is not None
+    assert await route_cache.get("XXX999", now_ms=between_the_two) is None
 
 
 async def test_a_row_expiring_exactly_now_is_pruned(route_cache: RouteCacheRepository) -> None:

--- a/backend/tests/maintenance/test_service.py
+++ b/backend/tests/maintenance/test_service.py
@@ -20,7 +20,7 @@ from flightsite.counters import CounterRegistry
 from flightsite.db import Database
 from flightsite.db.engine import QUICK_CHECK_OK
 from flightsite.db.models import Meta
-from flightsite.enrichment.cache import RouteCacheRepository
+from flightsite.enrichment.cache import MS_PER_SECOND, SECONDS_PER_DAY, RouteCacheRepository
 from flightsite.enrichment.model import RouteInfo
 from flightsite.live import LiveStore
 from flightsite.maintenance.model import (
@@ -745,9 +745,12 @@ async def test_the_real_route_cache_pruner_is_driven_by_the_cycle(
     route_cache: RouteCacheRepository,
 ) -> None:
     """The wiring the app uses, exercised end to end rather than with a double."""
-    await route_cache.store_not_found("XXX999-2026-08-31", now_ms=clock.now_ms - 10_000_000)
+    # Two days back, so the 24 h negative TTL has run out and the week-long
+    # positive one written below has not.
+    two_days_ago = clock.now_ms - 2 * SECONDS_PER_DAY * MS_PER_SECOND
+    await route_cache.store_not_found("XXX999", now_ms=two_days_ago)
     await route_cache.store_route(
-        "BAW117-2026-08-31",
+        "BAW117",
         RouteInfo(origin_ident="EGLL", destination_ident="KJFK"),
         now_ms=clock.now_ms,
     )

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -15,6 +15,11 @@ from flightsite.config import (
     Settings,
     SightingTimingSettings,
 )
+from flightsite.enrichment.cache import (
+    DEFAULT_ROUTE_TTL_DAYS,
+    MAX_ROUTE_TTL_DAYS,
+    MIN_ROUTE_TTL_DAYS,
+)
 
 
 @pytest.mark.parametrize(
@@ -150,6 +155,53 @@ def test_alert_template_ids_are_deduplicated() -> None:
 def test_enrichment_requires_a_key_when_enabled() -> None:
     with pytest.raises(ValidationError, match="requires an AeroDataBox API key"):
         EnrichmentSettings(aerodatabox_enabled=True)
+
+
+def test_the_enrichment_economy_defaults_to_a_week_and_no_cap() -> None:
+    """Slice 070's defaults: a week-long cache, and the spending it always had."""
+    enrichment = EnrichmentSettings()
+
+    assert enrichment.route_ttl_days == DEFAULT_ROUTE_TTL_DAYS
+    assert enrichment.daily_lookup_budget == 0
+
+
+def test_the_config_bounds_are_the_ones_the_cache_enforces() -> None:
+    """The model spells the bounds as literals (it cannot import the cache).
+
+    So this is the test that keeps the two spellings honest, exactly as
+    ``db.models``' ``CHECK`` vocabularies are kept honest against their enums.
+    """
+    field = EnrichmentSettings.model_fields["route_ttl_days"]
+    bounds = {
+        type(item).__name__: getattr(item, "ge", getattr(item, "le", None))
+        for item in field.metadata
+    }
+
+    assert bounds["Ge"] == MIN_ROUTE_TTL_DAYS
+    assert bounds["Le"] == MAX_ROUTE_TTL_DAYS
+
+
+@pytest.mark.parametrize("days", [MIN_ROUTE_TTL_DAYS, DEFAULT_ROUTE_TTL_DAYS, MAX_ROUTE_TTL_DAYS])
+def test_a_route_ttl_inside_the_bounds_is_accepted(days: int) -> None:
+    assert EnrichmentSettings(route_ttl_days=days).route_ttl_days == days
+
+
+@pytest.mark.parametrize(
+    "days",
+    [
+        pytest.param(0, id="below-a-day-is-not-a-cache"),
+        pytest.param(31, id="beyond-a-month-is-the-confirmation-freeze"),
+    ],
+)
+def test_a_route_ttl_outside_the_bounds_is_refused(days: int) -> None:
+    with pytest.raises(ValidationError):
+        EnrichmentSettings(route_ttl_days=days)
+
+
+def test_a_negative_daily_budget_is_refused() -> None:
+    """Zero already means uncapped; a negative number would mean nothing."""
+    with pytest.raises(ValidationError):
+        EnrichmentSettings(daily_lookup_budget=-1)
 
 
 def test_unknown_nested_key_is_rejected_by_the_model() -> None:

--- a/backend/tests/test_config_writeback.py
+++ b/backend/tests/test_config_writeback.py
@@ -145,7 +145,13 @@ def test_secrets_are_never_written_to_config_yaml(store: ConfigStore) -> None:
     config_text = store.config_path.read_text(encoding="utf-8")
     assert SECRET_SENTINEL not in config_text
     assert "aerodatabox_api_key" not in config_text
-    assert yaml.safe_load(config_text)["enrichment"] == {"aerodatabox_enabled": False}
+    # The non-secret half of the section is written in full; only the key is
+    # held back (slice 070 added the two economy numbers to that half).
+    assert yaml.safe_load(config_text)["enrichment"] == {
+        "aerodatabox_enabled": False,
+        "route_ttl_days": 7,
+        "daily_lookup_budget": 0,
+    }
 
 
 def test_secrets_are_written_only_to_secrets_yaml(store: ConfigStore) -> None:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -95,6 +95,15 @@ map:
 # FLIGHTSITE_ENRICHMENT__AERODATABOX_API_KEY — never in this file.
 enrichment:
   aerodatabox_enabled: false
+  # How long a found route stays cached, in days (1-30). A scheduled flight
+  # number flies the same airports for a season, so a week of cache is one
+  # lookup instead of one or two a day; a route confirmed on three separate
+  # days is then frozen for 30 days automatically.
+  route_ttl_days: 7
+  # Provider lookups allowed per UTC day. 0 is uncapped; set it if your
+  # AeroDataBox credits are finite. When it is spent, lookups stop until
+  # midnight UTC and cached routes keep being applied.
+  daily_lookup_budget: 0
 
 # Aircraft metadata sources. Mictronics and the FAA registry are always active
 # and need nothing here. OpenSky is opt-in because its licensing is unclear:

--- a/docs/API.md
+++ b/docs/API.md
@@ -126,7 +126,12 @@ source of each non-decoder field group (SPEC §22):
 {
   "operator": "Delta Air Lines",
   "registration": "N302DN",
-  "route": { "origin": "KATL", "destination": "KSLC" },
+  "route": {
+    "origin": "KATL",
+    "origin_name": "Hartsfield Jackson Atlanta International Airport",
+    "destination": "KSLC",
+    "destination_name": "Salt Lake City International Airport"
+  },
   "provenance": {
     "operator": "mictronics",
     "registration": "faa",
@@ -144,6 +149,16 @@ on `operator`, `owner`, `model` or `manufacture_year`, the four fields it may fi
 Fields without an entry are decoder-direct. Position source is a
 separate, always-present field (§ 3.3) because it is safety-relevant display state,
 not enrichment.
+
+The `route` block carries four members: `origin` and `destination` (the idents the
+enrichment provider reported) and `origin_name` and `destination_name` (those idents
+looked up in the **local** `airports` table imported by slice 027 — never a second
+provider call). All four are always present. A name is `null` when the ident is
+`null`, and also whenever the local dataset does not carry that ident — including on
+every install until an airports import has run, where every name is `null` while the
+idents are unaffected. Names carry no provenance entry of their own: `route` already
+names where the route came from, and a name is a local label for it rather than a
+second claim. Clients render the name when there is one and fall back to the ident.
 
 ### 2.7 Null / Unknown semantics
 
@@ -298,7 +313,12 @@ Aircraft object (the same shape used by the WebSocket):
     "severity": "high",
     "reasons": ["Rule: Military aircraft"]
   },
-  "route": { "origin": "KATL", "destination": "KSEA" },
+  "route": {
+    "origin": "KATL",
+    "origin_name": "Hartsfield Jackson Atlanta International Airport",
+    "destination": "KSEA",
+    "destination_name": "Seattle Tacoma International Airport"
+  },
   "provenance": {
     "registration": "mictronics",
     "operator": "mictronics",
@@ -312,6 +332,9 @@ Aircraft object (the same shape used by the WebSocket):
 - `route`: the current sighting's externally reported route (§2.6 shape) — always
   present, members `null` until enrichment lands (slice 026); never a locally
   inferred value (that is the separate nearest-airport context, slice 027).
+  `origin_name`/`destination_name` are the reported idents named from the local
+  `airports` table (slice 027, slice 070) and stay `null` until an airports import
+  has run.
 
 - `position_source`: `adsb` | `mlat` | `none` | `other` (SPEC §21). Non-positioned
   aircraft have `position: null`, `position_source: "none"`.
@@ -385,7 +408,12 @@ Sighting detail sketch:
   "ended_at": "2026-08-30T22:41:55Z",
   "duration_s": 2385,
   "closure_reason": "gap_timeout",
-  "route": { "origin": "KTCM", "destination": "PHIK" },
+  "route": {
+    "origin": "KTCM",
+    "origin_name": "McChord Air Force Base",
+    "destination": "PHIK",
+    "destination_name": "Hickam Air Force Base"
+  },
   "reception": {
     "rssi_peak_db": -3.2,
     "rssi_avg_db": -11.8,

--- a/docs/API.md
+++ b/docs/API.md
@@ -546,6 +546,26 @@ Two contract details worth knowing:
   and `permission_known_by` is always `"client"`. Browser permission is unobservable
   from the backend, so the health page joins this with the frontend notification store
   (slice 040) to show the permission the user actually granted.
+- `enrichment` carries `budget` and `cache` alongside the failure counters (slice 070):
+
+  ```json
+  "enrichment": {
+    "enabled": true, "running": true, "circuit_open": false,
+    "lookups": 308, "dropped": 0, "pending": 2, "failures": 0,
+    "budget": {
+      "limit": 500, "used_today": 137, "remaining": 363,
+      "resets_at": "2026-09-05T00:00:00.000Z"
+    },
+    "cache": { "hits": 4112, "misses": 308, "learned": 57 }
+  }
+  ```
+
+  `limit` and `remaining` are `null` on an uncapped install (`daily_lookup_budget: 0`,
+  the default) — which is not the same as `0`: one means there is no ceiling, the other
+  means today's ceiling has been reached. `used_today` counts route-cache rows fetched
+  in the current UTC day, so it survives a restart, and `resets_at` is the next UTC
+  midnight. `cache.learned` is the number of cached routes confirmed on enough separate
+  days to be frozen for 30 days ([DATA_MODEL.md §7](DATA_MODEL.md)).
 - `database.maintenance.vacuum_refusal` is `null` unless the guarded `VACUUM` last
   declined to run, and otherwise carries `reason` plus `required_free_bytes` and
   `available_free_bytes`. The free-space guard wants twice the database size, so on a

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -83,10 +83,13 @@ the Alerts page also apply immediately — the engine reloads them on every chan
 does ticking a new template under `alerts.enabled_templates`: the save instantiates it
 into a live rule (see the note below for what that does *not* do).
 
-So does `enrichment.*`. Enabling it, disabling it, and pasting a new
-`aerodatabox_api_key` all take effect on save: the backend rebuilds the route provider
-from what you just wrote and hands it to the running enrichment worker, which starts,
-stops, or swaps to the new key accordingly. Routes begin appearing on the next eligible
+So does `enrichment.*`. Enabling it, disabling it, pasting a new `aerodatabox_api_key`
+and changing `route_ttl_days` or `daily_lookup_budget` all take effect on save: the
+backend rebuilds the route provider and the spending plan from what you just wrote and
+hands both to the running enrichment worker, which starts, stops, or swaps to the new key
+accordingly. A change to either number is adopted in place — the worker keeps its queue
+and its subscription — so raising a budget you have just spent resumes lookups
+immediately rather than at midnight. Routes begin appearing on the next eligible
 callsign the receiver sees, with no restart
 ([issue #161](https://github.com/stevenpickles/flightsite/issues/161)). Turning it off
 is equally immediate, and equally complete: the worker stops and the API client is
@@ -236,13 +239,37 @@ storage from [DATA_MODEL.md §9](DATA_MODEL.md) instead.
 |---|---|---|---|
 | `aerodatabox_enabled` | bool | `false` | |
 | `aerodatabox_api_key` | secret | — | **Belongs in `secrets.yaml`, not here.** Required when enabled |
+| `route_ttl_days` | int | `7` | 1–30. How long a found route stays cached before it is bought again |
+| `daily_lookup_budget` | int | `0` | `0` = uncapped. Provider lookups allowed per UTC day |
 
 FlightSite is fully functional with enrichment off. This is the only setting that
 sends anything about observed aircraft to a third party — see
 [SECURITY.md §10](SECURITY.md).
 
-Both settings apply on save, in either direction and including a change of key;
-nothing here needs a restart. See [Applies immediately](#applies-immediately) above.
+Every setting here applies on save, in either direction and including a change of key
+or of either number; nothing in this section needs a restart. See
+[Applies immediately](#applies-immediately) above.
+
+**The two numbers are the credit economy** (slice 070). They bound spending from
+opposite ends: `route_ttl_days` decides how *often* one callsign may be asked about, and
+`daily_lookup_budget` decides how many callsigns may be asked about at all. Neither is a
+rate limit — FlightSite's 10 requests/minute burst limiter is separate and not
+configurable.
+
+A week is the default because a scheduled flight number flies the same pair of airports
+for a season: on the receiver these were measured on, 62 % of a day's airline callsigns
+had already been heard the previous day, so a week-long cache turns one or two lookups a
+day for such a flight into one a week. A route confirmed identical on three separate days
+is then frozen for 30 days automatically — that needs no setting, and it is why raising
+`route_ttl_days` beyond a month is not offered.
+
+Set `daily_lookup_budget` if your AeroDataBox credits are finite (a feeder allowance, a
+free tier). When the day's budget is spent, no further requests are made until 00:00 UTC;
+already-cached routes keep being applied, and the Health page's enrichment card shows
+what is used and left. Lookups still queued when the budget runs out are drained in
+priority order once it resets: aircraft currently matching an alert rule first, then
+aircraft inside `display_radius_nm`, then everything else, with refreshes of
+already-known routes last.
 
 ### `metadata` — aircraft metadata sources
 

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -695,23 +695,60 @@ counts for today's hours), since rollups for the current day are not yet final.
 
 ---
 
-## 7. Enrichment cache (slice 026)
+## 7. Enrichment cache (slice 026, economy in slice 070)
 
 ```sql
 CREATE TABLE route_cache (
-  cache_key    TEXT PRIMARY KEY,           -- normalized callsign (+date bucket)
-  status       TEXT NOT NULL CHECK (status IN ('ok','not_found','error')),
+  cache_key    TEXT PRIMARY KEY,           -- normalized callsign, nothing else
+  status       TEXT NOT NULL CHECK (status IN ('ok','not_found','restricted','error')),
   origin_ident TEXT,
   destination_ident TEXT,
   payload_json TEXT,                       -- provider extras, schema-validated
   fetched_ms   INTEGER NOT NULL,
-  expires_ms   INTEGER NOT NULL
+  expires_ms   INTEGER NOT NULL,
+  confirmations    INTEGER NOT NULL DEFAULT 0,  -- separate days agreeing (0014)
+  first_fetched_ms INTEGER                      -- when this answer first arrived
 ) WITHOUT ROWID;
 CREATE INDEX ix_route_cache_expiry ON route_cache(expires_ms);
 ```
 
-Negative results (`not_found`, `error`) are cached with shorter TTLs — "cache
-aggressively, respect provider limits" (SPEC §28). Pruned by expiry during maintenance.
+**The key is the callsign.** It carried a UTC date bucket until slice 070, on the
+reasoning that `DAL1234` is a different pair of airports next month — true, and the
+wrong bound. Measured on the owner's receiver: 2,200–2,650 distinct airline callsigns
+a day at ~190 lookups an hour, of which **62 % had already been heard the previous
+day** after four days of history. A dated key therefore re-bought two thirds of
+yesterday's answers every morning. Rows written under the old dated keys
+(`DAL1234:2026-09-03`) are carried through migration 0014 and left to expire; nothing
+reads them again.
+
+**Expiry is now the whole staleness rule**, and it is deliberately asymmetric:
+
+| Status | Meaning | TTL |
+|---|---|---|
+| `ok` | the provider named at least one airport | `enrichment.route_ttl_days` (default 7, 1–30) |
+| `not_found` | the provider answered and has no route | 24 h — often an unfiled schedule, worth asking again tomorrow |
+| `restricted` | HTTP 451: the flight is legally withheld ([#165](https://github.com/stevenpickles/flightsite/issues/165)) | `route_ttl_days` — the law does not change between sightings |
+| `error` | reserved: a definitive, unusable answer for one key | — (unwritten) |
+
+A provider *unavailability* — timeout, 429, 5xx, open circuit — is never stored: it is a
+fact about the network, not about the flight, and caching it would turn one bad minute
+into hours of false "no route" (SPEC §28: Unknown when uncertain).
+
+**Learned schedules.** A refresh returning the same origin/destination as the stored row
+on a **different calendar day** increments `confirmations`; at **three** the row's expiry
+is set **30 days** out, so a scheduled service costs one lookup a month rather than one a
+week. A differing answer resets `confirmations` to 0 and `first_fetched_ms` to now, and
+the row returns to the ordinary TTL. Provenance stays `aerodatabox` throughout — the
+answer is the provider's, confirmed against itself, never FlightSite's inference.
+
+**Early invalidation.** When the airport-context service (§3.6, slice 027) latches a
+*departure* from a field the cached route does not call the origin, or an *arrival* at
+one it does not call the destination, the row is deleted and the next observation buys a
+fresh answer — once per callsign per process, so a persistent disagreement cannot become
+a request per observation. This is the only path that deletes an unexpired row.
+
+Expired rows are not deleted on read; they are simply not returned, and maintenance
+prunes them by expiry.
 
 ---
 
@@ -882,3 +919,4 @@ field names; ingest normalizes before anything is persisted.
 | 035 | `activity_events`, `milestones` |
 | 037 | `watchlists`, `watchlist_entries` |
 | 038 | `alert_rules`, `alert_matches` |
+| 070 | `route_cache` gains `confirmations` / `first_fetched_ms` and the `restricted` status (rev 0014, a table rebuild) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -151,6 +151,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 067 | Open-issue severity triage | 066 | opus | low | Re-verify every open issue against dev, close the ones merged slices already fixed, and label the rest by severity (plus release-gate / decision) so the SPEC §114 bug gate is a label query; records the Pi 5 + SSD runtime environment (issue #157) |
 | 068 | Medium-severity fix bundle | 040, 056, 061, 064, 067 | opus | medium | Five single-concern commits: poller attach after first-run hot-start (#129), fix-dated live track points and no stale seen_pos_s inheritance (#145), a write path for the alert-match 'Notified' marker (#104), the live socket hoisted to the app shell per ADR-0015 (#105), and ADR-0014 accepting the measured track storage cost (#114); tracking issue #159 |
 | 069 | Enrichment hot-apply & honest restart badges | 026, 055, 056, 068 | opus | low | Apply enrichment settings on config save so AeroDataBox route lookup starts, stops or re-keys without a backend restart, and badge every Settings section that still needs one (issue #161) |
+| 070 | Route enrichment credit economy & airport names | 026, 027, 042, 069 | opus | medium | Week-long per-callsign route cache, learned schedules, a daily lookup budget spent in priority order, restricted flights cached instead of retried (#165), and airport names beside route idents from the local airports table (issue #167) |
 
 ## Parallelization Guide
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -134,7 +134,7 @@ FlightSite is local-first. The complete list of optional outbound traffic:
 
 | Traffic | When | What is sent |
 |---|---|---|
-| AeroDataBox route enrichment | Only when `enrichment.aerodatabox_enabled` is on **and** an API key is set; then at most once per airline callsign per UTC day, capped at 10 requests/minute | One `GET https://api.aerodatabox.com/flights/callsign/{callsign}` per lookup: the transmitted callsign in the URL path and your API key in the `X-Api-Key` header. No request body, no query parameters. |
+| AeroDataBox route enrichment | Only when `enrichment.aerodatabox_enabled` is on **and** an API key is set; then at most once per airline callsign per `enrichment.route_ttl_days` (default 7 days), capped by `enrichment.daily_lookup_budget` lookups per UTC day when you set one, and by 10 requests/minute always | One `GET https://api.aerodatabox.com/flights/callsign/{callsign}` per lookup: the transmitted callsign in the URL path and your API key in the `X-Api-Key` header. No request body, no query parameters. |
 | Basemap tiles | When using internet basemaps (default) | Standard tile HTTP requests, which reveal the viewed map area (and therefore approximately your receiver's region) to the tile provider |
 | Metadata updates | Only on the manual "Update Aircraft Metadata" action | Plain HTTP(S) downloads from Mictronics/tar1090, FAA, and airport-data sources; nothing about your receiver is uploaded |
 
@@ -149,9 +149,12 @@ name or identity. The request carries no body and no query string, so the callsi
 the key are the entire payload; the response is read and discarded except for the two
 airport identifiers and the flight number, which are cached locally.
 
-Answers are cached in the local `route_cache` table keyed by callsign and UTC date,
-including "no route found", so one flight costs at most one request a day however many
-times it is seen. Turning the feature off, or removing the key, stops every request: the
+Answers are cached in the local `route_cache` table keyed by callsign, including "no
+route found" (24 hours) and "legally restricted" (the same week as a route), so one
+flight costs at most one request per `route_ttl_days` however many times it is seen — and
+a route confirmed identical on three separate days is frozen for 30 days. If you set
+`daily_lookup_budget`, no request at all is made once that many lookups have been spent
+in a UTC day. Turning the feature off, or removing the key, stops every request: the
 provider is not constructed at all, so no socket is opened.
 
 Everything else — aircraft observations, sightings, analytics, alerts, configuration —

--- a/frontend/src/features/aircraft-detail/AircraftDetailPanel.test.tsx
+++ b/frontend/src/features/aircraft-detail/AircraftDetailPanel.test.tsx
@@ -188,6 +188,114 @@ describe("AircraftDetailPanel", () => {
     );
   });
 
+  it("names each end of the route beside its ident", () => {
+    // Slice 070: an ident is only meaningful to someone who already knows
+    // the airport. The name carries the meaning, the ident stays the value.
+    renderPanel();
+    seedSnapshot([
+      makeAircraft({
+        icao: "aaaaaa",
+        route: {
+          origin: "KATL",
+          destination: "KSLC",
+          origin_name: "Hartsfield–Jackson Atlanta International",
+          destination_name: "Salt Lake City International",
+        },
+        provenance: { route: "aerodatabox" },
+      }),
+    ]);
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa");
+    });
+
+    const section = screen.getByText("Route").closest("section") as HTMLElement;
+    expect(within(section).getByText("KATL")).toBeInTheDocument();
+    const originName = within(section).getByText(
+      "Hartsfield–Jackson Atlanta International",
+    );
+    // The full name is the accessible text and the tooltip; only the pixels
+    // are clipped, so a screen reader never reads a half-name.
+    expect(originName).toHaveAttribute(
+      "title",
+      "Hartsfield–Jackson Atlanta International",
+    );
+    expect(originName).toHaveClass("truncate");
+    expect(
+      within(section).getByText("Salt Lake City International"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the ident alone when the airport name is unknown", () => {
+    renderPanel();
+    seedSnapshot([
+      makeAircraft({
+        icao: "aaaaaa",
+        route: {
+          origin: "ZZZZ",
+          destination: "KSLC",
+          origin_name: null,
+          destination_name: "Salt Lake City International",
+        },
+        provenance: { route: "aerodatabox" },
+      }),
+    ]);
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa");
+    });
+
+    const section = screen.getByText("Route").closest("section") as HTMLElement;
+    // An unresolvable ident is still the truth the provider filed — it is
+    // shown, not replaced by `Unknown`.
+    expect(within(section).getByText("ZZZZ")).toBeInTheDocument();
+    expect(within(section).queryAllByText("Unknown")).toHaveLength(0);
+  });
+
+  it("renders a name-less payload from an older backend unchanged", () => {
+    // The name keys are absent, not null: a frontend ahead of its backend
+    // must degrade to exactly the pre-070 row rather than render "undefined".
+    renderPanel();
+    seedSnapshot([
+      makeAircraft({
+        icao: "aaaaaa",
+        route: { origin: "EGLL", destination: "KJFK" },
+        provenance: { route: "aerodatabox" },
+      }),
+    ]);
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa");
+    });
+
+    const section = screen.getByText("Route").closest("section") as HTMLElement;
+    expect(within(section).getByText("EGLL")).toBeInTheDocument();
+    expect(within(section).getByText("KJFK")).toBeInTheDocument();
+    expect(section.textContent).not.toContain("undefined");
+  });
+
+  it("keeps Unknown for a null ident even when a name would fit beside it", () => {
+    renderPanel();
+    seedSnapshot([
+      makeAircraft({
+        icao: "aaaaaa",
+        route: {
+          origin: null,
+          destination: "KSLC",
+          origin_name: null,
+          destination_name: "Salt Lake City International",
+        },
+        provenance: { route: "aerodatabox" },
+      }),
+    ]);
+    act(() => {
+      useLiveAircraftStore.getState().selectAircraft("aaaaaa");
+    });
+
+    const section = screen.getByText("Route").closest("section") as HTMLElement;
+    expect(within(section).getAllByText("Unknown")).toHaveLength(1);
+    expect(
+      within(section).getByText("Salt Lake City International"),
+    ).toBeInTheDocument();
+  });
+
   it("renders half a route as half a route, not as nothing", () => {
     renderPanel();
     seedSnapshot([

--- a/frontend/src/features/aircraft-detail/AircraftDetailPanel.tsx
+++ b/frontend/src/features/aircraft-detail/AircraftDetailPanel.tsx
@@ -29,6 +29,7 @@ import { FieldRow } from "@/features/aircraft-detail/components/FieldRow";
 import { IdentityMetadataSection } from "@/features/aircraft-detail/components/IdentityMetadataSection";
 import { InterestingSection } from "@/features/aircraft-detail/components/InterestingSection";
 import { PositionSourceBadge } from "@/features/aircraft-detail/components/PositionSourceBadge";
+import { routeEndpointValue } from "@/features/aircraft-detail/components/RouteEndpointValue";
 import { NearestAirportSection } from "@/features/aircraft-detail/components/NearestAirportSection";
 import { TrackStats } from "@/features/aircraft-detail/components/TrackStats";
 import { UnknownValue } from "@/features/aircraft-detail/components/UnknownValue";
@@ -270,12 +271,18 @@ export function AircraftDetailPanel() {
               <DetailSection title="Route">
                 <FieldRow
                   label="Origin"
-                  value={aircraft.route.origin}
+                  value={routeEndpointValue({
+                    ident: aircraft.route.origin,
+                    name: aircraft.route.origin_name,
+                  })}
                   provenanceSource={aircraft.provenance.route}
                 />
                 <FieldRow
                   label="Destination"
-                  value={aircraft.route.destination}
+                  value={routeEndpointValue({
+                    ident: aircraft.route.destination,
+                    name: aircraft.route.destination_name,
+                  })}
                   provenanceSource={aircraft.provenance.route}
                 />
               </DetailSection>

--- a/frontend/src/features/aircraft-detail/components/RouteEndpointValue.tsx
+++ b/frontend/src/features/aircraft-detail/components/RouteEndpointValue.tsx
@@ -1,0 +1,54 @@
+/**
+ * One end of a route — the ICAO/IATA ident the provider filed, plus the
+ * airport's name when this install can resolve it locally (slice 070).
+ *
+ * Three states, and each is deliberate:
+ *
+ * 1. **Ident with a name** — the ident keeps the emphasis a `FieldRow` value
+ *    already carries, and the name follows it in muted text. The name is the
+ *    part that can be arbitrarily long ("Seattle-Tacoma International"), so
+ *    it is the part that truncates, with the full text on `title` and in the
+ *    DOM: CSS truncation is visual only, so a screen reader still reads the
+ *    whole name rather than the clipped one.
+ * 2. **Ident alone** — rendered as the bare string, byte-for-byte the DOM
+ *    this row had before names existed. A backend that has not learned the
+ *    airport (or is older than this slice) changes nothing on screen.
+ * 3. **No ident** — `null`, so {@link FieldRow} renders `Unknown` exactly as
+ *    it does for every other absent value (`docs/API.md` §2.7). A name
+ *    without an ident is not a case the contract can produce, and inventing
+ *    a display for it would be inventing data.
+ */
+import type { ReactNode } from "react";
+
+export interface RouteEndpointValueProps {
+  ident: string | null;
+  /** `undefined` when the payload predates slice 070; treated as `null`. */
+  name?: string | null;
+}
+
+/** Returns the `value` a `FieldRow` should render for one route endpoint —
+ * a function rather than a component so `null` flows into `FieldRow`'s
+ * existing `Unknown` path instead of rendering an empty element. */
+export function routeEndpointValue({
+  ident,
+  name,
+}: RouteEndpointValueProps): ReactNode {
+  if (ident === null) {
+    return null;
+  }
+  const airportName = name ?? null;
+  if (airportName === null) {
+    return ident;
+  }
+  return (
+    <span className="inline-flex items-baseline gap-1.5">
+      <span>{ident}</span>
+      <span
+        title={airportName}
+        className="max-w-[10rem] truncate text-xs font-normal text-muted-foreground"
+      >
+        {airportName}
+      </span>
+    </span>
+  );
+}

--- a/frontend/src/features/health/HealthPage.test.tsx
+++ b/frontend/src/features/health/HealthPage.test.tsx
@@ -70,6 +70,18 @@ describe("HealthPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("puts the enrichment budget and cache counters on the page", async () => {
+    installDiagnosticsApiMock();
+    renderApp("/health");
+
+    const card = await screen.findByRole("region", {
+      name: "Route enrichment",
+    });
+    expect(within(card).getByText("12 / 100 used")).toBeInTheDocument();
+    expect(within(card).getByText("88 left today")).toBeInTheDocument();
+    expect(within(card).getByText("Routes learned")).toBeInTheDocument();
+  });
+
   it("shows the overall status as healthy when nothing is wrong", async () => {
     installDiagnosticsApiMock();
     renderApp("/health");

--- a/frontend/src/features/health/HealthPage.tsx
+++ b/frontend/src/features/health/HealthPage.tsx
@@ -5,6 +5,7 @@ import {
   HealthCard,
   StatTile,
 } from "@/features/health/components/HealthCard";
+import { EnrichmentHealthCard } from "@/features/health/components/EnrichmentHealthCard";
 import { NotificationHealthCard } from "@/features/health/components/NotificationHealthCard";
 import { RecentErrorsSection } from "@/features/health/components/RecentErrorsSection";
 import { StatusPill } from "@/features/health/components/StatusPill";
@@ -372,28 +373,10 @@ export function HealthPage() {
 
         <NotificationHealthCard notifications={data.notifications} />
 
-        <HealthCard
-          titleId="health-enrichment"
-          title="Route enrichment"
-          description="Optional external route lookups (SPEC §28)."
-        >
-          <DetailRow
-            label="Enabled"
-            value={data.enrichment.enabled ? "Yes" : "No"}
-          />
-          <DetailRow
-            label="Lookups"
-            value={formatCount(data.enrichment.lookups)}
-          />
-          <DetailRow
-            label="Failures"
-            value={formatCount(data.enrichment.failures)}
-          />
-          <DetailRow
-            label="Circuit breaker"
-            value={data.enrichment.circuit_open ? "Open" : "Closed"}
-          />
-        </HealthCard>
+        <EnrichmentHealthCard
+          enrichment={data.enrichment}
+          timezone={timezone}
+        />
       </div>
 
       <section

--- a/frontend/src/features/health/components/EnrichmentHealthCard.test.tsx
+++ b/frontend/src/features/health/components/EnrichmentHealthCard.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { EnrichmentHealthCard } from "@/features/health/components/EnrichmentHealthCard";
+import { enrichment } from "@/test/diagnosticsApiMock";
+import type { DiagnosticsEnrichment } from "@/lib/api/diagnostics";
+
+function renderCard(overrides: Partial<DiagnosticsEnrichment> = {}) {
+  return render(
+    <EnrichmentHealthCard
+      enrichment={enrichment(overrides)}
+      timezone="America/Los_Angeles"
+    />,
+  );
+}
+
+function card(): HTMLElement {
+  return screen.getByRole("region", { name: "Route enrichment" });
+}
+
+describe("EnrichmentHealthCard", () => {
+  it("keeps the slice 042 counters", () => {
+    renderCard({ enabled: true, lookups: 1240, failures: 3 });
+
+    const section = card();
+    expect(within(section).getByText("1,240")).toBeInTheDocument();
+    expect(within(section).getByText("3")).toBeInTheDocument();
+    expect(within(section).getByText("Closed")).toBeInTheDocument();
+  });
+
+  it("shows a capped budget as used, limit, remaining and reset time", () => {
+    renderCard({
+      budget: {
+        limit: 100,
+        used_today: 12,
+        remaining: 88,
+        resets_at: "2026-09-01T00:00:00.000Z",
+      },
+    });
+
+    const section = card();
+    expect(within(section).getByText("12 / 100 used")).toBeInTheDocument();
+    expect(within(section).getByText("88")).toBeInTheDocument();
+    // Rendered in the receiver's timezone: midnight UTC is the previous
+    // afternoon in Los Angeles, and that is the answer an operator needs.
+    expect(within(section).getByText("2026-08-31 17:00")).toBeInTheDocument();
+    expect(within(section).getByText("88 left today")).toHaveAttribute(
+      "data-tone",
+      "ok",
+    );
+  });
+
+  it("calls an uncapped budget uncapped rather than inventing a limit", () => {
+    renderCard({
+      budget: {
+        limit: null,
+        used_today: 412,
+        remaining: null,
+        resets_at: "2026-09-01T00:00:00.000Z",
+      },
+    });
+
+    const section = card();
+    expect(
+      within(section).getByText("412 used · uncapped"),
+    ).toBeInTheDocument();
+    expect(within(section).queryByText("Remaining today")).toBeNull();
+    expect(within(section).getByText("Uncapped")).toHaveAttribute(
+      "data-tone",
+      "idle",
+    );
+  });
+
+  it("warns, rather than errors, when the budget is spent", () => {
+    // Reaching a cap the operator set is the economy working, not a fault:
+    // cached and locally-learned routes keep being served and the counter
+    // rolls over at midnight UTC.
+    renderCard({
+      budget: {
+        limit: 50,
+        used_today: 50,
+        remaining: 0,
+        resets_at: "2026-09-01T00:00:00.000Z",
+      },
+    });
+
+    const pill = within(card()).getByText("Budget spent");
+    expect(pill).toHaveAttribute("data-tone", "warn");
+    expect(pill).not.toHaveAttribute("data-tone", "bad");
+  });
+
+  it("reports the cache counters", () => {
+    renderCard({ cache: { hits: 340, misses: 42, learned: 17 } });
+
+    const section = card();
+    expect(within(section).getByText("Cache hits")).toBeInTheDocument();
+    expect(within(section).getByText("340")).toBeInTheDocument();
+    expect(within(section).getByText("42")).toBeInTheDocument();
+    expect(within(section).getByText("Routes learned")).toBeInTheDocument();
+    expect(within(section).getByText("17")).toBeInTheDocument();
+  });
+
+  it("degrades to the pre-070 card when the backend sends neither block", () => {
+    // A frontend ahead of its backend must not render zeroes: "the cache
+    // never hits" and "this backend does not say" are different claims.
+    renderCard({ budget: undefined, cache: undefined });
+
+    const section = card();
+    expect(within(section).getByText("Lookups")).toBeInTheDocument();
+    expect(within(section).queryByText("Daily budget")).toBeNull();
+    expect(within(section).queryByText("Budget resets")).toBeNull();
+    expect(within(section).queryByText("Cache hits")).toBeNull();
+    expect(within(section).queryByText("Routes learned")).toBeNull();
+    expect(section.querySelector("[data-tone]")).toBeNull();
+  });
+});

--- a/frontend/src/features/health/components/EnrichmentHealthCard.tsx
+++ b/frontend/src/features/health/components/EnrichmentHealthCard.tsx
@@ -1,0 +1,91 @@
+import { DetailRow, HealthCard } from "@/features/health/components/HealthCard";
+import { StatusPill } from "@/features/health/components/StatusPill";
+import { enrichmentBudgetPresentation } from "@/features/health/lib/status";
+import {
+  formatCount,
+  formatReceiverLocalDateTime,
+} from "@/features/receiver/lib/format";
+import type { DiagnosticsEnrichment } from "@/lib/api/diagnostics";
+
+export interface EnrichmentHealthCardProps {
+  enrichment: DiagnosticsEnrichment;
+  /** The receiver's configured timezone, so the reset instant is shown in
+   * the operator's local time even though the budget rolls over at midnight
+   * UTC — the rollover is a UTC fact, but "when does that happen for me" is
+   * the question this row exists to answer. */
+  timezone: string;
+}
+
+/**
+ * Route enrichment on the Health page (SPEC §28, §67; roadmap slice 070).
+ *
+ * Beyond the counters slice 042 already showed, this reports the two things
+ * that decide whether a paid provider quota survives the month: how much of
+ * today's lookup budget is left, and how much of the traffic the cache is
+ * absorbing. Both come straight from `/api/v1/diagnostics`.
+ *
+ * Every new row is conditional on its block being present, so a frontend
+ * newer than its backend degrades to exactly the card slice 042 shipped
+ * instead of rendering rows of zeroes that would read as "the cache never
+ * hits" rather than "this backend does not say".
+ */
+export function EnrichmentHealthCard({
+  enrichment,
+  timezone,
+}: EnrichmentHealthCardProps) {
+  const { budget, cache } = enrichment;
+  const budgetStatus = enrichmentBudgetPresentation(budget);
+
+  return (
+    <HealthCard
+      titleId="health-enrichment"
+      title="Route enrichment"
+      description="Optional external route lookups (SPEC §28)."
+      status={
+        budgetStatus !== null ? (
+          <StatusPill tone={budgetStatus.tone} label={budgetStatus.label} />
+        ) : undefined
+      }
+    >
+      <DetailRow label="Enabled" value={enrichment.enabled ? "Yes" : "No"} />
+      <DetailRow label="Lookups" value={formatCount(enrichment.lookups)} />
+      <DetailRow label="Failures" value={formatCount(enrichment.failures)} />
+      <DetailRow
+        label="Circuit breaker"
+        value={enrichment.circuit_open ? "Open" : "Closed"}
+      />
+      {budget !== undefined && (
+        <>
+          <DetailRow
+            label="Daily budget"
+            value={
+              budget.limit === null
+                ? `${formatCount(budget.used_today)} used · uncapped`
+                : `${formatCount(budget.used_today)} / ${formatCount(budget.limit)} used`
+            }
+          />
+          {budget.limit !== null && (
+            <DetailRow
+              label="Remaining today"
+              value={formatCount(budget.remaining ?? 0)}
+            />
+          )}
+          <DetailRow
+            label="Budget resets"
+            value={formatReceiverLocalDateTime(budget.resets_at, timezone)}
+          />
+        </>
+      )}
+      {cache !== undefined && (
+        <>
+          <DetailRow label="Cache hits" value={formatCount(cache.hits)} />
+          <DetailRow label="Cache misses" value={formatCount(cache.misses)} />
+          <DetailRow
+            label="Routes learned"
+            value={formatCount(cache.learned)}
+          />
+        </>
+      )}
+    </HealthCard>
+  );
+}

--- a/frontend/src/features/health/lib/status.test.ts
+++ b/frontend/src/features/health/lib/status.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   decoderPresentation,
+  enrichmentBudgetPresentation,
   errorCountPresentation,
   integrityPresentation,
   maintenancePresentation,
@@ -122,5 +123,44 @@ describe("errorCountPresentation", () => {
       tone: "warn",
       label: "4 recent",
     });
+  });
+});
+
+describe("enrichmentBudgetPresentation", () => {
+  it("reports what is left of a capped budget", () => {
+    expect(
+      enrichmentBudgetPresentation({
+        limit: 100,
+        used_today: 12,
+        remaining: 88,
+        resets_at: "2026-09-01T00:00:00.000Z",
+      }),
+    ).toEqual({ tone: "ok", label: "88 left today" });
+  });
+
+  it("says uncapped rather than claiming health for an unlimited budget", () => {
+    expect(
+      enrichmentBudgetPresentation({
+        limit: null,
+        used_today: 412,
+        remaining: null,
+        resets_at: "2026-09-01T00:00:00.000Z",
+      }),
+    ).toEqual({ tone: "idle", label: "Uncapped" });
+  });
+
+  it("warns on a spent budget — a chosen cap being reached is not a fault", () => {
+    expect(
+      enrichmentBudgetPresentation({
+        limit: 50,
+        used_today: 50,
+        remaining: 0,
+        resets_at: "2026-09-01T00:00:00.000Z",
+      }),
+    ).toEqual({ tone: "warn", label: "Budget spent" });
+  });
+
+  it("has nothing to present for a backend that does not report a budget", () => {
+    expect(enrichmentBudgetPresentation(undefined)).toBeNull();
   });
 });

--- a/frontend/src/features/health/lib/status.ts
+++ b/frontend/src/features/health/lib/status.ts
@@ -12,6 +12,7 @@ import type { StatusTone } from "@/features/health/components/StatusPill";
 import type { NotificationPermissionState } from "@/features/notifications/lib/permission";
 import type {
   DecoderState,
+  DiagnosticsEnrichmentBudget,
   DiagnosticsStatus,
   MetadataSourceState,
 } from "@/lib/api/diagnostics";
@@ -166,4 +167,31 @@ export function errorCountPresentation(count: number): StatusPresentation {
   return count > 0
     ? { tone: "warn", label: `${count} recent` }
     : { tone: "ok", label: "None" };
+}
+
+/**
+ * The enrichment daily budget (slice 070).
+ *
+ * A spent budget is a `warn`, never a `bad`: enrichment is optional, the
+ * cap is one the operator chose, and reaching it means the economy worked —
+ * lookups stop, cached and locally-learned routes keep being served, and the
+ * counter rolls over at midnight UTC. Calling that an error would train
+ * people to ignore the one tone this page reserves for real breakage.
+ *
+ * `undefined` (a backend older than this slice) yields `null` so the card
+ * shows no pill at all rather than an invented state.
+ */
+export function enrichmentBudgetPresentation(
+  budget: DiagnosticsEnrichmentBudget | undefined,
+): StatusPresentation | null {
+  if (budget === undefined) {
+    return null;
+  }
+  if (budget.limit === null) {
+    return { tone: "idle", label: "Uncapped" };
+  }
+  if ((budget.remaining ?? 0) <= 0) {
+    return { tone: "warn", label: "Budget spent" };
+  }
+  return { tone: "ok", label: `${budget.remaining ?? 0} left today` };
 }

--- a/frontend/src/features/settings/lib/draft.test.ts
+++ b/frontend/src/features/settings/lib/draft.test.ts
@@ -22,7 +22,10 @@ import {
   pickRetention,
   pickUnitsAndTime,
 } from "@/features/settings/lib/draft";
-import { defaultFlightSiteConfig } from "@/test/configApiMock";
+import {
+  defaultEnrichmentConfig,
+  defaultFlightSiteConfig,
+} from "@/test/configApiMock";
 
 describe("draftFromConfig", () => {
   it("carries every server section into its corresponding draft field", () => {
@@ -83,7 +86,10 @@ describe("draftFromConfig", () => {
   it("never prefills the AeroDataBox key input, even when one is stored", () => {
     const draft = draftFromConfig(
       defaultFlightSiteConfig({
-        enrichment: { aerodatabox_enabled: true, aerodatabox_api_key: "•••" },
+        enrichment: defaultEnrichmentConfig({
+          aerodatabox_enabled: true,
+          aerodatabox_api_key: "•••",
+        }),
       }),
     );
     expect(draft.aerodataboxKeyInput).toBe("");
@@ -198,7 +204,11 @@ describe("buildEnrichmentPatch", () => {
 
   it("omits the key entirely when untouched", () => {
     const patch = buildEnrichmentPatch(base);
-    expect(patch.enrichment).toEqual({ aerodatabox_enabled: false });
+    expect(patch.enrichment).toEqual({
+      aerodatabox_enabled: false,
+      daily_lookup_budget: 0,
+      route_ttl_days: 7,
+    });
     expect(patch.enrichment).not.toHaveProperty("aerodatabox_api_key");
   });
 
@@ -212,6 +222,8 @@ describe("buildEnrichmentPatch", () => {
     expect(patch.enrichment).toEqual({
       aerodatabox_enabled: true,
       aerodatabox_api_key: "sk-new-key",
+      daily_lookup_budget: 0,
+      route_ttl_days: 7,
     });
   });
 
@@ -225,6 +237,8 @@ describe("buildEnrichmentPatch", () => {
     expect(patch.enrichment).toEqual({
       aerodatabox_enabled: false,
       aerodatabox_api_key: null,
+      daily_lookup_budget: 0,
+      route_ttl_days: 7,
     });
   });
 });

--- a/frontend/src/features/settings/lib/draft.ts
+++ b/frontend/src/features/settings/lib/draft.ts
@@ -48,6 +48,8 @@ export function draftFromConfig(config: FlightSiteConfig): SettingsDraft {
     aerodataboxEnabled: config.enrichment.aerodatabox_enabled,
     aerodataboxKeyInput: "",
     aerodataboxKeyTouched: false,
+    dailyLookupBudget: String(config.enrichment.daily_lookup_budget),
+    routeTtlDays: String(config.enrichment.route_ttl_days),
 
     openskyEnabled: config.metadata.opensky_enabled,
 
@@ -105,6 +107,8 @@ export function pickEnrichment(draft: SettingsDraft) {
     aerodataboxEnabled: draft.aerodataboxEnabled,
     aerodataboxKeyInput: draft.aerodataboxKeyInput,
     aerodataboxKeyTouched: draft.aerodataboxKeyTouched,
+    dailyLookupBudget: draft.dailyLookupBudget,
+    routeTtlDays: draft.routeTtlDays,
   };
 }
 
@@ -199,7 +203,15 @@ export function buildEnrichmentPatch(
   draft: ReturnType<typeof pickEnrichment>,
 ): ConfigPatch {
   const patch: ConfigPatch = {
-    enrichment: { aerodatabox_enabled: draft.aerodataboxEnabled },
+    enrichment: {
+      aerodatabox_enabled: draft.aerodataboxEnabled,
+      daily_lookup_budget: Math.trunc(
+        parseNumber(draft.dailyLookupBudget) ?? 0,
+      ),
+      route_ttl_days: Math.trunc(
+        parseNumber(draft.routeTtlDays) ?? ROUTE_TTL_DEFAULT_DAYS,
+      ),
+    },
   };
   if (draft.aerodataboxKeyTouched) {
     const trimmed = draft.aerodataboxKeyInput.trim();
@@ -232,3 +244,8 @@ export function buildRetentionPatch(
 }
 
 const RETENTION_DEFAULT_DAYS = 14;
+
+/** Only ever reached when the field is unparseable, which the section's own
+ * validation blocks before a save can fire — a value rather than a throw so
+ * the patch builder stays total. */
+const ROUTE_TTL_DEFAULT_DAYS = 7;

--- a/frontend/src/features/settings/lib/validation.ts
+++ b/frontend/src/features/settings/lib/validation.ts
@@ -14,6 +14,8 @@ export const ALERT_RADIUS_MAX_NM = 10000;
 export const RETENTION_MIN_DAYS = 7;
 export const RETENTION_MAX_DAYS = 30;
 export const MAX_RANGE_RINGS = 10;
+export const ROUTE_TTL_MIN_DAYS = 1;
+export const ROUTE_TTL_MAX_DAYS = 30;
 
 export function validateDisplayRadius(raw: string): string | null {
   const value = parseNumber(raw);
@@ -84,6 +86,33 @@ export function validateRangeRingRadii(raw: string): string | null {
   }
   if (new Set(values).size !== values.length) {
     return "Range ring radii must be unique.";
+  }
+  return null;
+}
+
+/** The daily provider-lookup allowance (slice 070). Zero is a legitimate
+ * value meaning "uncapped", not an empty field, so it is accepted rather
+ * than treated as the absence of an answer. */
+export function validateDailyLookupBudget(raw: string): string | null {
+  const value = parseNumber(raw);
+  if (value === null || !Number.isInteger(value) || value < 0) {
+    return "Enter a whole number of lookups per day, or 0 for unlimited.";
+  }
+  return null;
+}
+
+/** How long a cached route stays usable. Mirrors the backend's 1–30 bound:
+ * below a day the cache would never absorb a repeat flight, and beyond a
+ * month a schedule change would outlive its own correction. */
+export function validateRouteTtlDays(raw: string): string | null {
+  const value = parseNumber(raw);
+  if (
+    value === null ||
+    !Number.isInteger(value) ||
+    value < ROUTE_TTL_MIN_DAYS ||
+    value > ROUTE_TTL_MAX_DAYS
+  ) {
+    return `Enter a whole number of days between ${ROUTE_TTL_MIN_DAYS} and ${ROUTE_TTL_MAX_DAYS}.`;
   }
   return null;
 }

--- a/frontend/src/features/settings/sections/EnrichmentSection.test.tsx
+++ b/frontend/src/features/settings/sections/EnrichmentSection.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { EnrichmentSection } from "@/features/settings/sections/EnrichmentSection";
 import {
+  defaultEnrichmentConfig,
   defaultFlightSiteConfig,
   installConfigApiMock,
 } from "@/test/configApiMock";
@@ -14,10 +15,12 @@ function renderSection(hasStoredKey: boolean) {
     defaultOptions: { queries: { retry: false } },
   });
   const config = defaultFlightSiteConfig({
-    enrichment: {
+    enrichment: defaultEnrichmentConfig({
       aerodatabox_enabled: hasStoredKey,
       aerodatabox_api_key: hasStoredKey ? "•••" : null,
-    },
+      daily_lookup_budget: 100,
+      route_ttl_days: 7,
+    }),
   });
   return render(
     <QueryClientProvider client={queryClient}>
@@ -64,7 +67,11 @@ describe("EnrichmentSection", () => {
     const { fetchMock } = installConfigApiMock({
       secretsSet: { "enrichment.aerodatabox_api_key": true },
       config: {
-        enrichment: { aerodatabox_enabled: true, aerodatabox_api_key: "•••" },
+        enrichment: defaultEnrichmentConfig({
+          aerodatabox_enabled: true,
+          aerodatabox_api_key: "•••",
+          daily_lookup_budget: 100,
+        }),
       },
     });
     const user = userEvent.setup();
@@ -86,6 +93,8 @@ describe("EnrichmentSection", () => {
       enrichment: {
         aerodatabox_enabled: true,
         aerodatabox_api_key: "sk-new-value",
+        daily_lookup_budget: 100,
+        route_ttl_days: 7,
       },
     });
   });
@@ -94,7 +103,11 @@ describe("EnrichmentSection", () => {
     const { fetchMock } = installConfigApiMock({
       secretsSet: { "enrichment.aerodatabox_api_key": true },
       config: {
-        enrichment: { aerodatabox_enabled: true, aerodatabox_api_key: "•••" },
+        enrichment: defaultEnrichmentConfig({
+          aerodatabox_enabled: true,
+          aerodatabox_api_key: "•••",
+          daily_lookup_budget: 100,
+        }),
       },
     });
     const user = userEvent.setup();
@@ -113,7 +126,12 @@ describe("EnrichmentSection", () => {
     const [, putInit] = putCalls[0] as [string, RequestInit];
     const body = JSON.parse(String(putInit.body)) as Record<string, unknown>;
     expect(body).toEqual({
-      enrichment: { aerodatabox_enabled: false, aerodatabox_api_key: null },
+      enrichment: {
+        aerodatabox_enabled: false,
+        aerodatabox_api_key: null,
+        daily_lookup_budget: 100,
+        route_ttl_days: 7,
+      },
     });
   });
 
@@ -121,7 +139,11 @@ describe("EnrichmentSection", () => {
     const { fetchMock } = installConfigApiMock({
       secretsSet: { "enrichment.aerodatabox_api_key": true },
       config: {
-        enrichment: { aerodatabox_enabled: true, aerodatabox_api_key: "•••" },
+        enrichment: defaultEnrichmentConfig({
+          aerodatabox_enabled: true,
+          aerodatabox_api_key: "•••",
+          daily_lookup_budget: 100,
+        }),
       },
     });
     renderSection(true);
@@ -129,6 +151,138 @@ describe("EnrichmentSection", () => {
     // Nothing to save yet — untouched fields never dirty the section.
     expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("renders the lookup budget and cache lifetime from the config", () => {
+    installConfigApiMock();
+    renderSection(true);
+
+    expect(screen.getByLabelText(/daily lookup budget/i)).toHaveValue("100");
+    expect(screen.getByLabelText(/route cache lifetime/i)).toHaveValue("7");
+    // The helper text has to say what is being counted and when it resets —
+    // "100 lookups" is meaningless without both.
+    expect(screen.getByText(/one call to the provider/i)).toBeInTheDocument();
+    expect(screen.getByText(/resets at midnight UTC/i)).toBeInTheDocument();
+    expect(screen.getByText(/0 for unlimited/i)).toBeInTheDocument();
+  });
+
+  it("carries no restart badge for the budget or the cache lifetime either", () => {
+    // Both apply on save for the same reason the key does: the provider is
+    // rebuilt, not restarted (slice 069's badge is deliberately absent).
+    installConfigApiMock();
+    const { container } = renderSection(true);
+
+    expect(screen.getByLabelText(/daily lookup budget/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/route cache lifetime/i)).toBeInTheDocument();
+    expect(container).not.toHaveTextContent(/restart/i);
+  });
+
+  it("sends the edited budget and cache lifetime in the patch", async () => {
+    const { fetchMock } = installConfigApiMock({
+      secretsSet: { "enrichment.aerodatabox_api_key": true },
+      config: {
+        enrichment: defaultEnrichmentConfig({
+          aerodatabox_enabled: true,
+          aerodatabox_api_key: "•••",
+          daily_lookup_budget: 100,
+        }),
+      },
+    });
+    const user = userEvent.setup();
+    renderSection(true);
+
+    await user.clear(screen.getByLabelText(/daily lookup budget/i));
+    await user.type(screen.getByLabelText(/daily lookup budget/i), "250");
+    await user.clear(screen.getByLabelText(/route cache lifetime/i));
+    await user.type(screen.getByLabelText(/route cache lifetime/i), "14");
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(await screen.findByText(/^saved$/i)).toBeInTheDocument();
+    const putCalls = fetchMock.mock.calls.filter(
+      ([, init]) => (init as RequestInit | undefined)?.method === "PUT",
+    );
+    const [, putInit] = putCalls[0] as [string, RequestInit];
+    const body = JSON.parse(String(putInit.body)) as {
+      enrichment: Record<string, unknown>;
+    };
+    expect(body.enrichment.daily_lookup_budget).toBe(250);
+    expect(body.enrichment.route_ttl_days).toBe(14);
+    // The untouched key is still omitted — the new fields share the section's
+    // save, not its secret-handling rules.
+    expect(body.enrichment).not.toHaveProperty("aerodatabox_api_key");
+  });
+
+  it("accepts 0 as a budget — unlimited is a value, not a blank", async () => {
+    installConfigApiMock();
+    const user = userEvent.setup();
+    renderSection(true);
+
+    await user.clear(screen.getByLabelText(/daily lookup budget/i));
+    await user.type(screen.getByLabelText(/daily lookup budget/i), "0");
+
+    expect(screen.queryByText(/whole number of lookups/i)).toBeNull();
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeEnabled();
+  });
+
+  it("blocks a save on an out-of-range cache lifetime", async () => {
+    installConfigApiMock();
+    const user = userEvent.setup();
+    renderSection(true);
+
+    await user.clear(screen.getByLabelText(/route cache lifetime/i));
+    await user.type(screen.getByLabelText(/route cache lifetime/i), "45");
+
+    expect(
+      screen.getByText(/whole number of days between 1 and 30/i),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/route cache lifetime/i)).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+  });
+
+  it("blocks a save on a negative budget", async () => {
+    installConfigApiMock();
+    const user = userEvent.setup();
+    renderSection(true);
+
+    await user.clear(screen.getByLabelText(/daily lookup budget/i));
+    await user.type(screen.getByLabelText(/daily lookup budget/i), "-5");
+
+    expect(screen.getByText(/whole number of lookups/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+  });
+
+  it("shows a server-side field error against the field it names", async () => {
+    installConfigApiMock();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            detail: [
+              {
+                loc: ["enrichment", "daily_lookup_budget"],
+                msg: "Budget exceeds the provider plan.",
+                type: "value_error",
+              },
+            ],
+          }),
+          { status: 422, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+    const user = userEvent.setup();
+    renderSection(true);
+
+    await user.clear(screen.getByLabelText(/daily lookup budget/i));
+    await user.type(screen.getByLabelText(/daily lookup budget/i), "9000");
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(
+      await screen.findByText(/budget exceeds the provider plan/i),
+    ).toBeInTheDocument();
   });
 
   it("disables the enable-enrichment checkbox until a usable key exists", () => {

--- a/frontend/src/features/settings/sections/EnrichmentSection.tsx
+++ b/frontend/src/features/settings/sections/EnrichmentSection.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { FieldError } from "@/features/setup/components/FieldError";
 import { SectionSaveBar } from "@/features/settings/components/SectionSaveBar";
 import { SettingsSection } from "@/features/settings/components/SettingsSection";
 import {
@@ -15,6 +16,12 @@ import {
   fieldErrorsFrom,
   generalErrorMessage,
 } from "@/features/settings/lib/errors";
+import {
+  ROUTE_TTL_MAX_DAYS,
+  ROUTE_TTL_MIN_DAYS,
+  validateDailyLookupBudget,
+  validateRouteTtlDays,
+} from "@/features/settings/lib/validation";
 import { usePutConfigMutation } from "@/lib/api/config";
 import type { FlightSiteConfig } from "@/lib/api/config";
 
@@ -27,12 +34,14 @@ export interface EnrichmentSectionProps {
 }
 
 /**
- * Online route enrichment (SPEC §28): the AeroDataBox API key, masked, plus
- * whether enrichment is enabled.
+ * Online route enrichment (SPEC §28): the AeroDataBox API key, masked,
+ * whether enrichment is enabled, and the two dials that decide what it
+ * costs — the daily lookup budget and how long a cached route is reused
+ * (slice 070).
  *
  * Deliberately carries no "Applies on next restart" badge: the backend
- * rebuilds the enrichment provider on save, so a key or a toggle takes
- * effect on the next lookup. It is the only section on this page that
+ * rebuilds the enrichment provider on save, so a key, a toggle, a budget or
+ * a cache lifetime takes effect on the next lookup. It is the only section on this page that
  * changes a startup-built service without a restart, which is why the
  * absence of a badge here is a claim worth testing rather than an oversight.
  *
@@ -54,6 +63,17 @@ export function EnrichmentSection({
   const isDirty = isSectionDirty(draft, baseline);
   const fieldErrors = fieldErrorsFrom(mutation.error);
   const enabledError = fieldErrors["enrichment.aerodatabox_enabled"] ?? null;
+
+  // Client-side bounds are what block a save; a server-side message for the
+  // same field is still shown, but never disables the button — a rejection
+  // the user cannot see the cause of would otherwise leave the section
+  // unsavable until an unrelated edit.
+  const budgetBoundsError = validateDailyLookupBudget(draft.dailyLookupBudget);
+  const ttlBoundsError = validateRouteTtlDays(draft.routeTtlDays);
+  const budgetError =
+    budgetBoundsError ?? fieldErrors["enrichment.daily_lookup_budget"] ?? null;
+  const ttlError =
+    ttlBoundsError ?? fieldErrors["enrichment.route_ttl_days"] ?? null;
 
   const hasUsableKey =
     storedKeyPresent || draft.aerodataboxKeyInput.trim().length > 0;
@@ -173,12 +193,78 @@ export function EnrichmentSection({
         )}
       </div>
 
+      {/* The lookup economy (slice 070). Both fields apply on save for the
+       * same reason the key does — the provider is rebuilt, not restarted —
+       * so neither carries a restart caveat. */}
+      <div className="flex max-w-lg flex-col gap-4">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="settings-enrichment-budget">
+            Daily lookup budget
+          </Label>
+          <Input
+            id="settings-enrichment-budget"
+            inputMode="numeric"
+            value={draft.dailyLookupBudget}
+            aria-invalid={budgetError !== null}
+            aria-describedby={
+              budgetError !== null
+                ? "settings-enrichment-budget-error"
+                : "settings-enrichment-budget-help"
+            }
+            onChange={(event) => {
+              setDraft({ ...draft, dailyLookupBudget: event.target.value });
+            }}
+          />
+          <p
+            id="settings-enrichment-budget-help"
+            className="text-xs text-muted-foreground"
+          >
+            A lookup is one call to the provider for a flight whose route is not
+            already cached. The count resets at midnight UTC. Use 0 for
+            unlimited.
+          </p>
+          <FieldError
+            id="settings-enrichment-budget-error"
+            message={budgetError}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="settings-enrichment-ttl">
+            Route cache lifetime (days)
+          </Label>
+          <Input
+            id="settings-enrichment-ttl"
+            inputMode="numeric"
+            value={draft.routeTtlDays}
+            aria-invalid={ttlError !== null}
+            aria-describedby={
+              ttlError !== null
+                ? "settings-enrichment-ttl-error"
+                : "settings-enrichment-ttl-help"
+            }
+            onChange={(event) => {
+              setDraft({ ...draft, routeTtlDays: event.target.value });
+            }}
+          />
+          <p
+            id="settings-enrichment-ttl-help"
+            className="text-xs text-muted-foreground"
+          >
+            How long a cached route is reused before it is looked up again (
+            {ROUTE_TTL_MIN_DAYS}–{ROUTE_TTL_MAX_DAYS} days). Longer spends less
+            budget; shorter picks up schedule changes sooner.
+          </p>
+          <FieldError id="settings-enrichment-ttl-error" message={ttlError} />
+        </div>
+      </div>
+
       <SectionSaveBar
         isDirty={isDirty}
         isPending={mutation.isPending}
         justSaved={mutation.isSuccess && !isDirty}
         errorMessage={generalErrorMessage(mutation.error, fieldErrors)}
-        hasBlockingError={false}
+        hasBlockingError={budgetBoundsError !== null || ttlBoundsError !== null}
         onSave={handleSave}
       />
     </SettingsSection>

--- a/frontend/src/features/settings/types.ts
+++ b/frontend/src/features/settings/types.ts
@@ -59,6 +59,10 @@ export interface SettingsDraft {
    * submitted patch entirely, so a previously-stored key is never
    * disturbed just by opening the section. */
   aerodataboxKeyTouched: boolean;
+  /** Provider lookups allowed per UTC day, as typed; "0" means unlimited. */
+  dailyLookupBudget: string;
+  /** How long a learned route stays usable, 1–30 days. */
+  routeTtlDays: string;
 
   // Metadata sources.
   /** Whether the opt-in OpenSky aircraft database takes part in "Update

--- a/frontend/src/features/setup/lib/draft.test.ts
+++ b/frontend/src/features/setup/lib/draft.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import { DEFAULT_ENABLED_TEMPLATE_IDS } from "@/features/setup/constants";
 import { buildConfigPatch, draftFromConfig } from "@/features/setup/lib/draft";
-import { defaultFlightSiteConfig } from "@/test/configApiMock";
+import {
+  defaultEnrichmentConfig,
+  defaultFlightSiteConfig,
+} from "@/test/configApiMock";
 
 describe("draftFromConfig", () => {
   it("carries every server value into its corresponding draft field", () => {
@@ -74,7 +77,10 @@ describe("draftFromConfig", () => {
     const draft = draftFromConfig({
       first_run: false,
       config: defaultFlightSiteConfig({
-        enrichment: { aerodatabox_enabled: true, aerodatabox_api_key: "•••" },
+        enrichment: defaultEnrichmentConfig({
+          aerodatabox_enabled: true,
+          aerodatabox_api_key: "•••",
+        }),
       }),
       secrets_set: { "enrichment.aerodatabox_api_key": true },
     });

--- a/frontend/src/features/sighting-detail/SightingDetailPage.test.tsx
+++ b/frontend/src/features/sighting-detail/SightingDetailPage.test.tsx
@@ -181,6 +181,69 @@ describe("SightingDetailPage", () => {
     expect(screen.getByText("PHIK")).toBeInTheDocument();
   });
 
+  it("names the route's airports beside their idents", async () => {
+    installSightingsApiMock({
+      detail: {
+        88213: sightingDetail({
+          id: 88213,
+          route: {
+            origin: "KTCM",
+            destination: "PHIK",
+            origin_name: "Tacoma McChord Field",
+            destination_name: "Hickam Air Force Base",
+          },
+        }),
+      },
+    });
+
+    renderApp("/sightings/88213");
+
+    expect(await screen.findByText("KTCM")).toBeInTheDocument();
+    const originName = screen.getByText("Tacoma McChord Field");
+    expect(originName).toHaveAttribute("title", "Tacoma McChord Field");
+    expect(originName).toHaveClass("truncate");
+    expect(screen.getByText("Hickam Air Force Base")).toBeInTheDocument();
+  });
+
+  it("shows the ident alone when only one end has a name", async () => {
+    installSightingsApiMock({
+      detail: {
+        88213: sightingDetail({
+          id: 88213,
+          route: {
+            origin: "KTCM",
+            destination: "PHIK",
+            origin_name: null,
+            destination_name: "Hickam Air Force Base",
+          },
+        }),
+      },
+    });
+
+    renderApp("/sightings/88213");
+
+    expect(await screen.findByText("KTCM")).toBeInTheDocument();
+    expect(screen.getByText("Hickam Air Force Base")).toBeInTheDocument();
+  });
+
+  it("renders a pre-070 payload with no name keys at all", async () => {
+    installSightingsApiMock({
+      detail: {
+        88213: sightingDetail({
+          id: 88213,
+          route: { origin: "KTCM", destination: "PHIK" },
+        }),
+      },
+    });
+
+    renderApp("/sightings/88213");
+
+    const route = (await screen.findByText("Route")).closest(
+      "section",
+    ) as HTMLElement;
+    expect(route.textContent).not.toContain("undefined");
+  });
+
   it("omits the route section entirely when there is no route", async () => {
     installSightingsApiMock({
       detail: {

--- a/frontend/src/features/sighting-detail/SightingDetailSections.tsx
+++ b/frontend/src/features/sighting-detail/SightingDetailSections.tsx
@@ -7,6 +7,7 @@
 
 import { DetailSection } from "@/features/aircraft-detail/components/DetailSection";
 import { FieldRow } from "@/features/aircraft-detail/components/FieldRow";
+import { routeEndpointValue } from "@/features/aircraft-detail/components/RouteEndpointValue";
 import {
   formatAltitude,
   formatDistance,
@@ -108,12 +109,18 @@ export function SightingRouteSection({
     <DetailSection title="Route">
       <FieldRow
         label="Origin"
-        value={route.origin}
+        value={routeEndpointValue({
+          ident: route.origin,
+          name: route.origin_name,
+        })}
         provenanceSource={provenanceSource}
       />
       <FieldRow
         label="Destination"
-        value={route.destination}
+        value={routeEndpointValue({
+          ident: route.destination,
+          name: route.destination_name,
+        })}
         provenanceSource={provenanceSource}
       />
     </DetailSection>

--- a/frontend/src/lib/api/config.test.ts
+++ b/frontend/src/lib/api/config.test.ts
@@ -8,6 +8,7 @@ import {
   usePutConfigMutation,
 } from "@/lib/api/config";
 import {
+  defaultEnrichmentConfig,
   defaultFlightSiteConfig,
   installConfigApiMock,
 } from "@/test/configApiMock";
@@ -67,7 +68,10 @@ describe("putConfig", () => {
   it("never receives the real secret value back — only the mask or null", async () => {
     installConfigApiMock({
       config: defaultFlightSiteConfig({
-        enrichment: { aerodatabox_enabled: true, aerodatabox_api_key: "•••" },
+        enrichment: defaultEnrichmentConfig({
+          aerodatabox_enabled: true,
+          aerodatabox_api_key: "•••",
+        }),
       }),
       secretsSet: { "enrichment.aerodatabox_api_key": true },
     });

--- a/frontend/src/lib/api/config.ts
+++ b/frontend/src/lib/api/config.ts
@@ -61,6 +61,11 @@ export interface MapDocConfig {
 export interface EnrichmentConfig {
   aerodatabox_enabled: boolean;
   aerodatabox_api_key: string | null;
+  /** Provider lookups allowed per UTC day; `0` means uncapped (slice 070).
+   * Applied on save — the enrichment provider is rebuilt, not restarted. */
+  daily_lookup_budget: number;
+  /** How long a cached route stays usable, 1–30 days. */
+  route_ttl_days: number;
 }
 
 /** Mirrors `MetadataSettings`. The two default aircraft-metadata sources need

--- a/frontend/src/lib/api/diagnostics.ts
+++ b/frontend/src/lib/api/diagnostics.ts
@@ -169,6 +169,24 @@ export interface DiagnosticsNotifications {
   permission_known_by: "client";
 }
 
+/** The daily provider-call allowance (slice 070). `limit` and `remaining`
+ * are `null` together when no cap is configured; `resets_at` is the ISO-8601
+ * UTC instant the counter next rolls over (midnight UTC). */
+export interface DiagnosticsEnrichmentBudget {
+  limit: number | null;
+  used_today: number;
+  remaining: number | null;
+  resets_at: string;
+}
+
+/** Route-cache effectiveness (slice 070): `learned` counts routes the cache
+ * holds that were never paid for with a provider call. */
+export interface DiagnosticsEnrichmentCache {
+  hits: number;
+  misses: number;
+  learned: number;
+}
+
 export interface DiagnosticsEnrichment {
   enabled: boolean;
   running: boolean;
@@ -177,6 +195,10 @@ export interface DiagnosticsEnrichment {
   dropped: number;
   pending: number;
   failures: number;
+  /** Absent from a backend older than slice 070 — the Health card renders
+   * the rows it has rather than inventing zeroes for the ones it does not. */
+  budget?: DiagnosticsEnrichmentBudget;
+  cache?: DiagnosticsEnrichmentCache;
 }
 
 export interface DiagnosticsWebSocket {

--- a/frontend/src/lib/api/live.ts
+++ b/frontend/src/lib/api/live.ts
@@ -48,6 +48,13 @@ export interface Classification {
 export interface RouteInfo {
   origin: string | null;
   destination: string | null;
+  /** The airport's name, resolved locally from the airports metadata table
+   * (slice 070). `null` whenever the ident is `null` or is not one this
+   * install knows, and **absent entirely** from a payload produced by a
+   * backend older than slice 070 — hence optional here, and normalised to
+   * `null` at every render site. */
+  origin_name?: string | null;
+  destination_name?: string | null;
 }
 
 /** Locally inferred flight phase relative to a nearby field (slice 027).

--- a/frontend/src/test/configApiMock.ts
+++ b/frontend/src/test/configApiMock.ts
@@ -1,8 +1,27 @@
 import { vi } from "vitest";
 
-import type { ConfigResponse, FlightSiteConfig } from "@/lib/api/config";
+import type {
+  ConfigResponse,
+  EnrichmentConfig,
+  FlightSiteConfig,
+} from "@/lib/api/config";
 import type { ConnectionTestResult } from "@/lib/api/decoder";
 import type { MetadataStatusResponse } from "@/lib/api/metadata";
+
+/** The schema-default enrichment block. A helper of its own because tests
+ * that care about one enrichment field still have to supply the whole
+ * section when overriding it. */
+export function defaultEnrichmentConfig(
+  overrides: Partial<EnrichmentConfig> = {},
+): EnrichmentConfig {
+  return {
+    aerodatabox_enabled: false,
+    aerodatabox_api_key: null,
+    daily_lookup_budget: 0,
+    route_ttl_days: 7,
+    ...overrides,
+  };
+}
 
 /** A schema-default `FlightSiteConfig`, mirroring
  * `flightsite.config.models.Settings()` — used as the base every test
@@ -36,7 +55,7 @@ export function defaultFlightSiteConfig(
       range_rings_enabled: true,
       range_ring_radii_nm: [50, 100, 150, 200],
     },
-    enrichment: { aerodatabox_enabled: false, aerodatabox_api_key: null },
+    enrichment: defaultEnrichmentConfig(),
     metadata: { opensky_enabled: false },
     notifications: {
       enabled: true,

--- a/frontend/src/test/diagnosticsApiMock.ts
+++ b/frontend/src/test/diagnosticsApiMock.ts
@@ -4,6 +4,7 @@ import type {
   Diagnostics,
   DiagnosticsDatabase,
   DiagnosticsDecoder,
+  DiagnosticsEnrichment,
   DiagnosticsErrorEntry,
   DiagnosticsMetadata,
   DiagnosticsMetadataSource,
@@ -140,6 +141,31 @@ export function errorEntry(
   };
 }
 
+/** Enrichment as a slice-070 backend reports it: switched off, with a
+ * capped daily budget and a cache that has seen some traffic. Tests for an
+ * older backend drop `budget`/`cache` explicitly. */
+export function enrichment(
+  overrides: Partial<DiagnosticsEnrichment> = {},
+): DiagnosticsEnrichment {
+  return {
+    enabled: false,
+    running: false,
+    circuit_open: false,
+    lookups: 0,
+    dropped: 0,
+    pending: 0,
+    failures: 0,
+    budget: {
+      limit: 100,
+      used_today: 12,
+      remaining: 88,
+      resets_at: "2026-09-01T00:00:00.000Z",
+    },
+    cache: { hits: 340, misses: 42, learned: 17 },
+    ...overrides,
+  };
+}
+
 /** A healthy install. Every test starts here and overrides the one thing it
  * is about, which is what keeps a degraded-state test readable. */
 export function diagnostics(overrides: Partial<Diagnostics> = {}): Diagnostics {
@@ -180,15 +206,7 @@ export function diagnostics(overrides: Partial<Diagnostics> = {}): Diagnostics {
       },
       permission_known_by: "client",
     },
-    enrichment: {
-      enabled: false,
-      running: false,
-      circuit_open: false,
-      lookups: 0,
-      dropped: 0,
-      pending: 0,
-      failures: 0,
-    },
+    enrichment: enrichment(),
     websocket: {
       clients: 1,
       running: true,

--- a/frontend/src/test/liveAircraftFixtures.ts
+++ b/frontend/src/test/liveAircraftFixtures.ts
@@ -41,7 +41,12 @@ const BASE: LiveAircraft = {
   operator: null,
   operator_group: null,
   classification: null,
-  route: { origin: null, destination: null },
+  route: {
+    origin: null,
+    destination: null,
+    origin_name: null,
+    destination_name: null,
+  },
   nearest_airport: null,
   interesting: null,
   watchlists: [],

--- a/frontend/src/test/sightingsApiMock.ts
+++ b/frontend/src/test/sightingsApiMock.ts
@@ -53,7 +53,12 @@ export function sightingDetail(
     ended_at: "2026-08-30T22:41:55.000Z",
     duration_s: 2385,
     closure_reason: "gap_timeout",
-    route: { origin: "KTCM", destination: "PHIK" },
+    route: {
+      origin: "KTCM",
+      destination: "PHIK",
+      origin_name: "Tacoma McChord Field",
+      destination_name: "Hickam Air Force Base",
+    },
     reception: {
       rssi_peak_db: -3.2,
       rssi_avg_db: -11.8,

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -1945,6 +1945,62 @@ slices:
     risk_level: low
     notes: "Owner-requested on 2026-09-04 before v0.4.0: origin/destination were not appearing on fermi.local because enrichment had been enabled (and its key stored) after the last backend start, and the provider is built only at startup; a restart made routes flow within a minute (21 sightings enriched in the first sixty seconds). Same bug class as issues #110, #122 and #129: a config save that should apply live and did not. Added by Fable outside the phase plan."
 
+  - id: "070"
+    title: "Route enrichment credit economy & airport names"
+    phase: 8
+    branch: "070-enrichment-economy"
+    status: merged
+    depends_on: ["026", "027", "042", "069"]
+    objective: "Cut AeroDataBox usage by roughly three quarters and cap it hard — a week-long per-callsign cache, learned schedules, a daily lookup budget spent in priority order, and restricted flights cached instead of retried (#165) — and show airport names beside route idents from the local airports table (issue #167)."
+    scope:
+      - "route cache keyed by callsign alone (no UTC-day bucket) with a positive TTL of `enrichment.route_ttl_days` (default 7, 1-30), so a scheduled flight costs one lookup per week instead of one or two per day; negative results (204/404) cached 24 h instead of 1 h"
+      - "#165: AeroDataBox HTTP 451 (legally restricted flight) is a definitive per-callsign answer — cached with status `restricted` for the positive TTL, logged with its own reason, never fed to the circuit breaker, never counted as a provider failure"
+      - "learned schedules: a cached route confirmed identical on three separate calendar days is frozen for 30 days (`route_cache` gains `confirmations` and `first_fetched_ms`; migration 0014, linear on 0013); provenance stays `aerodatabox`"
+      - "a cheap consistency check invalidates a cached route early when the airport-context service latches a departure or approach at an airport that is neither the cached origin nor destination, so a changed schedule is caught by the aircraft's own behaviour rather than by waiting out the TTL"
+      - "`enrichment.daily_lookup_budget` (int, default 0 = uncapped): lookups per UTC day, counted from `route_cache.fetched_ms` so the count survives restarts; when spent, lookups stop until midnight UTC, one `enrichment_budget_exhausted` log line per day, and the pending queue keeps only what fits"
+      - "pending lookups drain in priority order rather than FIFO: aircraft currently matching an alert rule first, then aircraft inside `display_radius_nm`, then everything else, with refreshes of expired-but-known routes last; the alerts probe is a closure over app state in the `_alert_radius` style, not a service dependency"
+      - "diagnostics (`GET /api/v1/diagnostics` `enrichment` section) gains `budget: {limit, used_today, remaining, resets_at}` and `cache: {hits, misses, learned}` counters; the Health page's enrichment card shows budget used/remaining and the reset time; the Settings Enrichment section edits the budget and TTL (both apply on save via slice 069's apply path)"
+      - "airport names: every serialized `route` object (`/api/v1/aircraft` live payloads, aircraft detail, sighting rows and detail) gains `origin_name` and `destination_name`, resolved from the local `airports` table (slice 027) through the airport-context service's in-memory index — never from the provider; `null` when the ident is unknown locally. The detail panel, sighting detail and aircraft page render ident and name together, name truncated with a title tooltip"
+      - "docs: API.md §2.6 route shape and the diagnostics section, CONFIGURATION.md's enrichment table, SECURITY.md §10's request-frequency statement (now bounded by the budget), DATA_MODEL.md §7 route cache"
+    out_of_scope:
+      - "a second or free route provider (adsbdb.com, adsb.lol): SPEC §28 names AeroDataBox as the one v1 provider — owner decision tracked separately"
+      - "presence-gated lookups and overflight filtering: measured as low value for this receiver (1 % transient contacts); a `decision` note, no code"
+      - "a route sanity check against the live track geometry; only the airport-context latch is used"
+      - "changing the eligibility policy or the 10/min rate limiter"
+    acceptance_criteria:
+      - "a callsign looked up today is not looked up again for `route_ttl_days` days, across restarts, and a callsign seen twice in one day costs one lookup"
+      - "a 451 response caches a `restricted` row, the breaker's failure count does not move, `enrichment_failures` does not move, and the callsign is not re-requested for the TTL"
+      - "after three confirming days a route's expiry is 30 days out; a differing answer resets the confirmation count"
+      - "with `daily_lookup_budget: 5`, the sixth eligible callsign of the day is not requested, diagnostics report `remaining: 0`, and the next UTC day's first callsign is requested"
+      - "with an alert-matching aircraft and ten other pending callsigns, the alert-matching one is requested first"
+      - "`route.origin_name` is the airports-table name for a known ident and `null` for an unknown one, on every endpoint that carries `route`"
+      - "`alembic heads` shows exactly one head (0014); up and down migrate cleanly"
+      - "`Closes #167` and `Closes #165` in the PR body"
+    required_tests:
+      - cache tests for callsign-only keys, TTL from settings, negative 24 h, restricted status, confirmation counting and the 30-day freeze, and the consistency invalidation
+      - provider test for the 451 branch and a service test that the breaker is not fed by it
+      - budget tests (cap reached, restart survives, midnight reset via injected clock) and priority-order tests
+      - diagnostics passthrough test for `budget` and `cache`; config apply test that a changed budget/TTL applies on save
+      - serializer tests for `origin_name`/`destination_name` on live, detail and sighting payloads
+      - frontend tests for the detail-panel and sighting-detail rendering, the Health enrichment card, and the Settings fields
+    expected_artifacts:
+      - backend/src/flightsite/enrichment/
+      - backend/src/flightsite/db/migrations/versions/ (rev 0014)
+      - backend/src/flightsite/config/models.py
+      - backend/src/flightsite/diagnostics/service.py
+      - backend/src/flightsite/api/serializers.py
+      - backend/src/flightsite/airports/service.py
+      - frontend/src/features/aircraft-detail/
+      - frontend/src/features/health/
+      - frontend/src/features/settings/sections/EnrichmentSection.tsx
+      - docs/API.md
+      - docs/CONFIGURATION.md
+      - docs/DATA_MODEL.md
+      - docs/SECURITY.md
+    preferred_agent: opus
+    risk_level: medium
+    notes: "Owner-requested 2026-09-04 after v0.4.0: enrichment consumed AeroDataBox feeder credits faster than the feeder earns them. Measured on fermi.local: 2,200-2,650 distinct airline callsigns/day, ~190 lookups/hour, 62 % of a day's callsigns seen the previous day after only four days of history, 1 % transient contacts, and one restricted business jet retried nine times in twelve minutes (#165). The airport-name request came in the same conversation. Migration-bearing (0014): serialized against other migration slices per DEVELOPMENT.md. Added by Fable outside the phase plan."
+
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,
 # 027, 031, 033, 035, 037, 038, 052) are ADDITIONALLY serialized against each other


### PR DESCRIPTION
## Slice 070 — Route enrichment credit economy & airport names

Closes #167. Closes #165.

Owner-reported after v0.4.0: AeroDataBox feeder credits were being consumed faster than earned. Measured on fermi.local: 2,200–2,650 distinct airline callsigns/day, ~190 lookups/h, 62 % day-over-day callsign recurrence after four days, 1 % transient contacts, one restricted business jet retried nine times in twelve minutes.

**Enrichment economy (backend)**
- Route cache keyed by callsign alone (no UTC-day bucket); positive TTL `enrichment.route_ttl_days` (1–30, default 7); negative 24 h. A scheduled flight costs one lookup a week instead of one or two a day.
- **#165**: HTTP 451 → cached `restricted` for the positive TTL; logged with its own reason; never fed to the breaker; never counted as a failure.
- Learned schedules: `confirmations` + `first_fetched_ms` (migration **0014**, linear on 0013, spelled-out rebuild because `route_cache` is WITHOUT ROWID with a CHECK); three confirming days freeze a route for 30 days.
- Consistency invalidation: the reader already sees the live stream; an injected airport-context probe flags a cached route contradicted by a latched departure/arrival at another field, and the worker deletes the row once per callsign per process.
- `enrichment.daily_lookup_budget` (0 = uncapped): used-today counted from `route_cache.fetched_ms`, survives restarts, resets at 00:00 UTC, one warning per day when spent. Pending lookups drain by tier: alerting → inside `display_radius_nm` → other → refreshes, FIFO within a tier. Budget/TTL changes apply on save in place (no worker restart; raising a spent budget resumes lookups).
- Diagnostics: `enrichment.budget {limit, used_today, remaining, resets_at}` and `enrichment.cache {hits, misses, learned}`.

**Airport names (backend)**
- `AirportIndex.name_for` (ICAO, IATA fallback) from the local `airports` table; every `route` object on `/api/v1/aircraft/current`, `/interesting`, WebSocket snapshot/delta and sighting detail gains `origin_name` / `destination_name` (`null` when unknown). Dict lookup per ident, no queries.

**Frontend**
- Detail panel and sighting detail show ident + muted, truncated name (full name in `title` and DOM); older payloads without names render exactly as before.
- Health enrichment card: daily budget used/remaining/reset (receiver-local), cache counters; exhausted is `warn`, uncapped is `idle`.
- Settings → Enrichment: daily budget and route cache lifetime fields, validated, applying on save (no restart badge, asserted).

**Docs**: DATA_MODEL §7 rewritten; CONFIGURATION enrichment table; SECURITY §10 frequency statement; API §2.6 + examples and the diagnostics section; `config.example.yaml`.

**Out of scope, tracked**: a free route source ahead of AeroDataBox (#168, owner decision — SPEC §28 amendment + licence check). Sighting *list* rows carry no route block today, so no names there.

**Verification (local)**
- backend: ruff / format / mypy clean; `alembic heads` = 0014 only; full pytest **in progress on the integrated tree** (each half's agent ran it green: 4439 passed / 98.89 % and 4311 passed) — result appended below when done
- frontend: lint / typecheck / format:check clean; 187 files, 1770 tests passed on the integrated tree
- visual baselines unaffected (the HAR fixtures predate the name fields, so the detail rows render as before)

Migration 0014 ⇒ release notes recommend a backup before upgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHktB3arcz5Hwr34nYArtJ