### PR TITLE
Back-merge v0.5.0 into dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,69 @@ follows [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/) (`0.x.y` during pre-1.0 development).
 This file is updated only on release branches (see `docs/RELEASE.md`).
 
+## [0.5.0] — 2026-09-04
+
+A credit-economy release for route enrichment, plus airport names. Measured
+on the owner's receiver, v0.4.0 spent roughly one AeroDataBox lookup per
+airline callsign per day — 2,200 to 2,650 a day — faster than the feeder
+programme earned them. This release makes each scheduled flight cost one
+lookup a week, then one a month, caps the daily spend, and stops paying for
+flights the provider will never describe.
+
+### Added
+- **Daily lookup budget** (`enrichment.daily_lookup_budget`, Settings →
+  Enrichment; 0 = uncapped): lookups stop when the day's budget is spent and
+  resume at midnight UTC. The count is taken from the route cache, so it
+  survives restarts. Pending lookups are spent in priority order — aircraft
+  matching an alert rule first, then aircraft inside the display radius, then
+  the rest, with refreshes of already-known routes last
+- **Route cache lifetime** (`enrichment.route_ttl_days`, default 7, 1–30):
+  a found route is kept for a week, keyed by callsign alone instead of
+  callsign-plus-day, so a callsign seen twice in one day costs one lookup and
+  a daily flight costs one a week. Both settings apply on save
+- **Learned schedules**: a route confirmed identical on three separate days
+  is frozen for thirty days (migration 0014 adds `confirmations` and
+  `first_fetched_ms` to `route_cache`)
+- **Airport names beside route idents**: every `route` object carries
+  `origin_name` and `destination_name` resolved from the local airports
+  table (slice 027), and the aircraft detail panel and sighting detail show
+  "KATL · Hartsfield-Jackson Atlanta Intl" instead of the ident alone. No
+  provider call is involved; names are `null` until an airports import has
+  run
+- Health page: the enrichment card shows budget used and remaining, the
+  reset time, and cache hits / misses / learned routes; diagnostics gain
+  `enrichment.budget` and `enrichment.cache`
+
+### Fixed
+- **Legally restricted flights no longer burn credits or trip the breaker**
+  (#165): an HTTP 451 from AeroDataBox is now cached as `restricted` for the
+  route lifetime, logged with its own reason, and never counted as a provider
+  failure. Before, one blocked business jet was retried nine times in twelve
+  minutes and paused every other lookup for five minutes, twice
+- A cached route contradicted by the aircraft's own behaviour — a latched
+  departure or arrival at an airport that is neither end of the route — is
+  invalidated and re-fetched once, so a changed schedule is caught without
+  waiting out the cache lifetime
+- Negative answers (no schedule for a callsign) are remembered for 24 hours
+  instead of one
+
+### Upgrade notes
+- **Migration 0014** rebuilds `route_cache` (a few thousand rows at most).
+  Take a backup first: `docker compose exec flightsite-backend
+  flightsite-backup create`, then `docker compose pull && docker compose up -d`.
+- After upgrading, set **Settings → Enrichment → Daily lookup budget** to
+  what your credit source sustains; the default is uncapped, which preserves
+  the previous behaviour apart from the cache changes above.
+- Cached routes from before the upgrade keep their day-bucketed keys and
+  expire within hours; the new cache warms over the first week.
+
+### Known issues
+- The `ingest_duty_cycle` performance gate has no CI headroom and can fail
+  on a contended shared runner (#166); a re-run is the remedy until headroom
+  lands. Six low-severity items and the deferred Pi 4 SSD qualification
+  (#153) remain open. A free route source ahead of AeroDataBox is an owner
+  decision (#168).
+
 ## [0.4.0] — 2026-09-04
 
 Settings that take effect when you save them, and alerts that reach you

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flightsite"
-version = "0.4.0"
+version = "0.5.0"
 description = "FlightSite backend: self-hosted ADS-B observatory API and ingestion service."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "flightsite"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,6 +36,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | v0.3.1 | 8 | Same-day patch: aircraft label stability and the honest position-fix anchor (slices 063–064; recorded 2026-09-02) |
 | v0.3.2 | 8 | Military filter activation on real metadata availability + the clean Pi 5 performance baseline with five budgets promoted to hard gates (slices 065–066; recorded 2026-09-03) |
 | v0.4.0 | 8 | Settings that apply on save and alerts that reach every tab: enrichment hot-apply, stats-poller hot-start, app-shell-owned live socket, Notified marker write path, fix-dated track points, ADR-0014/0015, severity-triaged tracker (slices 067–069; recorded 2026-09-04) |
+| v0.5.0 | 8 | Route enrichment credit economy: week-long callsign cache, learned schedules, daily lookup budget with priority, restricted flights cached, airport names beside route idents (slice 070; migration 0014; recorded 2026-09-04) |
 | v1.0.0 | 8 | Qualified stable release per SPEC §114 definition of done |
 
 ## Slices

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flightsite-frontend",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flightsite-frontend",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@radix-ui/react-separator": "^1.1.15",
         "@radix-ui/react-slot": "^1.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flightsite-frontend",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -95,6 +95,12 @@ releases:
       socket with click-to-map, the alert-match Notified marker's write path,
       fix-dated track points, ADR-0014/0015, and the severity-triaged tracker
       (slices 067-069). Recorded 2026-09-04."
+  - version: "v0.5.0"
+    after_phase: 8
+    theme: "Route enrichment credit economy: week-long callsign cache, learned
+      schedules, a daily lookup budget spent in priority order, restricted
+      flights cached instead of retried, and airport names beside route idents
+      (slice 070; migration 0014). Recorded 2026-09-04."
   - version: "v1.0.0"
     after_phase: 8
     theme: "Qualified stable release per SPEC.md §114 definition of done."


### PR DESCRIPTION
Back-merge of the v0.5.0 release (main merge commit e24d711) into `dev`, per `docs/RELEASE.md` post-merge step 5: version bumps, refreshed `uv.lock`, curated `CHANGELOG.md` and the roadmap release entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHktB3arcz5Hwr34nYArtJ