### PR TITLE
fix(db): migration 0015 sightings rebuild with foreign keys off, checked, and resumable (slice 072, hotfix)

### DIFF
--- a/backend/src/flightsite/db/migrations/rebuild.py
+++ b/backend/src/flightsite/db/migrations/rebuild.py
@@ -1,0 +1,235 @@
+"""Rebuilding a SQLite table inside a migration, without eating its children.
+
+SQLite cannot alter a ``CHECK`` constraint (or most other things) in place, so
+a migration that widens one has to rebuild the table: create the new shape,
+copy every row, drop the old table, rename. Revisions 0014 and 0015 both do it.
+
+The part that is *not* obvious — and that cost a broken release, issue #178 —
+is what ``DROP TABLE`` means while ``PRAGMA foreign_keys`` is on. SQLite runs
+the drop as an implicit ``DELETE FROM`` of every row, and every deleted row is
+checked against every child table that references it. On a table with five
+``NO ACTION`` children, two of them unindexed on the referencing column, that
+is a full scan of those children *per parent row*, and it ends in
+``FOREIGN KEY constraint failed`` regardless: the children still point at the
+rows being deleted. Minutes of CPU, then a failure.
+
+Foreign keys are therefore turned **off** around the rebuild and turned back on
+afterwards — and because turning them off is silently a no-op inside a
+transaction, doing that correctly needs the care spelled out in
+:func:`set_foreign_keys`.
+
+What replaces the enforcement while it is off is
+:func:`check_foreign_keys`: after the rename, every child of the rebuilt table
+is verified to still resolve. Enforcement is suspended for the rebuild, not
+abandoned.
+
+:func:`rebuilding` packages the whole discipline as a context manager, and is
+what a revision should use.
+
+Also here: the ``has_*`` predicates, because a SQLite migration is **not
+atomic**. Alembic marks SQLite as non-transactional DDL, so every statement
+before a failing one stays committed and ``alembic_version`` still names the
+older revision — a restart re-runs the whole revision from the top over a
+half-migrated database. A rebuild step that cannot tolerate its own prior
+completion turns one failure into an unrecoverable one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from sqlalchemy import Connection
+
+
+class ForeignKeysNotSuspended(RuntimeError):
+    """``PRAGMA foreign_keys`` would not take the value the rebuild needs."""
+
+
+class DanglingForeignKeys(RuntimeError):
+    """A rebuild left rows referencing a parent row that is no longer there."""
+
+
+def has_table(bind: Connection, name: str) -> bool:
+    """True if a table called ``name`` exists."""
+    found = bind.exec_driver_sql(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?", (name,)
+    ).scalar()
+    return found is not None
+
+
+def has_index(bind: Connection, name: str) -> bool:
+    """True if an index called ``name`` exists."""
+    found = bind.exec_driver_sql(
+        "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?", (name,)
+    ).scalar()
+    return found is not None
+
+
+def has_column(bind: Connection, table: str, column: str) -> bool:
+    """True if ``table`` exists and carries ``column``."""
+    rows = bind.exec_driver_sql(f"PRAGMA table_info({table})").fetchall()
+    return any(str(row[1]) == column for row in rows)
+
+
+def foreign_keys_enabled(bind: Connection) -> bool:
+    """Whether this connection currently enforces foreign keys."""
+    return bool(bind.exec_driver_sql("PRAGMA foreign_keys").scalar())
+
+
+def _end_transaction(bind: Connection, *, commit: bool) -> None:
+    """End the transaction the DBAPI opened implicitly, if there is one.
+
+    pysqlite (and aiosqlite over it) begins a transaction on the first DML
+    statement and holds it open until something commits. Alembic's own
+    ``UPDATE alembic_version`` is DML, so a run that applies more than one
+    revision arrives at the next revision's body already inside a transaction,
+    while an install stepping over a single revision — the production upgrade
+    path — arrives outside one. Both happen; only the first needs ending.
+    """
+    driver = bind.connection.driver_connection
+    if getattr(driver, "in_transaction", False):
+        bind.exec_driver_sql("COMMIT" if commit else "ROLLBACK")
+
+
+def set_foreign_keys(bind: Connection, *, enabled: bool) -> None:
+    """Turn foreign-key enforcement on or off, and make sure it took.
+
+    ``PRAGMA foreign_keys`` is a **no-op inside a transaction** and SQLite
+    reports no error when it is ignored — which is exactly how a migration ends
+    up believing it disabled enforcement while the following ``DROP TABLE``
+    runs with enforcement on. So the value is written, read back, and only if
+    the read-back disagrees is the open transaction ended and the write
+    retried. A second disagreement is raised rather than assumed away.
+
+    Committing here is not a liberty the rebuild takes lightly; it is the only
+    way to reach a statement boundary where the pragma is honoured, and SQLite
+    DDL under Alembic is already non-transactional in the single-revision case.
+    """
+    wanted = "ON" if enabled else "OFF"
+    bind.exec_driver_sql(f"PRAGMA foreign_keys={wanted}")
+    if foreign_keys_enabled(bind) is enabled:
+        return
+    _end_transaction(bind, commit=True)
+    bind.exec_driver_sql(f"PRAGMA foreign_keys={wanted}")
+    if foreign_keys_enabled(bind) is not enabled:
+        raise ForeignKeysNotSuspended(
+            f"PRAGMA foreign_keys would not go {wanted}; refusing to rebuild a table "
+            "with enforcement in an unknown state"
+        )
+
+
+def child_tables(bind: Connection, parent: str) -> tuple[str, ...]:
+    """Every table holding a foreign key that references ``parent``.
+
+    Discovered from the schema rather than listed by hand, so a later slice
+    adding a table that references the rebuilt one is covered by the check
+    without anyone remembering to add it.
+    """
+    names = [
+        str(row[0])
+        for row in bind.exec_driver_sql(
+            "SELECT name FROM sqlite_master WHERE type = 'table' "
+            "AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        ).fetchall()
+    ]
+    children = []
+    for name in names:
+        references = bind.exec_driver_sql(f"PRAGMA foreign_key_list({name})").fetchall()
+        if any(str(row[2]) == parent for row in references):
+            children.append(name)
+    return tuple(children)
+
+
+def check_foreign_keys(bind: Connection, table: str) -> None:
+    """Verify ``table`` and every table referencing it still resolve.
+
+    ``PRAGMA foreign_key_check`` is scoped to the rebuilt table and its
+    children rather than run over the whole database: those are the only
+    relationships a rebuild can break, and a database that arrived with an
+    unrelated violation from some older build must not have its upgrade
+    blocked by it.
+
+    Raises:
+        DanglingForeignKeys: if any checked row no longer resolves.
+    """
+    violations: list[str] = []
+    for name in (table, *child_tables(bind, table)):
+        for row in bind.exec_driver_sql(f"PRAGMA foreign_key_check({name})").fetchall():
+            violations.append(f"{name} rowid={row[1]} -> {row[2]}")
+    if violations:
+        raise DanglingForeignKeys(
+            f"rebuilding {table} left {len(violations)} dangling reference(s): "
+            + "; ".join(violations[:10])
+        )
+
+
+@contextmanager
+def rebuilding(bind: Connection, table: str) -> Iterator[None]:
+    """Suspend foreign keys for a table rebuild, then check and restore them.
+
+    On the way out the references are verified; on the way out *through an
+    exception* the open transaction is rolled back first, so a rebuild that
+    fails half-way does not commit its own wreckage on the way to re-enabling
+    enforcement.
+    """
+    set_foreign_keys(bind, enabled=False)
+    try:
+        yield
+        check_foreign_keys(bind, table)
+    except BaseException:
+        _end_transaction(bind, commit=False)
+        raise
+    finally:
+        set_foreign_keys(bind, enabled=True)
+
+
+def reconcile_staging_table(bind: Connection, table: str, staging: str) -> None:
+    """Resolve the ``staging`` table a previous, failed attempt may have left.
+
+    Two states are possible after an interrupted rebuild, and they are not the
+    same. If ``table`` is gone and ``staging`` is present, the crash landed
+    between the drop and the rename and ``staging`` *is* the data: it is
+    renamed into place, and the rebuild then proceeds over it from the top. If
+    both are present, ``staging`` is a discarded copy and is dropped.
+    """
+    if not has_table(bind, staging):
+        return
+    if not has_table(bind, table):
+        bind.exec_driver_sql(f"ALTER TABLE {staging} RENAME TO {table}")
+        return
+    bind.exec_driver_sql(f"DROP TABLE {staging}")
+
+
+def row_count(bind: Connection, table: str) -> int:
+    """Number of rows in ``table`` (used by rebuilds to assert the copy)."""
+    return int(bind.exec_driver_sql(f"SELECT COUNT(*) FROM {table}").scalar_one())
+
+
+def assert_copied(bind: Connection, source: str, destination: str) -> None:
+    """Fail unless ``destination`` received every row of ``source``.
+
+    Cheap next to the copy itself, and the difference between a rebuild that
+    lost history and a rebuild that reported losing history.
+    """
+    before = row_count(bind, source)
+    after = row_count(bind, destination)
+    if before != after:
+        raise RuntimeError(f"copy from {source} to {destination} moved {after} of {before} rows")
+
+
+__all__ = (
+    "DanglingForeignKeys",
+    "ForeignKeysNotSuspended",
+    "assert_copied",
+    "check_foreign_keys",
+    "child_tables",
+    "foreign_keys_enabled",
+    "has_column",
+    "has_index",
+    "has_table",
+    "rebuilding",
+    "reconcile_staging_table",
+    "row_count",
+    "set_foreign_keys",
+)

--- a/backend/src/flightsite/db/migrations/versions/rev_0015_route_directory.py
+++ b/backend/src/flightsite/db/migrations/versions/rev_0015_route_directory.py
@@ -31,7 +31,10 @@ and carries four indexes, all of which are rebuilt with it.
 file) upgrade in **1.02 s** and downgrade in **1.51 s** on a developer SSD, so
 the three-year Scenario A database is on the order of ten seconds there and
 correspondingly longer on a Pi's SD card. A one-time cost, paid once, at the
-upgrade that introduces the second route source.
+upgrade that introduces the second route source. (That figure was taken with
+the child tables *empty*, which is the mistake the next section is about; the
+populated measurement is the one in
+``tests/db/test_migration_0015_children.py``.)
 
 The alternatives were to write a source the vocabulary forbids, to drop the
 constraint entirely — the same rebuild for less safety — or to edit the schema
@@ -47,11 +50,45 @@ is why a *fresh* database already carries the widened one by the time this
 revision runs. The rebuild is then a rebuild of an empty table, and the end
 state is identical either way.)
 
-Foreign keys are not a hazard here. Five tables reference ``sightings(id)``,
-but SQLite resolves a foreign-key clause at DML time rather than at schema
-time, and there are no views or triggers over the table whose reparse could
-fail while it is briefly absent. ``PRAGMA foreign_keys`` is off during
-migrations, so the drop-and-rename does not cascade.
+Foreign keys, and what this revision got wrong (issue #178)
+-----------------------------------------------------------
+
+This file originally claimed that "``PRAGMA foreign_keys`` is off during
+migrations, so the drop-and-rename does not cascade". That was false, and it
+took down a v0.6.0 upgrade. ``migrations/env.py`` builds its engine with
+:func:`flightsite.db.engine.create_sqlite_engine`, whose connect listener sets
+``PRAGMA foreign_keys=ON``; the app path migrates on the writer connection,
+which has the same pragma. Under enforcement, ``DROP TABLE sightings`` is an
+implicit ``DELETE`` of every row, each checked against the five ``NO ACTION``
+children — two of which (``activity_events``,
+``sighting_track_checkpoints``) have no index on ``sighting_id``. On a
+16,214-sighting install that was five minutes of full scans ending in
+``FOREIGN KEY constraint failed``, with the site down until a rollback. The
+"200,000 sightings in 1.02 s" measured above was taken on a seed whose child
+tables were empty, which is why neither the cost nor the failure showed.
+
+So the rebuild now runs inside the ``rebuilding`` context manager of
+:mod:`flightsite.db.migrations.rebuild`: enforcement is suspended (verified by
+reading the pragma back, because the
+pragma is silently a no-op inside a transaction), the references are checked
+with ``PRAGMA foreign_key_check`` after the rename, and enforcement is restored
+in a ``finally``.
+
+**Measured again, this time with children**: at the failing install's scale —
+16,214 sightings and 163,761 rows across the five children, an 11 MB file — the
+upgrade takes **0.10 s** and the downgrade **0.11 s** on a developer SSD, next
+to the five minutes and a failure the shipped version produced.
+``tests/db/test_migration_0015_children.py`` holds that measurement as a bound.
+
+Resumability
+------------
+
+Alembic treats SQLite as non-transactional DDL, so the statements before a
+failure stay committed while ``alembic_version`` still says 0014 — the exact
+half-migrated state the failed release left behind, and the state a restarting
+container re-enters this function with. Every step below is therefore
+conditional on its own prior completion: the directory tables, the
+``route_cache.source`` column, the four indexes and the staging table.
 
 Revision ID: 0015
 Revises: 0014
@@ -65,6 +102,8 @@ from typing import Any
 
 import sqlalchemy as sa
 from alembic import op
+
+from flightsite.db.migrations import rebuild
 
 revision: str = "0015"
 down_revision: str | None = "0014"
@@ -177,47 +216,77 @@ def _create_sightings(name: str, *, route_source_check: str) -> None:
 
 
 def _rebuild_sightings(*, route_source_check: str) -> None:
-    """Rebuild ``sightings`` into the requested shape, keeping every row."""
-    for name, _columns, _where in _SIGHTINGS_INDEXES:
-        op.drop_index(name, table_name=_SIGHTINGS)
-    _create_sightings(_SIGHTINGS_REBUILD, route_source_check=route_source_check)
-    carried = ", ".join(_SIGHTINGS_COLUMNS)
-    op.execute(f"INSERT INTO {_SIGHTINGS_REBUILD} ({carried}) SELECT {carried} FROM {_SIGHTINGS}")
-    op.drop_table(_SIGHTINGS)
-    op.rename_table(_SIGHTINGS_REBUILD, _SIGHTINGS)
-    for name, columns, where in _SIGHTINGS_INDEXES:
-        kwargs: dict[str, Any] = {} if where is None else {"sqlite_where": sa.text(where)}
-        op.create_index(name, _SIGHTINGS, list(columns), **kwargs)
+    """Rebuild ``sightings`` into the requested shape, keeping every row.
+
+    Foreign keys are suspended for the duration and checked afterwards — see
+    the module docstring and issue #178 — and every step is conditional, so a
+    re-run over a half-finished attempt continues rather than failing.
+    """
+    bind = op.get_bind()
+    with rebuild.rebuilding(bind, _SIGHTINGS):
+        for name, _columns, _where in _SIGHTINGS_INDEXES:
+            if rebuild.has_index(bind, name):
+                op.drop_index(name, table_name=_SIGHTINGS)
+        _create_sightings(_SIGHTINGS_REBUILD, route_source_check=route_source_check)
+        carried = ", ".join(_SIGHTINGS_COLUMNS)
+        op.execute(
+            f"INSERT INTO {_SIGHTINGS_REBUILD} ({carried}) SELECT {carried} FROM {_SIGHTINGS}"
+        )
+        rebuild.assert_copied(bind, _SIGHTINGS, _SIGHTINGS_REBUILD)
+        op.drop_table(_SIGHTINGS)
+        op.rename_table(_SIGHTINGS_REBUILD, _SIGHTINGS)
+        for name, columns, where in _SIGHTINGS_INDEXES:
+            kwargs: dict[str, Any] = {} if where is None else {"sqlite_where": sa.text(where)}
+            op.create_index(name, _SIGHTINGS, list(columns), **kwargs)
 
 
 def _create_directory_tables() -> None:
     """``route_directory`` and its staging table (``docs/DATA_MODEL.md`` §7.1)."""
-    op.create_table(
-        "route_directory",
-        sa.Column("callsign", sa.Text(), nullable=False),
-        sa.Column("airline_code", sa.Text(), nullable=True),
-        sa.Column("airport_codes", sa.Text(), nullable=False),
-        sa.Column("dataset_version", sa.Text(), nullable=False),
-        sa.PrimaryKeyConstraint("callsign"),
-        sqlite_with_rowid=False,
-    )
-    op.create_table(
-        "route_directory_staging",
-        sa.Column("callsign", sa.Text(), nullable=False),
-        sa.Column("airline_code", sa.Text(), nullable=True),
-        sa.Column("airport_codes", sa.Text(), nullable=False),
-        sa.PrimaryKeyConstraint("callsign"),
-        sqlite_with_rowid=False,
-    )
+    bind = op.get_bind()
+    if not rebuild.has_table(bind, "route_directory"):
+        op.create_table(
+            "route_directory",
+            sa.Column("callsign", sa.Text(), nullable=False),
+            sa.Column("airline_code", sa.Text(), nullable=True),
+            sa.Column("airport_codes", sa.Text(), nullable=False),
+            sa.Column("dataset_version", sa.Text(), nullable=False),
+            sa.PrimaryKeyConstraint("callsign"),
+            sqlite_with_rowid=False,
+        )
+    if not rebuild.has_table(bind, "route_directory_staging"):
+        op.create_table(
+            "route_directory_staging",
+            sa.Column("callsign", sa.Text(), nullable=False),
+            sa.Column("airline_code", sa.Text(), nullable=True),
+            sa.Column("airport_codes", sa.Text(), nullable=False),
+            sa.PrimaryKeyConstraint("callsign"),
+            sqlite_with_rowid=False,
+        )
+
+
+def _reconcile_interrupted_attempt() -> None:
+    """Put the database back on one of this revision's two footings.
+
+    A previous attempt can have been interrupted anywhere. The only step that
+    leaves an object behind is the staging table, and what it means depends on
+    whether ``sightings`` is still there — see
+    :func:`flightsite.db.migrations.rebuild.reconcile_staging_table`. Doing
+    this first means everything after it sees a database with a ``sightings``
+    table in one shape or the other, and nothing else out of place.
+    """
+    rebuild.reconcile_staging_table(op.get_bind(), _SIGHTINGS, _SIGHTINGS_REBUILD)
 
 
 def upgrade() -> None:
+    _reconcile_interrupted_attempt()
     _create_directory_tables()
-    op.add_column("route_cache", sa.Column("source", sa.Text(), nullable=True))
+    if not rebuild.has_column(op.get_bind(), "route_cache", "source"):
+        op.add_column("route_cache", sa.Column("source", sa.Text(), nullable=True))
     _rebuild_sightings(route_source_check=_ROUTE_SOURCE_CHECK)
 
 
 def downgrade() -> None:
+    _reconcile_interrupted_attempt()
     # A `vrs` route cannot exist under the older CHECK. The sighting itself is
     # history and is never deleted, but the route on it came from a source the
     # build being downgraded to cannot name — and SPEC §22 wants a provenance
@@ -232,7 +301,10 @@ def downgrade() -> None:
     # Same reasoning one table over, and the same remedy revision 0014 applied
     # to a `restricted` row: a cache entry the older build would misattribute
     # to AeroDataBox costs one lookup to replace, so it goes.
-    op.execute("DELETE FROM route_cache WHERE source = 'vrs'")
-    op.drop_column("route_cache", "source")
-    op.drop_table("route_directory_staging")
-    op.drop_table("route_directory")
+    bind = op.get_bind()
+    if rebuild.has_column(bind, "route_cache", "source"):
+        op.execute("DELETE FROM route_cache WHERE source = 'vrs'")
+        op.drop_column("route_cache", "source")
+    for table in ("route_directory_staging", "route_directory"):
+        if rebuild.has_table(bind, table):
+            op.drop_table(table)

--- a/backend/tests/db/test_migration_0015_children.py
+++ b/backend/tests/db/test_migration_0015_children.py
@@ -1,0 +1,508 @@
+"""Migration 0015 against a database that actually has children (issue #178).
+
+``tests/enrichment/test_migration_directory.py`` covers what revision 0015
+*changes*. This module covers what broke in production: the revision rebuilds
+``sightings``, five tables reference ``sightings(id)``, and every test that
+existed when the revision shipped seeded **no child rows at all**. With the
+foreign keys the application's connections enforce, ``DROP TABLE sightings``
+is an implicit ``DELETE`` checked row by row against those five children — five
+minutes of CPU on a 16,214-sighting install, then
+``FOREIGN KEY constraint failed``, then a rollback and six minutes of downtime.
+
+So the fixtures here populate every child, and the assertions are the three
+things the failure denied: the upgrade finishes in a bounded time, every child
+row is still attached to its sighting afterwards, and ``foreign_key_check``
+has nothing to say. Plus the two mechanisms that make it so — the suspended
+pragma, and resuming from the wreckage of a failed attempt.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
+
+from flightsite.db import migrate
+from flightsite.db.migrations import rebuild
+from tests.db.harness import create_sql, database_at, index_names, index_sql, table_names
+
+REVISION = "0015"
+PREVIOUS = "0014"
+SIGHTINGS = "sightings"
+STAGING = "sightings_rebuild"
+
+#: Sightings in the populated fixture, and 30,300 child rows around them.
+#: Within an order of magnitude of the install that failed (16,214 sightings)
+#: rather than of a unit test, because what the shipped revision did was
+#: quadratic in this number — and still well under a second to seed, so it runs
+#: in the ordinary suite rather than behind a marker.
+SIGHTING_COUNT = 3000
+
+#: Rows written per sighting into each child table, in the proportions a real
+#: database carries them: one track blob, several track checkpoints, a couple
+#: of sighting events, an activity event or two, an occasional alert match.
+CHECKPOINTS_PER_SIGHTING = 5
+EVENTS_PER_SIGHTING = 2
+ACTIVITY_PER_SIGHTING = 2
+ALERT_MATCH_EVERY = 10
+
+#: Wall-clock bound for upgrading the populated fixture, and for downgrading
+#: it again. **Measured** on a developer SSD: 0.053 s to upgrade and 0.049 s to
+#: downgrade this fixture, and 0.101 s / 0.108 s at the failing install's scale
+#: (16,214 sightings, 163,761 child rows, an 11 MB file). The bound is three
+#: orders of magnitude above that because it is a *regression* gate on a shared
+#: CI runner, not a benchmark — the failure it exists to catch ran for five
+#: minutes on a database five times this size and then raised.
+MIGRATION_BUDGET_S = 30.0
+
+#: Every table that references ``sightings(id)``. The rebuild has to leave all
+#: five resolving, and every one of them is seeded before the upgrade runs.
+CHILD_TABLES = (
+    "sighting_tracks",
+    "sighting_track_checkpoints",
+    "sighting_events",
+    "activity_events",
+    "alert_matches",
+)
+
+
+def _seed_children(db_path: Path, count: int = SIGHTING_COUNT) -> dict[str, int]:
+    """Fill a 0014 database with sightings and rows in every child table.
+
+    Written with stdlib ``sqlite3`` against the schema revision 0014 left, the
+    way an older build would have written it — not through today's models,
+    which is the same discipline :mod:`tests.db.harness` applies.
+
+    Returns the row count seeded into each child table.
+    """
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("PRAGMA foreign_keys=ON")
+        connection.execute(
+            "INSERT INTO aircraft (id, icao24, first_seen_ms, last_seen_ms) "
+            "VALUES (1, 'ae1463', 1, 2)"
+        )
+        connection.executemany(
+            "INSERT INTO sightings (id, aircraft_id, started_ms, ended_ms, callsign_last, "
+            "origin_ident, destination_ident, route_source, max_range_nm, msg_count) "
+            "VALUES (?, 1, ?, ?, ?, 'KATL', 'KSLC', 'aerodatabox', ?, ?)",
+            [
+                (index, index * 1000, index * 1000 + 500, f"DAL{index:04d}", index / 10.0, index)
+                for index in range(1, count + 1)
+            ],
+        )
+        connection.executemany(
+            "INSERT INTO sighting_tracks (sighting_id, encoding_version, point_count, "
+            "started_ms, points_blob) VALUES (?, 1, 4, ?, ?)",
+            [(index, index * 1000, b"\x00\x01\x02\x03") for index in range(1, count + 1)],
+        )
+        connection.executemany(
+            "INSERT INTO sighting_track_checkpoints (sighting_id, seq, ts_ms, lat, lon, "
+            "alt_ft, gs_kt, track_deg, pos_source) VALUES (?, ?, ?, 51.5, -0.1, 30000, "
+            "440.0, 90.0, 0)",
+            [
+                (index, seq, index * 1000 + seq)
+                for index in range(1, count + 1)
+                for seq in range(CHECKPOINTS_PER_SIGHTING)
+            ],
+        )
+        connection.executemany(
+            "INSERT INTO sighting_events (sighting_id, ts_ms, type) VALUES (?, ?, ?)",
+            [
+                (index, index * 1000 + seq, "callsign_change" if seq else "route_enriched")
+                for index in range(1, count + 1)
+                for seq in range(EVENTS_PER_SIGHTING)
+            ],
+        )
+        connection.executemany(
+            "INSERT INTO activity_events (ts_ms, type, severity, aircraft_id, sighting_id) "
+            "VALUES (?, 'sighting_closed', 'info', 1, ?)",
+            [
+                (index * 1000 + seq, index)
+                for index in range(1, count + 1)
+                for seq in range(ACTIVITY_PER_SIGHTING)
+            ],
+        )
+        connection.executemany(
+            "INSERT INTO alert_matches (builtin_key, sighting_id, aircraft_id, matched_ms, "
+            "severity, reason) VALUES ('emergency', ?, 1, ?, 'high', 'squawk 7700')",
+            [
+                (index, index * 1000)
+                for index in range(1, count + 1)
+                if index % ALERT_MATCH_EVERY == 0
+            ],
+        )
+    return _child_counts(db_path)
+
+
+def _child_counts(db_path: Path) -> dict[str, int]:
+    """Row count of every child table."""
+    with sqlite3.connect(db_path) as connection:
+        return {
+            table: int(connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+            for table in CHILD_TABLES
+        }
+
+
+def _orphans(db_path: Path) -> dict[str, int]:
+    """Rows in each child whose ``sighting_id`` no longer names a sighting."""
+    with sqlite3.connect(db_path) as connection:
+        return {
+            table: int(
+                connection.execute(
+                    f"SELECT COUNT(*) FROM {table} WHERE sighting_id IS NOT NULL "
+                    "AND sighting_id NOT IN (SELECT id FROM sightings)"
+                ).fetchone()[0]
+            )
+            for table in CHILD_TABLES
+        }
+
+
+def _foreign_key_violations(db_path: Path) -> list[tuple[object, ...]]:
+    """Whatever ``PRAGMA foreign_key_check`` finds across the whole database."""
+    with sqlite3.connect(db_path) as connection:
+        return list(connection.execute("PRAGMA foreign_key_check"))
+
+
+def _schema_of(db_path: Path, names: tuple[str, ...]) -> dict[str, str]:
+    """The stored SQL of the named tables and indexes, for comparing schemas."""
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute(
+            "SELECT name, sql FROM sqlite_master WHERE name IN "
+            f"({', '.join('?' * len(names))}) ORDER BY name",
+            names,
+        ).fetchall()
+    return {str(name): str(sql) for name, sql in rows}
+
+
+#: The objects revision 0015 creates or recreates, whose definitions must come
+#: out identical whether the upgrade ran clean or resumed from a failed one.
+AFFECTED_OBJECTS = (
+    "route_directory",
+    "route_directory_staging",
+    "route_cache",
+    SIGHTINGS,
+    "ix_sightings_aircraft",
+    "ix_sightings_started",
+    "ix_sightings_open",
+    "ix_sightings_max_range",
+)
+
+
+@pytest.fixture
+async def populated_0014(db_path: Path) -> Path:
+    """A revision-0014 database with sightings and every child table filled."""
+    async with database_at(db_path, PREVIOUS):
+        pass
+    _seed_children(db_path)
+    return db_path
+
+
+# ------------------------------------------------------- the upgrade with children
+
+
+@pytest.mark.perf
+async def test_the_upgrade_finishes_promptly_on_a_database_with_children(
+    populated_0014: Path,
+) -> None:
+    """The regression gate: the failure this replaces ran for minutes, then raised.
+
+    A bound rather than a benchmark — see :data:`MIGRATION_BUDGET_S`.
+    """
+    started = time.perf_counter()
+    async with database_at(populated_0014, REVISION) as database:
+        assert await database.current_revision() == REVISION
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < MIGRATION_BUDGET_S, f"upgrade with children took {elapsed:.2f}s"
+
+
+async def test_every_child_row_survives_the_rebuild(populated_0014: Path) -> None:
+    """Not one row of the five children may be deleted, orphaned or renumbered."""
+    before = _child_counts(populated_0014)
+
+    async with database_at(populated_0014, REVISION):
+        pass
+
+    assert _child_counts(populated_0014) == before
+    assert _orphans(populated_0014) == dict.fromkeys(CHILD_TABLES, 0)
+
+
+async def test_the_upgrade_leaves_no_dangling_reference_anywhere(
+    populated_0014: Path,
+) -> None:
+    """Enforcement is suspended for the rebuild, so this is what replaces it."""
+    async with database_at(populated_0014, REVISION):
+        pass
+
+    assert _foreign_key_violations(populated_0014) == []
+
+
+async def test_the_sightings_themselves_survive_the_rebuild(populated_0014: Path) -> None:
+    with sqlite3.connect(populated_0014) as connection:
+        before = list(
+            connection.execute("SELECT id, callsign_last, max_range_nm FROM sightings ORDER BY id")
+        )
+
+    async with database_at(populated_0014, REVISION):
+        pass
+
+    with sqlite3.connect(populated_0014) as connection:
+        after = list(
+            connection.execute("SELECT id, callsign_last, max_range_nm FROM sightings ORDER BY id")
+        )
+    assert len(after) == SIGHTING_COUNT
+    assert after == before
+
+
+# ------------------------------------------------------ the downgrade with children
+
+
+@pytest.mark.perf
+async def test_the_downgrade_is_bounded_and_keeps_the_children(
+    populated_0014: Path,
+) -> None:
+    """Rollback rebuilds the same table, so it needs the same discipline."""
+    async with database_at(populated_0014, REVISION):
+        pass
+    before = _child_counts(populated_0014)
+
+    started = time.perf_counter()
+    async with database_at(populated_0014, REVISION) as database:
+        await database.downgrade_to(PREVIOUS)
+        assert await database.current_revision() == PREVIOUS
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < MIGRATION_BUDGET_S, f"downgrade with children took {elapsed:.2f}s"
+    assert _child_counts(populated_0014) == before
+    assert _orphans(populated_0014) == dict.fromkeys(CHILD_TABLES, 0)
+    assert _foreign_key_violations(populated_0014) == []
+
+
+# ----------------------------------------------------------------- the pragma itself
+
+
+async def test_the_rebuild_runs_with_foreign_keys_off_and_restores_them(
+    db_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The claim the original revision made without ever checking it.
+
+    ``PRAGMA foreign_keys`` is read back on the migration's *own* connection —
+    once while the rebuild is finished but not yet unwound, which is when
+    :func:`flightsite.db.migrations.rebuild.check_foreign_keys` runs, and once
+    after each attempt to change it, which is what proves enforcement came
+    back rather than merely being asked to.
+    """
+    during: list[bool] = []
+    after_each_change: list[bool] = []
+    original_check = rebuild.check_foreign_keys
+    original_set = rebuild.set_foreign_keys
+
+    def check_spy(bind: sa.Connection, table: str) -> None:
+        during.append(rebuild.foreign_keys_enabled(bind))
+        original_check(bind, table)
+
+    def set_spy(bind: sa.Connection, *, enabled: bool) -> None:
+        original_set(bind, enabled=enabled)
+        after_each_change.append(rebuild.foreign_keys_enabled(bind))
+
+    monkeypatch.setattr(rebuild, "check_foreign_keys", check_spy)
+    monkeypatch.setattr(rebuild, "set_foreign_keys", set_spy)
+
+    async with database_at(db_path, PREVIOUS):
+        pass
+    _seed_children(db_path, count=10)
+    async with database_at(db_path, REVISION):
+        pass
+
+    assert during == [False], "the rebuild did not run with foreign keys suspended"
+    assert after_each_change == [False, True], "enforcement was not restored afterwards"
+
+
+def test_the_pragma_is_restored_even_though_it_had_to_leave_a_transaction(
+    db_path: Path,
+) -> None:
+    """Suspending enforcement inside an open transaction is silently a no-op.
+
+    This is the empirical fact the fix turns on, and it is asserted directly
+    rather than inferred: a plain ``PRAGMA foreign_keys=OFF`` issued after a
+    DML statement — which is where a multi-revision Alembic run arrives, its
+    ``UPDATE alembic_version`` having opened a transaction pysqlite holds open
+    — leaves enforcement *on*. Going through
+    :func:`flightsite.db.migrations.rebuild.rebuilding` ends that transaction
+    first, and restores enforcement on the way out.
+    """
+    engine = sa.create_engine(f"sqlite:///{db_path.as_posix()}")
+    with engine.connect() as connection:
+        connection.exec_driver_sql("PRAGMA foreign_keys=ON")
+        connection.exec_driver_sql("CREATE TABLE parent (id INTEGER PRIMARY KEY)")
+        connection.exec_driver_sql("INSERT INTO parent (id) VALUES (1)")
+        driver = connection.connection.driver_connection
+        assert isinstance(driver, sqlite3.Connection)
+        assert driver.in_transaction is True
+
+        connection.exec_driver_sql("PRAGMA foreign_keys=OFF")
+        ignored_inside_a_transaction = rebuild.foreign_keys_enabled(connection)
+
+        connection.exec_driver_sql("INSERT INTO parent (id) VALUES (2)")
+        with rebuild.rebuilding(connection, "parent"):
+            suspended = rebuild.foreign_keys_enabled(connection)
+        restored = rebuild.foreign_keys_enabled(connection)
+    engine.dispose()
+
+    assert ignored_inside_a_transaction is True
+    assert suspended is False
+    assert restored is True
+
+
+def test_a_dangling_reference_is_raised_rather_than_committed(db_path: Path) -> None:
+    """The check is the substitute for the enforcement, so it has to bite."""
+    engine = sa.create_engine(f"sqlite:///{db_path.as_posix()}")
+    with engine.connect() as connection:
+        connection.exec_driver_sql("CREATE TABLE parent (id INTEGER PRIMARY KEY)")
+        connection.exec_driver_sql(
+            "CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent (id))"
+        )
+        connection.exec_driver_sql("INSERT INTO parent (id) VALUES (1)")
+        connection.exec_driver_sql("INSERT INTO child (id, parent_id) VALUES (1, 1)")
+
+        with pytest.raises(rebuild.DanglingForeignKeys), rebuild.rebuilding(connection, "parent"):
+            connection.exec_driver_sql("DELETE FROM parent")
+
+        assert rebuild.foreign_keys_enabled(connection) is True
+    engine.dispose()
+
+
+def test_the_children_of_a_table_are_discovered_from_the_schema(db_path: Path) -> None:
+    """So a later slice's new child table is checked without anyone adding it."""
+    engine = sa.create_engine(f"sqlite:///{db_path.as_posix()}")
+    with engine.connect() as connection:
+        connection.exec_driver_sql("CREATE TABLE parent (id INTEGER PRIMARY KEY)")
+        connection.exec_driver_sql(
+            "CREATE TABLE later (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent (id))"
+        )
+        connection.exec_driver_sql("CREATE TABLE unrelated (id INTEGER PRIMARY KEY)")
+        found = rebuild.child_tables(connection, "parent")
+    engine.dispose()
+
+    assert found == ("later",)
+
+
+# --------------------------------------------------------- resuming a failed attempt
+
+
+def _replay_failed_attempt(db_path: Path, *, past_the_drop: bool = False) -> None:
+    """Leave the database in the state a failed 0015 attempt leaves it in.
+
+    Replayed through Alembic's own operations against the revision module
+    itself, rather than hand-written SQL, so the objects a resumed upgrade
+    finds are byte-for-byte the ones the failed attempt created.
+
+    By default this is fermi's state, where ``DROP TABLE sightings`` was the
+    statement that raised: directory tables present, ``route_cache.source``
+    added, all four ``sightings`` indexes dropped, an empty
+    ``sightings_rebuild`` left behind (its ``INSERT … SELECT`` rolled back with
+    the failing statement), and ``alembic_version`` still naming 0014.
+
+    With ``past_the_drop`` it is the narrower window a crash — a power cut, a
+    container kill — can land in instead: the copy done and ``sightings``
+    dropped, with the history sitting in ``sightings_rebuild`` and five child
+    tables referencing a table that no longer exists.
+    """
+    module = migrate.script_directory().get_revision(REVISION).module
+    engine = sa.create_engine(f"sqlite:///{db_path.as_posix()}")
+    with engine.connect() as connection:
+        connection.exec_driver_sql("PRAGMA foreign_keys=OFF")
+        context = MigrationContext.configure(connection, opts={"render_as_batch": True})
+        with Operations.context(context) as operations:
+            module._create_directory_tables()
+            operations.add_column("route_cache", sa.Column("source", sa.Text(), nullable=True))
+            for name, _columns, _where in module._SIGHTINGS_INDEXES:
+                operations.drop_index(name, table_name=SIGHTINGS)
+            module._create_sightings(STAGING, route_source_check=module._ROUTE_SOURCE_CHECK)
+            if past_the_drop:
+                carried = ", ".join(module._SIGHTINGS_COLUMNS)
+                operations.execute(
+                    f"INSERT INTO {STAGING} ({carried}) SELECT {carried} FROM {SIGHTINGS}"
+                )
+                operations.drop_table(SIGHTINGS)
+        connection.commit()
+    engine.dispose()
+
+
+async def test_the_partial_state_of_a_failed_attempt_is_resumable(
+    populated_0014: Path,
+) -> None:
+    """A restarting container re-runs 0015 over the wreckage of the last try."""
+    before = _child_counts(populated_0014)
+    _replay_failed_attempt(populated_0014)
+    assert STAGING in table_names(populated_0014)
+
+    async with database_at(populated_0014, REVISION) as database:
+        assert await database.current_revision() == REVISION
+
+    assert _child_counts(populated_0014) == before
+    assert _orphans(populated_0014) == dict.fromkeys(CHILD_TABLES, 0)
+    assert _foreign_key_violations(populated_0014) == []
+    assert index_names(populated_0014, SIGHTINGS) >= {
+        "ix_sightings_aircraft",
+        "ix_sightings_started",
+        "ix_sightings_open",
+        "ix_sightings_max_range",
+    }
+    assert "ended_ms IS NULL" in index_sql(populated_0014, "ix_sightings_open")
+    assert STAGING not in table_names(populated_0014)
+
+
+async def test_a_resumed_upgrade_lands_on_the_same_schema_as_a_clean_one(
+    db_path: Path, tmp_path: Path
+) -> None:
+    """Same end state, object for object — otherwise "resumable" is a wish."""
+    clean = tmp_path / "clean.sqlite3"
+    async with database_at(clean, PREVIOUS):
+        pass
+    _seed_children(clean, count=20)
+    async with database_at(clean, REVISION):
+        pass
+
+    async with database_at(db_path, PREVIOUS):
+        pass
+    _seed_children(db_path, count=20)
+    _replay_failed_attempt(db_path)
+    async with database_at(db_path, REVISION):
+        pass
+
+    resumed = _schema_of(db_path, AFFECTED_OBJECTS)
+    assert set(resumed) == set(AFFECTED_OBJECTS), "an object is missing, not merely different"
+    assert resumed == _schema_of(clean, AFFECTED_OBJECTS)
+    assert "vrs" in create_sql(db_path, SIGHTINGS)
+
+
+async def test_an_interrupted_rename_keeps_the_history_it_was_carrying(
+    populated_0014: Path,
+) -> None:
+    """The one partial state where the staging table *is* the data.
+
+    A crash between ``DROP TABLE sightings`` and the rename leaves the rows in
+    ``sightings_rebuild`` and no ``sightings`` at all. Dropping the staging
+    table on the next attempt — the obvious reading of "clear anything left
+    behind" — would delete the history instead of migrating it.
+    """
+    before = _child_counts(populated_0014)
+    _replay_failed_attempt(populated_0014, past_the_drop=True)
+    assert SIGHTINGS not in table_names(populated_0014)
+
+    async with database_at(populated_0014, REVISION) as database:
+        assert await database.current_revision() == REVISION
+
+    with sqlite3.connect(populated_0014) as connection:
+        surviving = int(connection.execute("SELECT COUNT(*) FROM sightings").fetchone()[0])
+    assert surviving == SIGHTING_COUNT
+    assert STAGING not in table_names(populated_0014)
+    assert _child_counts(populated_0014) == before
+    assert _orphans(populated_0014) == dict.fromkeys(CHILD_TABLES, 0)
+    assert _foreign_key_violations(populated_0014) == []

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -368,6 +368,55 @@ have tests (empty DB + realistic upgrade fixtures), and may be applied automatic
 at startup. Adjacent released versions must have a tested upgrade path. Rollback is
 supported where practical. Historical data is never casually discarded.
 
+### SQLite DDL is not transactional — write resumable revisions
+
+Alembic marks SQLite as non-transactional DDL, so a revision is **not** all-or-nothing:
+every statement before a failing one stays committed while `alembic_version` still
+names the *older* revision. A container that restarts after a failed migration re-runs
+the whole revision from the top over a half-migrated database.
+
+So each step of a revision must tolerate its own prior completion — create a table only
+if absent, add a column only if missing, drop an index only if present, clear a stray
+staging table before recreating it. `flightsite.db.migrations.rebuild` provides the
+`has_table` / `has_index` / `has_column` predicates for exactly this.
+
+### Rebuilding a table: disable foreign keys, then check them
+
+SQLite cannot alter a `CHECK` (or most constraints) in place, so widening one means
+rebuilding the table: create the new shape, copy every row, drop the old table, rename.
+Every FlightSite connection — the app writer, the readers, and the engine
+`migrations/env.py` builds — runs with `PRAGMA foreign_keys=ON`, and under enforcement
+`DROP TABLE` is an implicit `DELETE` of every row, each checked against every child
+table that references it. On a table with unindexed children that is a full scan per
+parent row, and it fails anyway with `FOREIGN KEY constraint failed`. This took down a
+v0.6.0 upgrade (issue #178).
+
+A rebuild therefore goes through `flightsite.db.migrations.rebuild.rebuilding()`, which:
+
+1. issues `PRAGMA foreign_keys=OFF` **and reads it back** — the pragma is silently a
+   no-op inside a transaction, and pysqlite has one open whenever a preceding DML
+   statement (Alembic's own `UPDATE alembic_version`, for instance) started one, so the
+   helper commits to reach a statement boundary and retries rather than assuming;
+2. runs the rebuild;
+3. runs `PRAGMA foreign_key_check` over the rebuilt table and every table the schema
+   says references it, and raises on any row — enforcement is *suspended* for the
+   rebuild, not abandoned;
+4. restores `PRAGMA foreign_keys=ON` in a `finally`, rolling back first if the rebuild
+   raised.
+
+The same applies to `downgrade()`, which rebuilds the same table.
+
+### Measure migrations against populated data
+
+A migration's cost is measured against a database with **rows in the child tables**,
+never an empty seed: the v0.6.0 defect was invisible in a "200,000 sightings in 1.02 s"
+measurement precisely because the five tables referencing `sightings` were empty. Seed
+with the slice-050 synthetic generator (`flightsite.perf.storage_qualification`) or a
+fixture that fills every child, and state the measured figure in the revision docstring.
+`backend/tests/db/test_migration_0015_children.py` is the worked example: it seeds every
+child of `sightings`, asserts each row survives with its reference intact, and bounds
+the wall time.
+
 ### Parallel migrations & persistence worker
 
 Concurrent worktrees can each add an Alembic revision, producing divergent heads.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -70,7 +70,12 @@ Every release branch must complete all applicable items:
 - [ ] Docker Compose deployment validated (arm64 and amd64 images)
 - [ ] Backup test: backup taken during active ingestion, manifest valid
 - [ ] Restore test: backup restores and passes integrity checks
-- [ ] Adjacent-version upgrade test: previous release's data dir upgrades in place
+- [ ] Adjacent-version upgrade test: previous release's data dir upgrades in place —
+      run against a **populated** data directory (a real deployment's backup, or a
+      slice-050 synthetic dataset), not a fresh or lightly seeded one, and **before the
+      release PR is opened**. Record the wall time of the migration step. An empty
+      database exercises none of the per-row work a schema change does, which is how
+      v0.6.0 shipped a migration that hung and failed on any real install (issue #178)
 - [ ] Demo-mode validation: full stack runs and exercises scenarios
 - [ ] Live-decoder validation against readsb/dump1090-fa where appropriate
 - [ ] Raspberry Pi 4 qualification where required — run the procedure in

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -154,6 +154,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | 069 | Enrichment hot-apply & honest restart badges | 026, 055, 056, 068 | opus | low | Apply enrichment settings on config save so AeroDataBox route lookup starts, stops or re-keys without a backend restart, and badge every Settings section that still needs one (issue #161) |
 | 070 | Route enrichment credit economy & airport names | 026, 027, 042, 069 | opus | medium | Week-long per-callsign route cache, learned schedules, a daily lookup budget spent in priority order, restricted flights cached instead of retried (#165), and airport names beside route idents from the local airports table (issue #167) |
 | 071 | Offline route directory (VRS standing data) & enrichment resilience | 021, 027, 049, 070 | opus | medium | VRS standing-data routes as the primary origin/destination source (SPEC §28 amended, ADR-0016), AeroDataBox only for misses, inferred route end shown where no source knows the callsign, last known route served when a refresh cannot happen, CI headroom for the flaky perf gates (issue #173; #166, #170) |
+| 072 | Migration 0015 rebuild fix | 071 | opus | high | Hotfix: run the `sightings` rebuild with foreign keys off and checked afterwards, resumable from the v0.6.0 partial state, with migration tests that seed every child table (issue #178; v0.6.1) |
 
 ## Parallelization Guide
 

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -2057,6 +2057,42 @@ slices:
     risk_level: medium
     notes: "Owner decision 2026-09-05 after the route-source research on #168: amend SPEC §28 to admit an offline route directory as the primary source. Bundled with the resilience items proposed in the same conversation (inferred end, last-known route) and the CI headroom for #166/#170, whose flakes cost four re-runs during the v0.4.0 and v0.5.0 trains. Migration-bearing (0015). Added by Fable outside the phase plan."
 
+  - id: "072"
+    title: "Migration 0015 rebuild fix"
+    phase: 8
+    branch: "072-migration-0015-fix"
+    status: merged
+    depends_on: ["071"]
+    objective: "Make migration 0015's `sightings` rebuild correct on a populated database — foreign keys off around the rebuild and checked afterwards, resumable from the partial state a v0.6.0 attempt leaves — and make the migration test suite incapable of missing this class of defect again (issue #178; supersedes v0.6.0 with v0.6.1)."
+    scope:
+      - "`rev_0015`: `PRAGMA foreign_keys=OFF` before the rebuild, issued while no transaction is open (pysqlite opens one implicitly at the first DML and the pragma is a no-op inside one), `PRAGMA foreign_key_check` after the rename with a hard failure on any row, `PRAGMA foreign_keys=ON` at the end; the same discipline in `downgrade`; the docstring's false claim about migration pragmas replaced by the truth"
+      - "resumable from the v0.6.0 partial state (directory tables and `route_cache.source` already present, `sightings` indexes already dropped, empty `sightings_rebuild` present, `alembic_version` 0014): every step tolerates its own prior completion"
+      - "a shared helper (or documented pattern) for SQLite table rebuilds in `db/migrations/`, so the next rebuild inherits the discipline instead of re-deriving it"
+      - "migration tests seed **every** child of `sightings` (`sighting_tracks`, `sighting_track_checkpoints`, `sighting_events`, `activity_events`, `alert_matches`) with rows referencing real sightings before upgrading, assert every child row survives with its FK intact and `foreign_key_check` is empty after both upgrade and downgrade, bound the wall time on a few thousand sightings with children, and upgrade from a fixture reproducing the recorded partial state"
+      - "`docs/DEVELOPMENT.md` Database migrations: a rebuild must disable foreign keys, check them afterwards and be tested against populated child tables; migration cost is measured against the slice-050 synthetic dataset, never an empty seed; a note that Alembic on SQLite autocommits DDL statement by statement so a failed migration leaves partial DDL behind"
+      - "`docs/RELEASE.md`: the adjacent-version upgrade test must run against a populated data directory before the release PR is opened, not only on the owner's host after publish"
+    out_of_scope:
+      - "indexes on `activity_events.sighting_id` and `sighting_track_checkpoints.sighting_id` (would also have masked the symptom; worth a separate measured decision, tracked as a follow-up)"
+      - "any change to slice 071's behaviour"
+    acceptance_criteria:
+      - "on a database with 5,000 sightings and populated children, 0014→0015 completes in seconds, keeps every child row, and `foreign_key_check` returns nothing; 0015→0014 likewise"
+      - "on a copy of the recorded v0.6.0 partial state, 0015 completes and the end state is byte-for-byte the shape of a clean upgrade"
+      - "`alembic heads` shows exactly one head (0015)"
+      - "the upgrade of fermi.local's restored v0.5.0 database to v0.6.1 completes at startup within the health-check window"
+      - "`Closes #178` in the PR body"
+    required_tests:
+      - populated-children migration tests (up, down, timing, foreign_key_check), partial-state resume test, helper unit tests
+    expected_artifacts:
+      - backend/src/flightsite/db/migrations/versions/rev_0015_route_directory.py
+      - backend/src/flightsite/db/migrations/ (rebuild helper)
+      - backend/tests/enrichment/test_migration_economy.py
+      - backend/tests/db/
+      - docs/DEVELOPMENT.md
+      - docs/RELEASE.md
+    preferred_agent: opus
+    risk_level: high
+    notes: "Hotfix slice. v0.6.0 was released 2026-09-05 with migration 0015 rebuilding `sightings` under foreign_keys=ON: the DROP TABLE's implicit DELETE scanned unindexed children per parent row and would end in a constraint error; fermi.local hung for five minutes and was rolled back from its pre-upgrade backup with no data loss. The slice-071 measurement and its 18 migration tests all used a database with empty child tables. v0.6.0 is marked pre-release and superseded; v0.6.1 carries this fix. Added by Fable outside the phase plan."
+
 # Parallelization guide (dependency-derived; Fable owns merge order). Slices adding
 # Alembic migrations or extending the slice-009 persistence worker (021, 024, 026,
 # 027, 031, 033, 035, 037, 038, 052) are ADDITIONALLY serialized against each other


### PR DESCRIPTION
## Slice 072 — Migration 0015 rebuild fix (hotfix for v0.6.0)

Closes #178.

v0.6.0's migration 0015 rebuilt `sightings` under `foreign_keys=ON` (the migration connection carries the app pragmas; the docstring claimed otherwise), so `DROP TABLE sightings` ran an implicit per-row foreign-key delete check against five `NO ACTION` children, two without an index on `sighting_id`. On fermi.local (16k sightings, 164k child rows) it ran for five minutes toward `FOREIGN KEY constraint failed`; the site was rolled back from its pre-upgrade backup. Alembic's non-transactional SQLite DDL had already committed the steps before the drop.

**Fix**
- New shared helper `db/migrations/rebuild.py`: `rebuilding()` suspends foreign keys **and proves it** — the pragma is written, read back, and only if it was ignored (a transaction Alembic already opened, e.g. on a multi-revision run) is the DBAPI transaction ended and the write retried; the production 0014→0015 path commits nothing early. `check_foreign_keys` runs `PRAGMA foreign_key_check` scoped to the table and its schema-discovered children and fails hard; enforcement is restored in a `finally`.
- `rev_0015` uses it for both directions and is **resumable**: `_reconcile_interrupted_attempt()` handles the recorded v0.6.0 partial state (directory tables and column present, sightings indexes gone, empty `sightings_rebuild`) and the narrower crash-after-DROP window where `sightings_rebuild` *is* the history and must be renamed into place. The docstring records the false claim, the real pragma behaviour, the failure, and the populated measurement.
- Docs: DEVELOPMENT.md (non-transactional DDL and resumable revisions; rebuild discipline; measure against populated data), RELEASE.md (adjacent-version upgrade test against a populated data directory **before** the release PR opens, wall time recorded).

**Measured with children** (developer SSD): 3,000 sightings + 30k child rows: upgrade 0.053 s, downgrade 0.049 s. fermi's scale, 16,214 sightings + 163,761 child rows: upgrade **0.101 s**, downgrade 0.108 s. The shipped revision fails the same fixtures with the production error.

**Tests** (`tests/db/test_migration_0015_children.py`, 12): all five children seeded; bounded upgrade/downgrade (30 s budget, `perf`-marked); every child row survives un-orphaned; `foreign_key_check` empty; sightings identical row for row; the pragma reads 0 during and 1 after on the migration's own connection; the ignored-inside-a-transaction case; `DanglingForeignKeys` bites; children discovered from the schema; three resumability cases incl. fermi's partial state replayed through Alembic's own operations and compared on `sqlite_master` SQL.

**Verification (local)**: ruff / format / mypy clean; `alembic heads` = 0015 only; agent's full run 4604 passed / 98.74 %; integrated-tree full run in progress (appended below). Standalone `alembic upgrade head` on a 5,000-sighting / 50k-child database: stamped 0015, `foreign_key_check` empty, no stray table.

Release plan: v0.6.1 supersedes v0.6.0 (already marked pre-release); before upgrading fermi.local the corrected migration is pre-flighted against a staged copy of its database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBBZTrt75zZtra3SDtJKhG