### PR TITLE
Back-merge v0.6.1 into dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ follows [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/) (`0.x.y` during pre-1.0 development).
 This file is updated only on release branches (see `docs/RELEASE.md`).
 
+## [0.6.1] — 2026-09-05
+
+A same-day hotfix that supersedes v0.6.0, which must not be installed on any
+database that already holds sightings.
+
+### Fixed
+- **Migration 0015 no longer hangs and fails on a populated database** (#178).
+  The `sightings` rebuild ran its `DROP TABLE` with foreign-key enforcement
+  on, so every existing sighting triggered full scans of child tables that
+  carry no index on their sighting column, and the statement would end in a
+  constraint error after minutes of work; the upgrade of the owner's
+  receiver hung for five minutes and was rolled back from its pre-upgrade
+  backup. The rebuild now disables foreign keys while no transaction is
+  open, verifies them with `PRAGMA foreign_key_check` after the rename, and
+  restores enforcement afterwards. It is also resumable: an install that
+  tried v0.6.0 and was left with the directory tables, the new column, its
+  sighting indexes dropped and an empty rebuild table completes the same
+  migration to the same end state
+- Migration tests now seed every child of `sightings` before upgrading, and
+  the release checklist requires the adjacent-version upgrade test against
+  a populated data directory before a release PR opens; the discipline for
+  SQLite table rebuilds is written down in `docs/DEVELOPMENT.md`
+
+### Upgrade notes
+- Everything in the v0.6.0 notes applies, including **take a backup first**
+  and the one-time *Update Aircraft Metadata* run to import the routes
+  dataset.
+- If you already attempted v0.6.0 and it hung: stop the stack, pin the
+  v0.6.1 images, and start — the corrected migration resumes from where the
+  failed one stopped. If you restored your backup instead, upgrade normally.
+
 ## [0.6.0] — 2026-09-05
 
 Origin and destination without an API key. The Virtual Radar Server

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flightsite"
-version = "0.6.0"
+version = "0.6.1"
 description = "FlightSite backend: self-hosted ADS-B observatory API and ingestion service."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "flightsite"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,6 +38,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | v0.4.0 | 8 | Settings that apply on save and alerts that reach every tab: enrichment hot-apply, stats-poller hot-start, app-shell-owned live socket, Notified marker write path, fix-dated track points, ADR-0014/0015, severity-triaged tracker (slices 067–069; recorded 2026-09-04) |
 | v0.5.0 | 8 | Route enrichment credit economy: week-long callsign cache, learned schedules, daily lookup budget with priority, restricted flights cached, airport names beside route idents (slice 070; migration 0014; recorded 2026-09-04) |
 | v0.6.0 | 8 | Offline route directory: VRS standing-data routes as the primary origin/destination source (SPEC §28 amended, ADR-0016), AeroDataBox only for misses, inferred route end, last-known route, CI perf-gate headroom (slice 071; migration 0015; recorded 2026-09-05) |
+| v0.6.1 | 8 | Same-day hotfix superseding v0.6.0: migration 0015's sightings rebuild runs with foreign keys off and checked, resumable from a failed v0.6.0 attempt (slice 072; recorded 2026-09-05) |
 | v1.0.0 | 8 | Qualified stable release per SPEC §114 definition of done |
 
 ## Slices

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flightsite-frontend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flightsite-frontend",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@radix-ui/react-separator": "^1.1.15",
         "@radix-ui/react-slot": "^1.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flightsite-frontend",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -107,6 +107,11 @@ releases:
       origin/destination source (SPEC §28 amended, ADR-0016), AeroDataBox only
       for misses, inferred route end, last-known route, CI perf-gate headroom
       (slice 071; migration 0015). Recorded 2026-09-05."
+  - version: "v0.6.1"
+    after_phase: 8
+    theme: "Same-day hotfix superseding v0.6.0: migration 0015's sightings
+      rebuild runs with foreign keys off and checked, and resumes from a
+      failed v0.6.0 attempt (slice 072). Recorded 2026-09-05."
   - version: "v1.0.0"
     after_phase: 8
     theme: "Qualified stable release per SPEC.md §114 definition of done."


### PR DESCRIPTION
Back-merge of the v0.6.1 hotfix release into `dev`, per `docs/RELEASE.md` post-merge step 5: version bumps, refreshed `uv.lock`, curated `CHANGELOG.md` and the roadmap release entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBBZTrt75zZtra3SDtJKhG