### PR TITLE
Back-merge v0.7.0 into dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ follows [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/) (`0.x.y` during pre-1.0 development).
 This file is updated only on release branches (see `docs/RELEASE.md`).
 
+## [0.7.0] — 2026-09-06
+
+The tracker is empty. This release clears the six low-severity items that
+remained after every open issue was triaged in v0.4.0, and it is the first
+release with no known product bug of any severity.
+
+### Added
+- **Per-rule alert history**: each rule on the Alerts page has a *Show
+  matches* control that filters the history to that rule, backed by a new
+  `rule_id` filter on `GET /api/v1/alerts/matches` (#98)
+- `metadata.source_url_overrides`: point any metadata dataset download at a
+  mirror or a local fixture server, per source, from `config.yaml` or the
+  environment; never applied to a request that carries a key (#112)
+- Demo mode now carries a handful of military, government and police
+  airframes, so those alert templates fire in demo and in the end-to-end
+  suite (#112)
+
+### Changed
+- The alert engine no longer evaluates rules on a stale-aircraft event,
+  which carries no new input; a removal no longer forces an immediate
+  persistence flush; and the nearest-airport context keeps an inferred
+  approach or departure through a two-minute dropout, so an aircraft that
+  goes quiet on final does not lose its phase (#138)
+- The map's label-density tier is driven by the number of labelled aircraft
+  rather than by every live entry, so Mode S-only contacts no longer push
+  labels into the sparse tier; anchor behaviour under sustained collision
+  was measured against MapLibre's placement code and accepted as already
+  bounded (#147)
+
+### Fixed
+- The WAL kill-drill test no longer fails on a slow or busy machine: it
+  waits on the subprocess's own progress instead of a fixed window (#100)
+- Every aircraft-layer style expression is validated against the MapLibre
+  style specification in the unit suite, so an invalid expression fails a
+  test instead of failing silently in the browser (#96)
+
+### Upgrade notes
+- No database migration: `docker compose pull && docker compose up -d`.
+- No configuration change is required; the URL overrides are optional.
+
+### Known issues
+- The Raspberry Pi 4 SSD performance qualification (#153) remains deferred
+  by the owner; the Pi 5 NVMe baseline is the current reference run. No
+  other issue is open.
+
 ## [0.6.1] — 2026-09-05
 
 A same-day hotfix that supersedes v0.6.0, which must not be installed on any

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flightsite"
-version = "0.6.1"
+version = "0.7.0"
 description = "FlightSite backend: self-hosted ADS-B observatory API and ingestion service."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "flightsite"
-version = "0.6.1"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,6 +39,7 @@ Releases are prepared on `release/vX.Y.Z` branches from qualified `dev`; the mer
 | v0.5.0 | 8 | Route enrichment credit economy: week-long callsign cache, learned schedules, daily lookup budget with priority, restricted flights cached, airport names beside route idents (slice 070; migration 0014; recorded 2026-09-04) |
 | v0.6.0 | 8 | Offline route directory: VRS standing-data routes as the primary origin/destination source (SPEC §28 amended, ADR-0016), AeroDataBox only for misses, inferred route end, last-known route, CI perf-gate headroom (slice 071; migration 0015; recorded 2026-09-05) |
 | v0.6.1 | 8 | Same-day hotfix superseding v0.6.0: migration 0015's sightings rebuild runs with foreign keys off and checked, resumable from a failed v0.6.0 attempt (slice 072; recorded 2026-09-05) |
+| v0.7.0 | 8 | Empty tracker: per-rule alert history, metadata URL overrides, demo classification airframes, true-cadence consumer follow-ups, labelled-count density tier, kill-drill and style-spec test hardening (slice 073; recorded 2026-09-06) |
 | v1.0.0 | 8 | Qualified stable release per SPEC §114 definition of done |
 
 ## Slices

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flightsite-frontend",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flightsite-frontend",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "dependencies": {
         "@radix-ui/react-separator": "^1.1.15",
         "@radix-ui/react-slot": "^1.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flightsite-frontend",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.7.0",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/planning/roadmap.yaml
+++ b/planning/roadmap.yaml
@@ -112,6 +112,12 @@ releases:
     theme: "Same-day hotfix superseding v0.6.0: migration 0015's sightings
       rebuild runs with foreign keys off and checked, and resumes from a
       failed v0.6.0 attempt (slice 072). Recorded 2026-09-05."
+  - version: "v0.7.0"
+    after_phase: 8
+    theme: "Empty tracker: per-rule alert history, metadata URL overrides,
+      demo classification airframes, true-cadence consumer follow-ups,
+      labelled-count density tier, kill-drill and style-spec test hardening
+      (slice 073). Recorded 2026-09-06."
   - version: "v1.0.0"
     after_phase: 8
     theme: "Qualified stable release per SPEC.md §114 definition of done."


### PR DESCRIPTION
Back-merge of the v0.7.0 release into `dev`, per `docs/RELEASE.md` post-merge step 5: version bumps, refreshed `uv.lock`, curated `CHANGELOG.md` and the roadmap release entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJPnjSq1YHk6bSsst68RP5